### PR TITLE
Remove *All APIs from dig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 
 ## v0.4 (unreleased)
 - Add support form `map`, `slice` and `array` to dig
-
 - Remove `Must*` funcs to greatly reduce API surface area.
+- Remove `*All` funcs to reduce API surface area. Available methods on
+container are `Provide`, `Resolve` and `Invoke`
 
 ## v0.3 (2 May 2017)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ var (
 	typeslice = []int{1, 2, 3}
 	typearray = [2]string{"one", "two"}
 )
-err := c.ProvideAll(typemap, typeslice, typearray)
+err := c.Provide(typemap, typeslice, typearray)
 
 var resolveslice []int
 err := c.Resolve(&resolveslice)

--- a/container_test.go
+++ b/container_test.go
@@ -164,7 +164,7 @@ func TestComplexType(t *testing.T) {
 		},
 		{
 			"test ctor",
-			func(c *Container) error { return c.ProvideAll(testslice, testmap, testarray, ctorWithMapsAndSlices) },
+			func(c *Container) error { return c.Provide(testslice, testmap, testarray, ctorWithMapsAndSlices) },
 			func(t *testing.T, c *Container) error {
 				err := c.Resolve(&resolveTestResult)
 				assert.Equal(t, resolveTestResult.testarray[0], "one")
@@ -176,7 +176,7 @@ func TestComplexType(t *testing.T) {
 		},
 		{
 			"test invoke",
-			func(c *Container) error { return c.ProvideAll(testslice, testmap, testarray) },
+			func(c *Container) error { return c.Provide(testslice, testmap, testarray) },
 			func(t *testing.T, c *Container) error {
 				if err := c.Invoke(ctorWithMapsAndSlices); err != nil {
 					return err
@@ -315,7 +315,7 @@ func TestConstructorErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			c := New()
-			require.NoError(t, c.ProvideAll(tt.registers...))
+			require.NoError(t, c.Provide(tt.registers...))
 			var p1 *FlakyParent
 			err := c.Resolve(&p1)
 			if tt.wantErr != "" {
@@ -331,7 +331,7 @@ func TestInvokeSuccess(t *testing.T) {
 	t.Parallel()
 	c := New()
 
-	err := c.ProvideAll(
+	err := c.Provide(
 		NewParent1,
 		NewChild1,
 		NewGrandchild1,
@@ -351,7 +351,7 @@ func TestInvokeAndRegisterSuccess(t *testing.T) {
 	t.Parallel()
 	c := New()
 	child := &Child1{}
-	err := c.ProvideAll(
+	err := c.Provide(
 		&Parent1{
 			c1: child,
 		},
@@ -372,7 +372,7 @@ func TestInvokeAndRegisterFailure(t *testing.T) {
 	t.Parallel()
 	c := New()
 	child := &Child1{}
-	err := c.ProvideAll(
+	err := c.Provide(
 		&Parent1{
 			c1: child,
 		},
@@ -403,7 +403,7 @@ func TestInvokeFailureUnresolvedDependencies(t *testing.T) {
 	t.Parallel()
 	c := New()
 
-	err := c.ProvideAll(
+	err := c.Provide(
 		NewParent1,
 	)
 	assert.NoError(t, err)
@@ -415,11 +415,11 @@ func TestInvokeFailureUnresolvedDependencies(t *testing.T) {
 	require.Contains(t, err.Error(), "dependency of type *dig.Parent12 is not registered")
 }
 
-func TestProvideAll(t *testing.T) {
+func TestProvide(t *testing.T) {
 	t.Parallel()
 	c := New()
 
-	err := c.ProvideAll(
+	err := c.Provide(
 		NewParent1,
 		NewChild1,
 		NewGrandchild1,
@@ -498,7 +498,7 @@ func TestResolveAll(t *testing.T) {
 	t.Parallel()
 	c := New()
 
-	err := c.ProvideAll(
+	err := c.Provide(
 		NewGrandchild1,
 		NewChild1,
 		NewParent1,
@@ -509,7 +509,7 @@ func TestResolveAll(t *testing.T) {
 	var p3 *Parent1
 	var p4 *Parent1
 
-	err = c.ResolveAll(&p1, &p2, &p3, &p4)
+	err = c.Resolve(&p1, &p2, &p3, &p4)
 	require.NoError(t, err, "Did not expect error on resolve all")
 	require.Equal(t, p1.name, "Parent1")
 	require.True(t, p1 == p2 && p2 == p3 && p3 == p4, "All pointers must be equal")

--- a/doc.go
+++ b/doc.go
@@ -36,6 +36,8 @@
 //
 // • Provide a pointer to an existing object
 //
+// • Provide a slice, map, array
+//
 // • Provide a "constructor function" that returns one pointer (or interface)
 //
 // Provide a Constructor
@@ -76,6 +78,27 @@
 //   // dig container is now able to provide *Type1 as a dependency
 //   // to other constructors that require it.
 //
+// Provide an Maps, slices or arrays
+//
+// Dig also support maps, slices and arrays as objects to
+// resolve, or provided as a dependency to the constructor.
+//
+//
+//   c := dig.New()
+//   var (
+//   	typemap = map[string]int{}
+//   	typeslice = []int{1, 2, 3}
+//   	typearray = [2]string{"one", "two"}
+//   )
+//   err := c.Provide(typemap, typeslice, typearray)
+//
+//   var resolveslice []int
+//   err := c.Resolve(&resolveslice)
+//
+//   c.Invoke(func(map map[string]int, slice []int, array [2]string) {
+//   	// do something
+//   })
+//
 // Resolve
 //
 // Resolve retrieves objects from the container by building the object graph.
@@ -114,21 +137,6 @@
 //   err := c.Provide(&Type1{Name: "I am an thing"})
 //   // dig container is now able to provide *Type1 as a dependency
 //   // to other constructors that require it.
-//
-// Error Handling and Alternatives
-//
-// Provide and Resolve (and their ProvideAll and ResolveAll counterparts)
-// return errors, and usages of
-// dig should fully utilize the error checking, since
-// container creation is done through reflection meaning a lot of the errors surface
-// at runtime.
-//
-//
-// There are, however, Must* alternatives of all the methods available. They
-// are drawn from some of the patterns in the Go standard library and are there
-// to simplify usage in critical scenarios: where not being able to resolve an
-// object is not an option and panic is preferred.
-//
 //
 //
 package dig

--- a/examples/three/three.go
+++ b/examples/three/three.go
@@ -55,7 +55,7 @@ func main() {
 	//
 	// At this point no functions are called and no objects are created.
 	// dig is merely constructing a directional graph of dependencies.
-	err := c.ProvideAll(newOne, newTwo, newThree)
+	err := c.Provide(newOne, newTwo, newThree)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
resolves #40 
`Provide`, `Resolve` APIs support variadic arguments to reduce API surface area to `Provide`, `Resolve` and `Invoke`
