### PR TITLE
Introduce maps, slice and arrays to dig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## v0.4 (unreleased)
+- Add support form `map`, `slice` and `array` to dig
 
 ## v0.3 (2 May 2017)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ err := c.Provide(&Type1{Name: "I am an thing"})
 
 ### Provide an Maps, slices or arrays
 
-Dig is now able to support maps, slices and arrays as objects to
+Dig also support maps, slices and arrays as objects to
 resolve, or provided as a dependency to the constructor.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ BETA. Expect potential API changes.
 There are two ways to Provide an object:
 
 1. Provide a pointer to an existing object
+1. Provide a slice, map, array
 1. Provide a "constructor function" that returns one pointer (or interface)
 
 ### Provide a Constructor
@@ -62,6 +63,28 @@ err := c.Provide(&Type1{Name: "I am an thing"})
 // to other constructors that require it.
 ```
 
+
+### Provide an Maps, slices or arrays
+
+Dig is now able to support maps, slices and arrays as objects to
+resolve, or provided as a dependency to the constructor.
+
+```go
+c := dig.New()
+var (
+	typemap = map[string]int{}
+	typeslice = []int{1, 2, 3}
+	typearray = [2]string{"one", "two"}
+)
+err := c.ProvideAll(typemap, typeslice, typearray)
+
+var resolveslice []int
+err := c.Resolve(&resolveslice)
+
+c.Invoke(func(map map[string]int, slice []int, array [2]string) {
+	// do something
+})
+```
 
 ## Resolve
 

--- a/container.go
+++ b/container.go
@@ -102,6 +102,12 @@ func (c *Container) Provide(t interface{}) error {
 			}
 		}
 		return c.Graph.InsertConstructor(t)
+	case reflect.Slice:
+		fallthrough
+	case reflect.Array:
+		fallthrough
+	case reflect.Map:
+		fallthrough
 	case reflect.Ptr:
 		v := reflect.ValueOf(t)
 		if ctype.Elem().Kind() == reflect.Interface {

--- a/container.go
+++ b/container.go
@@ -86,8 +86,8 @@ func (c *Container) Invoke(t interface{}) error {
 // Provide an object in the Container
 //
 // The provided argument must be a function that accepts its dependencies as
-// arguments and returns a single result, which must be a pointer type.
-// The function may optionally return an error as a second result.
+// arguments and returns one or more results, which must be a pointer type, map, slice or an array.
+// The function may optionally return an error as the last argument.
 func (c *Container) Provide(t interface{}) error {
 	ctype := reflect.TypeOf(t)
 	switch ctype.Kind() {
@@ -123,7 +123,7 @@ func (c *Container) MustRegister(t interface{}) {
 
 // Resolve all of the dependencies of the provided class
 //
-// Provided object must be a pointer
+// Provided object must be a pointer, map, slice or an array
 // Any dependencies of the object will receive constructor calls, or be initialized (once)
 // Constructor with return value *object will be called
 func (c *Container) Resolve(obj interface{}) (err error) {

--- a/container.go
+++ b/container.go
@@ -102,13 +102,7 @@ func (c *Container) Provide(t interface{}) error {
 			}
 		}
 		return c.Graph.InsertConstructor(t)
-	case reflect.Slice:
-		fallthrough
-	case reflect.Array:
-		fallthrough
-	case reflect.Map:
-		fallthrough
-	case reflect.Ptr:
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr:
 		v := reflect.ValueOf(t)
 		if ctype.Elem().Kind() == reflect.Interface {
 			ctype = ctype.Elem()

--- a/container_setup_test.go
+++ b/container_setup_test.go
@@ -169,3 +169,32 @@ func NewFlakyChildFailure() (*FlakyChild, error) {
 func threeObjects() (*Child1, *Child2, *Child3, error) {
 	return &Child1{}, &Child2{}, &Child3{}, nil
 }
+
+var (
+	testmap = map[string]int{
+		"one":   1,
+		"two":   2,
+		"three": 3,
+	}
+	testslice = []int{1, 2, 3}
+	testarray = [2]string{"one", "two"}
+
+	resolvemap        map[string]int
+	resolveslice      []int
+	resolvearray      [2]string
+	resolveTestResult *testresult
+)
+
+type testresult struct {
+	testmap   map[string]int
+	testslice []int
+	testarray [2]string
+}
+
+func ctorWithMapsAndSlices(testmap map[string]int, testslice []int, testarray [2]string) *testresult {
+	return &testresult{
+		testmap:   testmap,
+		testslice: testslice,
+		testarray: testarray,
+	}
+}

--- a/container_test.go
+++ b/container_test.go
@@ -128,40 +128,61 @@ func TestComplexType(t *testing.T) {
 	tts := []struct {
 		name    string
 		Provide func(c *Container) error
-		resolve func(c *Container) error
+		resolve func(t *testing.T, c *Container) error
 		es      string
 	}{
 		{
 			"test map",
 			func(c *Container) error { return c.Provide(testmap) },
-			func(c *Container) error { return c.Resolve(&resolvemap) },
+			func(t *testing.T, c *Container) error {
+				err := c.Resolve(&resolvemap)
+				assert.Equal(t, resolvemap["one"], 1)
+				return err
+			},
 			"",
 		},
 		{
 			"test slice",
 			func(c *Container) error { return c.Provide(testslice) },
-			func(c *Container) error { return c.Resolve(&resolveslice) },
+			func(t *testing.T, c *Container) error {
+				err := c.Resolve(&resolveslice)
+				assert.Equal(t, resolveslice[0], 1)
+				return err
+			},
 			"",
 		},
 		{
 			"test array",
 			func(c *Container) error { return c.Provide(testarray) },
-			func(c *Container) error { return c.Resolve(&resolvearray) },
+			func(t *testing.T, c *Container) error {
+				err := c.Resolve(&resolvearray)
+				assert.Equal(t, resolvearray[0], "one")
+				return err
+			},
 			"",
 		},
 		{
 			"test ctor",
 			func(c *Container) error { return c.ProvideAll(testslice, testmap, testarray, ctorWithMapsAndSlices) },
-			func(c *Container) error { return c.Resolve(&resolveTestResult) },
+			func(t *testing.T, c *Container) error {
+				err := c.Resolve(&resolveTestResult)
+				assert.Equal(t, resolveTestResult.testarray[0], "one")
+				assert.Equal(t, resolveTestResult.testmap["one"], 1)
+				assert.Equal(t, resolveTestResult.testslice[0], 1)
+				return err
+			},
 			"",
 		},
 		{
 			"test invoke",
 			func(c *Container) error { return c.ProvideAll(testslice, testmap, testarray) },
-			func(c *Container) error {
+			func(t *testing.T, c *Container) error {
 				if err := c.Invoke(ctorWithMapsAndSlices); err != nil {
 					return err
 				}
+				assert.Equal(t, resolveTestResult.testarray[0], "one")
+				assert.Equal(t, resolveTestResult.testmap["one"], 1)
+				assert.Equal(t, resolveTestResult.testslice[0], 1)
 				return c.Resolve(&resolveTestResult)
 			},
 			"",
@@ -175,7 +196,7 @@ func TestComplexType(t *testing.T) {
 			err := tc.Provide(c)
 			require.NoError(t, err, "Provide part of the test cant have errors")
 
-			err = tc.resolve(c)
+			err = tc.resolve(t, c)
 			if tc.es != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.es, "Unexpected error message")

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -111,7 +111,12 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 	}
 	for i := 0; i < argc; i++ {
 		arg := ctype.In(i)
-		if arg.Kind() != reflect.Ptr && arg.Kind() != reflect.Interface {
+		switch arg.Kind() {
+		case reflect.Interface, reflect.Ptr:
+			fallthrough
+		case reflect.Map, reflect.Array, reflect.Slice:
+			break
+		default:
 			return errArgKind
 		}
 		n.deps[i] = arg

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -112,9 +112,7 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 	for i := 0; i < argc; i++ {
 		arg := ctype.In(i)
 		switch arg.Kind() {
-		case reflect.Interface, reflect.Ptr:
-			fallthrough
-		case reflect.Map, reflect.Array, reflect.Slice:
+		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Array, reflect.Slice:
 			break
 		default:
 			return errArgKind


### PR DESCRIPTION
#26 
Dig to support non named typed maps slices and arrays. 

We have constructors and providers to put `n` objects of type `x` into dig. This PR will allow users to add slices and maps of special types into dig and make objects ready for use.