### PR TITLE
Add readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # dig: Dependency Injection Framework for Go
 
+[![GoDoc][doc-img]][doc]
+[![Coverage Status][cov-img]][cov]
+[![Build Status][ci-img]][ci]
+[![Report Card][report-card-img]][report-card]
+
 `package dig` provides an opinionated way of resolving object dependencies.
 
 For runnable examples, see the [examples directory](examples/).
@@ -108,3 +113,12 @@ There are, however, `Must*` alternatives of all the methods available. They
 are drawn from some of the patterns in the Go standard library and are there
 to simplify usage in critical scenarios: where not being able to resolve an
 object is not an option and panic is preferred.
+
+[doc]: https://godoc.org/go.uber.org/dig
+[doc-img]: https://godoc.org/go.uber.org/dig?status.svg
+[cov]: https://coveralls.io/github/uber-go/dig?branch=master
+[cov-img]: https://coveralls.io/repos/github/uber-go/dig/badge.svg?branch=master
+[ci]: https://travis-ci.org/uber-go/dig
+[ci-img]: https://travis-ci.org/uber-go/dig.svg?branch=master
+[report-card]: https://goreportcard.com/report/github.com/uber-go/dig
+[report-card-img]: https://goreportcard.com/badge/github.com/uber-go/dig


### PR DESCRIPTION
Add godoc, covrage, travis and report card badges to the readme. I think the coveralls one might take a build or two to fully kick in (I just enabled in)