### PR TITLE
Fix error handling for constructors and Invoke

### DIFF
--- a/container.go
+++ b/container.go
@@ -71,14 +71,12 @@ func (c *Container) Invoke(t interface{}) error {
 			}
 			count--
 		}
-		if count > 0 {
-			for i := 0; i < count; i++ {
-				switch values[i].Type().Kind() {
-				case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr, reflect.Interface:
-					c.Graph.InsertObject(values[i])
-				default:
-					return errors.Wrapf(errReturnKind, "%v", ctype)
-				}
+		for i := 0; i < count; i++ {
+			switch values[i].Type().Kind() {
+			case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr, reflect.Interface:
+				c.Graph.InsertObject(values[i])
+			default:
+				return errors.Wrapf(errReturnKind, "%v", ctype)
 			}
 		}
 	default:

--- a/container.go
+++ b/container.go
@@ -65,13 +65,11 @@ func (c *Container) Invoke(t interface{}) error {
 		// execute the provided func
 		values := cv.Call(args)
 		count := len(values)
-		if count > 0 {
-			if values[count-1].Type() == _typeOfError {
-				if err, _ := values[count-1].Interface().(error); err != nil {
-					return errors.Wrapf(err, "Error executing the function %v", ctype)
-				}
-				count--
+		if count > 0 && values[count-1].Type() == _typeOfError {
+			if err, _ := values[count-1].Interface().(error); err != nil {
+				return errors.Wrapf(err, "error executing the function %v", ctype)
 			}
+			count--
 		}
 		if count > 0 {
 			for i := 0; i < count; i++ {

--- a/container.go
+++ b/container.go
@@ -64,17 +64,17 @@ func (c *Container) Invoke(t interface{}) error {
 
 		// execute the provided func
 		values := cv.Call(args)
-		rc := len(values)
-		if rc > 0 {
-			if values[len(values)-1].Type() == _typeOfError {
-				if err, _ := values[rc-1].Interface().(error); err != nil {
+		count := len(values)
+		if count > 0 {
+			if values[count-1].Type() == _typeOfError {
+				if err, _ := values[count-1].Interface().(error); err != nil {
 					return errors.Wrapf(err, "Error executing the function %v", ctype)
 				}
-				rc--
+				count--
 			}
 		}
-		if rc > 0 {
-			for i := 0; i < rc; i++ {
+		if count > 0 {
+			for i := 0; i < count; i++ {
 				switch values[i].Type().Kind() {
 				case reflect.Slice, reflect.Array, reflect.Map, reflect.Ptr, reflect.Interface:
 					c.Graph.InsertObject(values[i])

--- a/container_test.go
+++ b/container_test.go
@@ -319,6 +319,8 @@ func TestConstructorErrors(t *testing.T) {
 			var p1 *FlakyParent
 			err := c.Resolve(&p1)
 			if tt.wantErr != "" {
+				var registeredError error
+				require.Error(t, c.Resolve(&registeredError))
 				require.EqualError(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)

--- a/container_test.go
+++ b/container_test.go
@@ -393,7 +393,9 @@ func TestInvokeReturnedError(t *testing.T) {
 	err := c.Invoke(func() error {
 		return errors.New("oops")
 	})
-	require.Contains(t, err.Error(), "Error executing the function func() error: oops")
+	var registeredError *error
+	require.Error(t, c.Resolve(&registeredError), "type *error is not registered")
+	require.Contains(t, err.Error(), "error executing the function func() error: oops")
 
 	err = c.Invoke(func() (*Child1, error) {
 		return &Child1{}, nil

--- a/container_test.go
+++ b/container_test.go
@@ -319,8 +319,8 @@ func TestConstructorErrors(t *testing.T) {
 			var p1 *FlakyParent
 			err := c.Resolve(&p1)
 			if tt.wantErr != "" {
-				var registeredError error
-				require.Error(t, c.Resolve(&registeredError))
+				var registeredError *error
+				require.Error(t, c.Resolve(&registeredError), "type *error is not registered")
 				require.EqualError(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -92,6 +92,13 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 	ctype := reflect.TypeOf(ctor)
 	// count of number of objects to be registered from the list of return parameters
 	count := ctype.NumOut()
+	if count > 0 {
+		// if last parameter is an error, we will not include it in the graph
+		if ctype.Out(count-1) == _typeOfError {
+			count--
+		}
+	}
+
 	objTypes := make([]reflect.Type, count, count)
 	for i := 0; i < count; i++ {
 		objTypes[i] = ctype.Out(i)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -92,11 +92,9 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 	ctype := reflect.TypeOf(ctor)
 	// count of number of objects to be registered from the list of return parameters
 	count := ctype.NumOut()
-	if count > 0 {
-		// if last parameter is an error, we will not include it in the graph
-		if ctype.Out(count-1) == _typeOfError {
-			count--
-		}
+	// if last parameter is an error, we will not include it in the graph
+	if count > 0 && ctype.Out(count-1) == _typeOfError {
+		count--
 	}
 
 	objTypes := make([]reflect.Type, count, count)

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -114,18 +114,22 @@ func (n *funcNode) value(g *Graph, objType reflect.Type) (reflect.Value, error) 
 
 	values := cv.Call(args)
 
-	// cache constructed values in the node
-
-	for _, v := range values {
-		g.InsertObject(v)
-	}
-
-	// if last value is an error, it is returned as a separate argument, otherwise nil
-	err, _ = values[len(values)-1].Interface().(error)
-
-	for _, v := range values {
-		if objType == v.Type() {
-			return v, err
+	rc := len(values)
+	if rc > 0 {
+		// check if last argument is an error
+		if values[len(values)-1].Type() == _typeOfError {
+			err, _ = values[rc-1].Interface().(error)
+			rc--
+		}
+		// cache constructed values in the node
+		for i := 0; i < rc; i++ {
+			g.InsertObject(values[i])
+		}
+		// return value for the requested object type
+		for i := 0; i < rc; i++ {
+			if objType == values[i].Type() {
+				return values[i], err
+			}
 		}
 	}
 	return reflect.Zero(objType), err

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -114,19 +114,19 @@ func (n *funcNode) value(g *Graph, objType reflect.Type) (reflect.Value, error) 
 
 	values := cv.Call(args)
 
-	rc := len(values)
-	if rc > 0 {
+	count := len(values)
+	if count > 0 {
 		// check if last argument is an error
-		if values[len(values)-1].Type() == _typeOfError {
-			err, _ = values[rc-1].Interface().(error)
-			rc--
+		if values[count-1].Type() == _typeOfError {
+			err, _ = values[count-1].Interface().(error)
+			count--
 		}
 		// cache constructed values in the node
-		for i := 0; i < rc; i++ {
+		for i := 0; i < count; i++ {
 			g.InsertObject(values[i])
 		}
 		// return value for the requested object type
-		for i := 0; i < rc; i++ {
+		for i := 0; i < count; i++ {
 			if objType == values[i].Type() {
 				return values[i], err
 			}


### PR DESCRIPTION
#43 
Provide, Invoke don't register type `error` which is recommended to be last parameter in the function return.
