### PR TITLE
Add Invoke function to resolve dependency

### DIFF
--- a/container.go
+++ b/container.go
@@ -68,7 +68,7 @@ func (c *Container) Invoke(t interface{}) error {
 		for idx := range args {
 			arg := ctype.In(idx)
 			if node, ok := c.nodes[arg]; ok {
-				v, err := node.value(c)
+				v, err := node.value(c, arg)
 				if err != nil {
 					return errors.Wrapf(err, "unable to resolve %v", arg)
 				}

--- a/container.go
+++ b/container.go
@@ -87,6 +87,7 @@ func (c *Container) Invoke(t interface{}) error {
 		values := cv.Call(args)
 		if len(values) > 0 {
 			c.Lock()
+			defer c.Unlock()
 			err, _ := values[len(values)-1].Interface().(error)
 			for _, v := range values {
 				switch v.Type().Kind() {
@@ -96,7 +97,6 @@ func (c *Container) Invoke(t interface{}) error {
 					return errors.Wrapf(errReturnKind, "%v", ctype)
 				}
 			}
-			c.Unlock()
 			return err
 		}
 	default:

--- a/container_test.go
+++ b/container_test.go
@@ -265,22 +265,36 @@ func TestInvokeSuccess(t *testing.T) {
 func TestInvokeAndRegisterSuccess(t *testing.T) {
 	t.Parallel()
 	c := New()
-	testname := "myChild"
+	child := &Child1{}
 	err := c.ProvideAll(
 		&Parent1{
-			name: testname,
+			c1: child,
 		},
 	)
 	assert.NoError(t, err)
-	var name string
-	err = c.Invoke(func(p1 *Parent1) string {
+	err = c.Invoke(func(p1 *Parent1) *Child1 {
 		require.NotNil(t, p1)
-		name = p1.name
-		return p1.name
+		return p1.c1
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, name, "myChild")
-	assert.NotNil(t, c.nodes[reflect.TypeOf(testname)])
+	assert.NotNil(t, c.nodes[reflect.TypeOf(child)])
+}
+
+func TestInvokeAndRegisterFailure(t *testing.T) {
+	t.Parallel()
+	c := New()
+	child := &Child1{}
+	err := c.ProvideAll(
+		&Parent1{
+			c1: child,
+		},
+	)
+	assert.NoError(t, err)
+	err = c.Invoke(func(p1 *Parent1) Child1 {
+		require.NotNil(t, p1)
+		return *p1.c1
+	})
+	require.Contains(t, err.Error(), "constructor return type must be a pointer")
 }
 
 func TestInvokeFailureUnresolvedDependencies(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -246,20 +246,19 @@ func TestInvokeSuccess(t *testing.T) {
 	c := New()
 
 	err := c.ProvideAll(
-		&Parent1{},
-		&Parent12{},
+		NewParent1,
+		NewChild1,
+		NewGrandchild1,
 	)
 	assert.NoError(t, err)
-	var c1 Child1
-	var c2 Child2
+	var c1 *Child1
 
-	err = c.Invoke(func(p1 *Parent1, p2 *Parent12) {
-		c1 = Child1{}
-		c2 = Child2{}
+	err = c.Invoke(func(p1 *Parent1) {
+		require.NotNil(t, p1)
+		c1 = p1.c1
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, c1)
-	assert.NotNil(t, c2)
 }
 
 func TestInvokeFailureUnresolvedDependencies(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -21,6 +21,7 @@
 package dig
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -259,6 +260,27 @@ func TestInvokeSuccess(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, c1)
+}
+
+func TestInvokeAndRegisterSuccess(t *testing.T) {
+	t.Parallel()
+	c := New()
+	testname := "myChild"
+	err := c.ProvideAll(
+		&Parent1{
+			name: testname,
+		},
+	)
+	assert.NoError(t, err)
+	var name string
+	err = c.Invoke(func(p1 *Parent1) string {
+		require.NotNil(t, p1)
+		name = p1.name
+		return p1.name
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, name, "myChild")
+	assert.NotNil(t, c.nodes[reflect.TypeOf(testname)])
 }
 
 func TestInvokeFailureUnresolvedDependencies(t *testing.T) {


### PR DESCRIPTION
#21 
Invoke function resolves the dependencies provided as arguments to the constructor, and invokes the function. The Invoke(func) can be used as a callback function with resolved dependencies from dig. 
