### PR TITLE
Updated Provide ctors with common returns types to return error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove `Must*` funcs to greatly reduce API surface area.
 - Remove `*All` funcs to reduce API surface area. Available methods on
 container are `Provide`, `Resolve` and `Invoke`
+- Providing constructors with common returned types results in an error.
 
 ## v0.3 (2 May 2017)
 

--- a/container_test.go
+++ b/container_test.go
@@ -438,20 +438,6 @@ func TestProvide(t *testing.T) {
 	require.NotNil(t, p1.c1.gc1, "Grandchild1 must have been registered")
 }
 
-func TestConcurrentAccess(t *testing.T) {
-	t.Parallel()
-	c := New()
-
-	for i := 0; i < 10; i++ {
-		go func() {
-			require.NoError(t, c.Provide(NewGrandchild1))
-
-			var gc1 *Grandchild1
-			require.NoError(t, c.Resolve(&gc1))
-		}()
-	}
-}
-
 func TestCycles(t *testing.T) {
 	t.Parallel()
 	c := New()

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -152,7 +152,7 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 func (g *Graph) ValidateReturnTypes(ctype reflect.Type) error {
 	g.RLock()
 	defer g.RUnlock()
-	objMap := make(map[reflect.Type]bool)
+	objMap := make(map[reflect.Type]bool, ctype.NumOut())
 	for i := 0; i < ctype.NumOut(); i++ {
 		objType := ctype.Out(i)
 		if _, ok := g.nodes[objType]; ok {

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -30,10 +30,10 @@ import (
 )
 
 var (
-	errArgKind     = errors.New("constructor arguments must be pointers")
-	errRetNode     = errors.New("node already exist for the constructor")
-	errCtorRetNode = errors.New("constructor return types must be distinct")
-	_typeOfError   = reflect.TypeOf((*error)(nil)).Elem()
+	errArgKind = errors.New("constructor arguments must be pointers")
+	errRetNode = errors.New("node already exist for the constructor")
+
+	_typeOfError = reflect.TypeOf((*error)(nil)).Elem()
 )
 
 // Graph contains all Graph for current graph
@@ -159,7 +159,7 @@ func (g *Graph) ValidateReturnTypes(ctype reflect.Type) error {
 			return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, ctype.Out(i))
 		}
 		if objMap[objType] {
-			return errors.Wrapf(errCtorRetNode, "ctor: %v, object type: %v", ctype, ctype.Out(i))
+			return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, ctype.Out(i))
 		}
 		objMap[objType] = true
 	}

--- a/internal/graph/graph_setup_test.go
+++ b/internal/graph/graph_setup_test.go
@@ -41,6 +41,9 @@ type Child2 struct{}
 
 type Child3 struct{}
 
+func oneObject() (*Child1, error) {
+	return &Child1{}, nil
+}
 func threeObjects() (*Child1, *Child2, *Child3, error) {
 	return &Child1{}, &Child2{}, &Child3{}, nil
 }

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -125,7 +125,7 @@ func TestCtorConflicts(t *testing.T) {
 	err = g.InsertConstructor(func() (*Child1, *Child1, error) {
 		return &Child1{}, &Child1{}, nil
 	})
-	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child1, error), object type: *graph.Child1: constructor return types must be distinct")
+	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
 }
 
 func TestMultiObjectRegisterResolve(t *testing.T) {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -111,6 +111,17 @@ func TestGraphString(t *testing.T) {
 	require.Contains(t, g.String(), "*graph.Parent12 -> (object) obj: *graph.Parent12")
 }
 
+func TestCtorConflicts(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+
+	err := g.InsertConstructor(threeObjects)
+	require.NoError(t, err)
+
+	err = g.InsertConstructor(oneObject)
+	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
+}
+
 func TestMultiObjectRegisterResolve(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -115,16 +115,17 @@ func TestCtorConflicts(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()
 
-	err := g.InsertConstructor(func() (*Child1, *Child1, *Child3, error) {
-		return &Child1{}, &Child1{}, &Child3{}, nil
-	})
+	err := g.InsertConstructor(threeObjects)
 	require.NoError(t, err)
 
 	err = g.InsertConstructor(oneObject)
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
 
-	err = g.InsertConstructor(threeObjects)
-	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child2, *graph.Child3, error), object type: *graph.Child1: node already exist for the constructor")
+	g.Reset()
+	err = g.InsertConstructor(func() (*Child1, *Child1, error) {
+		return &Child1{}, &Child1{}, nil
+	})
+	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child1, error), object type: *graph.Child1: constructor return types must be distinct")
 }
 
 func TestMultiObjectRegisterResolve(t *testing.T) {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -115,11 +115,16 @@ func TestCtorConflicts(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()
 
-	err := g.InsertConstructor(threeObjects)
+	err := g.InsertConstructor(func() (*Child1, *Child1, *Child3, error) {
+		return &Child1{}, &Child1{}, &Child3{}, nil
+	})
 	require.NoError(t, err)
 
 	err = g.InsertConstructor(oneObject)
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
+
+	err = g.InsertConstructor(threeObjects)
+	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child2, *graph.Child3, error), object type: *graph.Child1: node already exist for the constructor")
 }
 
 func TestMultiObjectRegisterResolve(t *testing.T) {


### PR DESCRIPTION
resolves #47 
Providing constructors with common return types will now result in an error. For example- 
```
ctor1(a *A, b *B) (x *x)
ctor2() (a *A)
```
Provide(ctor1) - success
Provide(ctor2) - returns an error -> `"ctor: func() (*X, error), object type: *X: node already exist for the constructor"`