### PR TITLE
Invoke to propagate error to caller

### DIFF
--- a/container.go
+++ b/container.go
@@ -67,6 +67,9 @@ func (c *Container) Invoke(t interface{}) error {
 
 		if len(values) > 0 {
 			err, _ := values[len(values)-1].Interface().(error)
+			if err != nil {
+				return errors.Wrapf(err, "Error executing the function %v", ctype)
+			}
 			for _, v := range values {
 				switch v.Type().Kind() {
 				case reflect.Ptr:
@@ -75,7 +78,6 @@ func (c *Container) Invoke(t interface{}) error {
 					return errors.Wrapf(errReturnKind, "%v", ctype)
 				}
 			}
-			return err
 		}
 	default:
 		return errParamType

--- a/container.go
+++ b/container.go
@@ -72,7 +72,7 @@ func (c *Container) Invoke(t interface{}) error {
 			}
 			for _, v := range values {
 				switch v.Type().Kind() {
-				case reflect.Ptr:
+				case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr, reflect.Interface:
 					c.Graph.InsertObject(v)
 				default:
 					return errors.Wrapf(errReturnKind, "%v", ctype)
@@ -104,7 +104,7 @@ func (c *Container) Provide(t interface{}) error {
 			}
 		}
 		return c.Graph.InsertConstructor(t)
-	case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr:
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr, reflect.Interface:
 		v := reflect.ValueOf(t)
 		if ctype.Elem().Kind() == reflect.Interface {
 			ctype = ctype.Elem()

--- a/container.go
+++ b/container.go
@@ -66,8 +66,7 @@ func (c *Container) Invoke(t interface{}) error {
 		values := cv.Call(args)
 
 		if len(values) > 0 {
-			err, _ := values[len(values)-1].Interface().(error)
-			if err != nil {
+			if err, _ := values[len(values)-1].Interface().(error); err != nil {
 				return errors.Wrapf(err, "Error executing the function %v", ctype)
 			}
 			for _, v := range values {

--- a/container_test.go
+++ b/container_test.go
@@ -21,6 +21,7 @@
 package dig
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -382,6 +383,15 @@ func TestInvokeAndRegisterFailure(t *testing.T) {
 		return *p1.c1
 	})
 	require.Contains(t, err.Error(), "constructor return type must be a pointer")
+}
+
+func TestInvokeReturnedError(t *testing.T) {
+	t.Parallel()
+	c := New()
+	err := c.Invoke(func() error {
+		return errors.New("oops")
+	})
+	require.Contains(t, err.Error(), "Error executing the function func() error: oops")
 }
 
 func TestInvokeFailureUnresolvedDependencies(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -392,6 +392,11 @@ func TestInvokeReturnedError(t *testing.T) {
 		return errors.New("oops")
 	})
 	require.Contains(t, err.Error(), "Error executing the function func() error: oops")
+
+	err = c.Invoke(func() (*Child1, error) {
+		return &Child1{}, nil
+	})
+	assert.NoError(t, err)
 }
 
 func TestInvokeFailureUnresolvedDependencies(t *testing.T) {


### PR DESCRIPTION
If called function returns an error, we are trying to insert it into the graph (which fails because error is not a pointer type). We should rather just return the error back to the caller.