### PR TITLE
Register constructors with multiple return pointers

### DIFF
--- a/container.go
+++ b/container.go
@@ -74,7 +74,7 @@ func (c *Container) Provide(t interface{}) error {
 				return errReturnKind
 			}
 		}
-		return c.registerConstructor(t)
+		return c.provideConstructor(t)
 	case reflect.Ptr:
 		return c.provideObject(t, ctype)
 	default:
@@ -209,9 +209,7 @@ func (c *Container) provideObject(o interface{}, otype reflect.Type) error {
 }
 
 // constr must be a function that returns the result type and an error
-// registerConstructor takes two parameters
-// constr - constructor registered for all the return objects
-func (c *Container) registerConstructor(constr interface{}) error {
+func (c *Container) provideConstructor(constr interface{}) error {
 	ctype := reflect.TypeOf(constr)
 	// count of number of objects to be registered from the list of return parameters
 	count := ctype.NumOut()

--- a/container.go
+++ b/container.go
@@ -65,21 +65,21 @@ func (c *Container) Provide(t interface{}) error {
 	ctype := reflect.TypeOf(t)
 	switch ctype.Kind() {
 	case reflect.Func:
-		couts := ctype.NumOut()
-		if couts == 0 {
+		count := ctype.NumOut()
+		if count == 0 {
 			return errReturnCount
-		} else if couts == 1 {
+		} else if count == 1 {
 			objType := ctype.Out(0)
 			if objType.Kind() != reflect.Ptr && objType.Kind() != reflect.Interface {
 				return errReturnKind
 			}
 		} else {
 			// last variable must be error
-			if ctype.Out(couts-1) != _typeOfError {
+			if ctype.Out(count-1) != _typeOfError {
 				return errReturnErrKind
 			}
 		}
-		return c.registerConstructor(t, couts)
+		return c.registerConstructor(t, count)
 	case reflect.Ptr:
 		return c.provideObject(t, ctype)
 	default:
@@ -214,15 +214,15 @@ func (c *Container) provideObject(o interface{}, otype reflect.Type) error {
 }
 
 // constr must be a function that returns the result type and an error
-func (c *Container) registerConstructor(constr interface{}, couts int) error {
+func (c *Container) registerConstructor(constr interface{}, count int) error {
 	ctype := reflect.TypeOf(constr)
-	objTypes := make([]reflect.Type, couts, couts)
-	for i := 0; i < couts; i++ {
+	objTypes := make([]reflect.Type, count, count)
+	for i := 0; i < count; i++ {
 		objTypes[i] = ctype.Out(i)
 	}
 
-	nodes := make([]node, couts, couts)
-	for i := 0; i < couts; i++ {
+	nodes := make([]node, count, count)
+	for i := 0; i < count; i++ {
 		nodes[i] = node{
 			objType: objTypes[i],
 		}
@@ -241,7 +241,7 @@ func (c *Container) registerConstructor(constr interface{}, couts int) error {
 		n.deps[i] = arg
 	}
 
-	for i := 0; i < couts; i++ {
+	for i := 0; i < count; i++ {
 		c.nodes[objTypes[i]] = &n
 	}
 

--- a/container.go
+++ b/container.go
@@ -217,7 +217,7 @@ func (c *Container) provideObject(o interface{}, otype reflect.Type) error {
 // registerConstructor takes two parameters
 // constr - constructor registered for all the return objects
 // count - count of number of objects to be registered from the list of return parameters
-// If last parameter is an error, the count is reduced to igonre the error a
+// If last parameter is an error, the count is reduced to igonre the error
 func (c *Container) registerConstructor(constr interface{}, count int) error {
 	ctype := reflect.TypeOf(constr)
 	objTypes := make([]reflect.Type, count, count)

--- a/container_setup_test.go
+++ b/container_setup_test.go
@@ -165,3 +165,7 @@ func NewFlakyChild() (*FlakyChild, error) {
 func NewFlakyChildFailure() (*FlakyChild, error) {
 	return nil, errors.New("great sadness")
 }
+
+func threeObjects() (*Child1, *Child2, *Child3, error) {
+	return &Child1{}, &Child2{}, &Child3{}, nil
+}

--- a/container_test.go
+++ b/container_test.go
@@ -424,6 +424,10 @@ func TestMultiObjectRegisterResolve(t *testing.T) {
 	var third *Child3
 	require.NoError(t, c.Resolve(&third), "No error expected during first Resolve")
 
+	var errRegistered *error
+	require.Error(t, c.Resolve(&errRegistered), "type *error shouldn't be registered")
+	require.Nil(t, errRegistered)
+
 	require.NotNil(t, first, "Child1 must have been registered")
 	require.NotNil(t, second, "Child2 must have been registered")
 	require.NotNil(t, third, "Child3 must have been registered")

--- a/container_test.go
+++ b/container_test.go
@@ -315,6 +315,7 @@ func TestResolveAll(t *testing.T) {
 	err = c.ResolveAll(&p1, &p2, &p3, &p4)
 	require.NoError(t, err, "Did not expect error on resolve all")
 	require.Equal(t, p1.name, "Parent1")
+	require.True(t, p1 == p2 && p2 == p3 && p3 == p4, "All pointers must be equal")
 }
 
 func TestEmptyAfterReset(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -293,7 +293,7 @@ func TestCycles(t *testing.T) {
 	require.NoError(t, c.Provide(c1))
 	require.NoError(t, c.Provide(c2))
 	err := c.Provide(c3)
-	require.Contains(t, err.Error(), "unable to Provide dig.Type3")
+	require.Contains(t, err.Error(), "unable to Provide [dig.Type3]")
 	require.Contains(t, err.Error(), "func(dig.Type1) dig.Type3 -> func(dig.Type2, dig.Type3) dig.Type1 -> func(dig.Type1) dig.Type3")
 }
 

--- a/node.go
+++ b/node.go
@@ -139,7 +139,7 @@ func (n *funcNode) value(g *Container, objType reflect.Type) (reflect.Value, err
 		}
 	}
 
-	// last value must be an error
+	// if last value is an error, it is returned as a separate argument, otherwise nil
 	err, _ := values[len(values)-1].Interface().(error)
 
 	for _, v := range values {

--- a/node.go
+++ b/node.go
@@ -29,7 +29,7 @@ import (
 
 type graphNode interface {
 	// Return value of the object
-	value(g *Container) (reflect.Value, error)
+	value(g *Container, objType reflect.Type) (reflect.Value, error)
 
 	// Other things that need to be present before this object can be created
 	dependencies() []interface{}
@@ -63,7 +63,7 @@ type objNode struct {
 }
 
 // Return the earlier provided instance
-func (n *objNode) value(g *Container) (reflect.Value, error) {
+func (n *objNode) value(g *Container, objType reflect.Type) (reflect.Value, error) {
 	return n.cachedValue, nil
 }
 
@@ -81,18 +81,19 @@ func (n objNode) String() string {
 }
 
 type funcNode struct {
-	node
-
 	// constructor must be a function that returns the result type and an
 	// error
 	constructor interface{}
 	deps        []interface{}
+	nodes       []node
 }
 
 // Call the function and return the result
-func (n *funcNode) value(g *Container) (reflect.Value, error) {
-	if n.cached {
-		return n.cachedValue, nil
+func (n *funcNode) value(g *Container, objType reflect.Type) (reflect.Value, error) {
+	for _, node := range n.nodes {
+		if node.cached && node.objType == objType {
+			return node.cachedValue, nil
+		}
 	}
 
 	ct := reflect.TypeOf(n.constructor)
@@ -114,9 +115,9 @@ func (n *funcNode) value(g *Container) (reflect.Value, error) {
 	for idx := range args {
 		arg := ct.In(idx)
 		if node, ok := g.nodes[arg]; ok {
-			v, err := node.value(g)
+			v, err := node.value(g, arg)
 			if err != nil {
-				return reflect.Zero(n.objType), errors.Wrapf(err, "unable to resolve %v", arg)
+				return reflect.Zero(arg), errors.Wrapf(err, "unable to resolve %v", arg)
 			}
 			args[idx] = v
 		}
@@ -125,26 +126,37 @@ func (n *funcNode) value(g *Container) (reflect.Value, error) {
 	cv := reflect.ValueOf(n.constructor)
 
 	values := cv.Call(args)
-	v := values[0]
-
-	// If the function has two return values, the second one is an error.
-	var err error
-	if len(values) > 1 {
-		err, _ = values[1].Interface().(error)
+	for _, node := range n.nodes {
+		for _, v := range values {
+			if node.objType == v.Type() {
+				node.cached = true
+				node.cachedValue = v
+			}
+		}
 	}
 
-	n.cached = true
-	n.cachedValue = v
-	return v, err
+	// last value must be an error
+	err, _ := values[len(values)-1].Interface().(error)
+
+	for _, v := range values {
+		if objType == v.Type() {
+			return v, err
+		}
+	}
+	return reflect.Zero(objType), err
 }
 
 func (n funcNode) dependencies() []interface{} {
 	return n.deps
 }
 
+func (n funcNode) id() string {
+	return reflect.TypeOf(n.constructor).String()
+}
+
 func (n funcNode) String() string {
 	return fmt.Sprintf(
-		"(function) id: %s, deps: %v, type: %v, constructor: %v, cached: %v, cachedValue: %v",
-		n.id(), n.deps, n.objType, n.constructor, n.cached, n.cachedValue,
+		"(function) id: %s, deps: %v, constructor: %v, nodes: %v",
+		n.id(), n.deps, n.constructor, n.nodes,
 	)
 }

--- a/node_test.go
+++ b/node_test.go
@@ -20,22 +20,16 @@
 
 package dig
 
-import (
-	"testing"
+// func TestNodeStrings(t *testing.T) {
+// 	n := objNode{}
+// 	require.Contains(t, n.String(), "(object)")
 
-	"reflect"
-
-	"github.com/stretchr/testify/require"
-)
-
-func TestNodeStrings(t *testing.T) {
-	n := objNode{}
-	require.Contains(t, n.String(), "(object)")
-
-	fn := funcNode{
-		node: node{
-			objType: reflect.TypeOf(n),
-		},
-	}
-	require.Contains(t, fn.String(), "(function)")
-}
+// 	var nodes []node
+// 	nodes = append(nodes, node{
+// 		objType: reflect.TypeOf(n),
+// 	})
+// 	fn := funcNode{
+// 		nodes: nodes,
+// 	}
+// 	require.Contains(t, fn.String(), "(function)")
+// }

--- a/node_test.go
+++ b/node_test.go
@@ -20,16 +20,28 @@
 
 package dig
 
-// func TestNodeStrings(t *testing.T) {
-// 	n := objNode{}
-// 	require.Contains(t, n.String(), "(object)")
+import (
+	"reflect"
+	"testing"
 
-// 	var nodes []node
-// 	nodes = append(nodes, node{
-// 		objType: reflect.TypeOf(n),
-// 	})
-// 	fn := funcNode{
-// 		nodes: nodes,
-// 	}
-// 	require.Contains(t, fn.String(), "(function)")
-// }
+	"github.com/stretchr/testify/require"
+)
+
+func singleObject() (*Child1, error) {
+	return &Child1{}, nil
+}
+
+func TestNodeStrings(t *testing.T) {
+	n := objNode{}
+	require.Contains(t, n.String(), "(object)")
+
+	var nodes []node
+	nodes = append(nodes, node{
+		objType: reflect.TypeOf(n),
+	})
+	fn := funcNode{
+		constructor: singleObject,
+		nodes:       nodes,
+	}
+	require.Contains(t, fn.String(), "(function)")
+}


### PR DESCRIPTION
Fixes #18 
Constructors with multiple return objects are now registered and cached in the graph. 
This PR does not resolve generic objects returned on constructor initialization such as `io.Closer`