### PR TITLE
[Prototype] Add InvokeOnce functionality to container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Remove `*All` funcs to reduce API surface area. Available methods on
 container are `Provide`, `Resolve` and `Invoke`
 - Providing constructors with common returned types results in an error.
-- Add `InvokOnce` functionality to invoke only once on unresolved return types
+- Add `InvokeOnce` functionality to invoke only once on unresolved return types
   of the provided function
 
 ## v0.3 (2 May 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Remove `*All` funcs to reduce API surface area. Available methods on
 container are `Provide`, `Resolve` and `Invoke`
 - Providing constructors with common returned types results in an error.
+- Add `InvokOnce` functionality to invoke only once on unresolved return types
+  of the provided function
 
 ## v0.3 (2 May 2017)
 

--- a/container.go
+++ b/container.go
@@ -61,7 +61,7 @@ func (c *Container) InvokeOnce(t interface{}) error {
 	if ctype.Kind() != reflect.Func {
 		return errors.Wrapf(errParamType, _invokeErr, ctype)
 	}
-	if err := c.ValidateReturnTypes(ctype, true); err != nil {
+	if err := c.ValidateInvokeReturnTypes(ctype); err != nil {
 		return ErrInvokeOnce
 	}
 	return c.Invoke(t)

--- a/container.go
+++ b/container.go
@@ -53,7 +53,7 @@ type Container struct {
 	graph.Graph
 }
 
-// InvokeOnce only allows function invokation once to register the
+// InvokeOnce only allows function invocation once to register the
 // return types. If return types are already registered, specific error
 // is returned to the caller
 func (c *Container) InvokeOnce(t interface{}) error {

--- a/container.go
+++ b/container.go
@@ -34,6 +34,9 @@ var (
 	errReturnKind  = errors.New("constructor return type must be a pointer")
 	errArgKind     = errors.New("constructor arguments must be pointers")
 
+	// ErrInvokeOnce is returned if function is already invoked
+	ErrInvokeOnce = errors.New("function is already invoked")
+
 	_typeOfError = reflect.TypeOf((*error)(nil)).Elem()
 
 	_forCtor   = "for constructor %v"
@@ -48,6 +51,20 @@ func New() *Container {
 // Container facilitates automated dependency resolution
 type Container struct {
 	graph.Graph
+}
+
+// InvokeOnce only allows function invokation once to register the
+// return types. If return types are already registered, specific error
+// is returned to the caller
+func (c *Container) InvokeOnce(t interface{}) error {
+	ctype := reflect.TypeOf(t)
+	if ctype.Kind() != reflect.Func {
+		return errors.Wrapf(errParamType, _invokeErr, ctype)
+	}
+	if err := c.ValidateReturnTypes(ctype, true); err != nil {
+		return ErrInvokeOnce
+	}
+	return c.Invoke(t)
 }
 
 // Invoke the function and resolve the dependencies immidiately without providing the

--- a/container_setup_test.go
+++ b/container_setup_test.go
@@ -198,3 +198,17 @@ func ctorWithMapsAndSlices(testmap map[string]int, testslice []int, testarray [2
 		testarray: testarray,
 	}
 }
+
+type type1 struct{}
+type type2 struct{}
+type type3 struct{}
+
+func newT1(*type2, *type3) *type1 {
+	return &type1{}
+}
+func newT2() *type2 {
+	return &type2{}
+}
+func newT3() *type3 {
+	return &type3{}
+}

--- a/container_test.go
+++ b/container_test.go
@@ -384,6 +384,11 @@ func TestInvokeOnceFailOnResolvedTypes(t *testing.T) {
 	c.Provide(newT1, newT2, newT3)
 	require.NoError(t, c.InvokeOnce(newT1))
 	assert.Equal(t, c.InvokeOnce(newT2), ErrInvokeOnce)
+
+	c.Reset()
+	c.Provide(newT1, newT2, newT3)
+	require.NoError(t, c.InvokeOnce(newT2))
+	require.NoError(t, c.InvokeOnce(newT1))
 }
 
 func TestInvokeAndRegisterSuccess(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -373,6 +373,10 @@ func TestInvokeOnce(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, c1)
+
+	type empty struct{}
+	require.NoError(t, c.InvokeOnce(func() *empty { return &empty{} }))
+	assert.Equal(t, c.InvokeOnce(func() *empty { return &empty{} }), ErrInvokeOnce)
 }
 
 func TestInvokeAndRegisterSuccess(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -349,6 +349,32 @@ func TestInvokeSuccess(t *testing.T) {
 	assert.NotNil(t, c1)
 }
 
+func TestInvokeOnce(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	err := c.Provide(
+		NewParent1,
+		NewChild1,
+		NewGrandchild1,
+	)
+	assert.NoError(t, err)
+	var c1 *Child1
+
+	err = c.InvokeOnce(NewParent1)
+	assert.NoError(t, err)
+
+	err = c.InvokeOnce(NewParent1)
+	assert.Equal(t, ErrInvokeOnce, err)
+
+	err = c.InvokeOnce(func(p1 *Parent1) {
+		require.NotNil(t, p1)
+		c1 = p1.c1
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, c1)
+}
+
 func TestInvokeAndRegisterSuccess(t *testing.T) {
 	t.Parallel()
 	c := New()

--- a/container_test.go
+++ b/container_test.go
@@ -379,6 +379,13 @@ func TestInvokeOnce(t *testing.T) {
 	assert.Equal(t, c.InvokeOnce(func() *empty { return &empty{} }), ErrInvokeOnce)
 }
 
+func TestInvokeOnceFailOnResolvedTypes(t *testing.T) {
+	c := New()
+	c.Provide(newT1, newT2, newT3)
+	require.NoError(t, c.InvokeOnce(newT1))
+	assert.Equal(t, c.InvokeOnce(newT2), ErrInvokeOnce)
+}
+
 func TestInvokeAndRegisterSuccess(t *testing.T) {
 	t.Parallel()
 	c := New()

--- a/container_test.go
+++ b/container_test.go
@@ -380,6 +380,7 @@ func TestInvokeOnce(t *testing.T) {
 }
 
 func TestInvokeOnceFailOnResolvedTypes(t *testing.T) {
+	t.Parallel()
 	c := New()
 	c.Provide(newT1, newT2, newT3)
 	require.NoError(t, c.InvokeOnce(newT1))

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -138,15 +138,15 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 }
 
 // ValidateInvokeReturnTypes validates Invoke return types and returns an error
-// if the grah node of return type is resolved and cached.
+// if the graph node of return type is resolved and cached.
 func (g *Graph) ValidateInvokeReturnTypes(ctype reflect.Type) error {
 	if err := g.checkDuplicateReturns(ctype); err != nil {
 		return err
 	}
 	for i := 0; i < ctype.NumOut(); i++ {
 		objType := ctype.Out(i)
-		if _, ok := g.nodes[objType]; ok {
-			if obj, ok := g.nodes[objType].(*objNode); ok && obj.cached {
+		if node, ok := g.nodes[objType]; ok {
+			if obj, ok := node.(*objNode); ok && obj.cached {
 				return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)
 			}
 		}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -94,7 +94,7 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 		objTypes[i] = ctype.Out(i)
 	}
 
-	if err := g.ValidateReturnTypes(ctype, false); err != nil {
+	if err := g.validateCtorReturnTypes(ctype); err != nil {
 		return err
 	}
 
@@ -137,25 +137,42 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 	return nil
 }
 
-// ValidateReturnTypes validates if Invoke func's return type is Provided to the graph
-// checkCachedObjects=true ensures to throw an error only when the node is already
-// resolved and cached.
-//
-func (g *Graph) ValidateReturnTypes(ctype reflect.Type, checkCachedObjects bool) error {
-	objMap := make(map[reflect.Type]bool, ctype.NumOut())
+// ValidateInvokeReturnTypes validates Invoke return types and returns an error
+// if the grah node of return type is resolved and cached.
+func (g *Graph) ValidateInvokeReturnTypes(ctype reflect.Type) error {
+	if err := g.checkDuplicateReturns(ctype); err != nil {
+		return err
+	}
 	for i := 0; i < ctype.NumOut(); i++ {
 		objType := ctype.Out(i)
 		if _, ok := g.nodes[objType]; ok {
-			// for Invoke validation, graphNode may not be resolved (still in the form of funcNode).
-			// checkCachedObjects ensures to throw an error only when the node is resolved and cached.
-			if checkCachedObjects {
-				if obj, ok := g.nodes[objType].(*objNode); ok && obj.cached {
-					return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)
-				}
-			} else {
+			if obj, ok := g.nodes[objType].(*objNode); ok && obj.cached {
 				return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)
 			}
 		}
+	}
+	return nil
+}
+
+// validateCtorReturnTypes validates provided constructor and returns error
+// when graph node for ctor return type is not already provided
+func (g *Graph) validateCtorReturnTypes(ctype reflect.Type) error {
+	if err := g.checkDuplicateReturns(ctype); err != nil {
+		return err
+	}
+	for i := 0; i < ctype.NumOut(); i++ {
+		objType := ctype.Out(i)
+		if _, ok := g.nodes[objType]; ok {
+			return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)
+		}
+	}
+	return nil
+}
+
+func (g *Graph) checkDuplicateReturns(ctype reflect.Type) error {
+	objMap := make(map[reflect.Type]bool, ctype.NumOut())
+	for i := 0; i < ctype.NumOut(); i++ {
+		objType := ctype.Out(i)
 		if objMap[objType] {
 			return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)
 		}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -138,12 +138,16 @@ func (g *Graph) InsertConstructor(ctor interface{}) error {
 }
 
 // ValidateReturnTypes validates if Invoke func's return type is Provided to the graph
-// checkCachedObjects=true additionally checks if objects are resolved and cached in the graph
+// checkCachedObjects=true ensures to throw an error only when the node is already
+// resolved and cached.
+//
 func (g *Graph) ValidateReturnTypes(ctype reflect.Type, checkCachedObjects bool) error {
 	objMap := make(map[reflect.Type]bool, ctype.NumOut())
 	for i := 0; i < ctype.NumOut(); i++ {
 		objType := ctype.Out(i)
 		if _, ok := g.nodes[objType]; ok {
+			// for Invoke validation, graphNode may not be resolved (still in the form of funcNode).
+			// checkCachedObjects ensures to throw an error only when the node is resolved and cached.
 			if checkCachedObjects {
 				if obj, ok := g.nodes[objType].(*objNode); ok && obj.cached {
 					return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -145,7 +145,7 @@ func (g *Graph) ValidateReturnTypes(ctype reflect.Type, checkCachedObjects bool)
 		objType := ctype.Out(i)
 		if _, ok := g.nodes[objType]; ok {
 			if checkCachedObjects {
-				if g.checkCachedObjects(objType) {
+				if obj, ok := g.nodes[objType].(*objNode); ok && obj.cached {
 					return errors.Wrapf(errRetNode, "ctor: %v, object type: %v", ctype, objType)
 				}
 			} else {
@@ -158,11 +158,6 @@ func (g *Graph) ValidateReturnTypes(ctype reflect.Type, checkCachedObjects bool)
 		objMap[objType] = true
 	}
 	return nil
-}
-
-func (g *Graph) checkCachedObjects(objType reflect.Type) bool {
-	obj, ok := g.nodes[objType].(*objNode)
-	return ok && obj.cached
 }
 
 // DFS and tracking if same node is visited twice

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -128,6 +128,20 @@ func TestCtorConflicts(t *testing.T) {
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
 }
 
+func TestValidateReturnTypes(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+
+	err := g.InsertConstructor(threeObjects)
+	require.NoError(t, err)
+	err = g.ValidateReturnTypes(reflect.TypeOf(oneObject), false)
+	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
+
+	g.InsertObject(reflect.ValueOf(&Child1{}))
+	err = g.ValidateReturnTypes(reflect.TypeOf(oneObject), true)
+	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
+}
+
 func TestMultiObjectRegisterResolve(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -128,7 +128,7 @@ func TestCtorConflicts(t *testing.T) {
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
 }
 
-func TestValidateReturnTypes(t *testing.T) {
+func TestConstructorOverrideReturnsError(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()
 

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -128,17 +128,22 @@ func TestCtorConflicts(t *testing.T) {
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, *graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
 }
 
-func TestConstructorOverrideReturnsError(t *testing.T) {
+func TestCtorOverrideReturnsError(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()
 
 	err := g.InsertConstructor(threeObjects)
 	require.NoError(t, err)
-	err = g.ValidateReturnTypes(reflect.TypeOf(oneObject), false)
+	err = g.validateCtorReturnTypes(reflect.TypeOf(oneObject))
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
+}
+
+func TestInvokeOverrideReturnsError(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
 
 	g.InsertObject(reflect.ValueOf(&Child1{}))
-	err = g.ValidateReturnTypes(reflect.TypeOf(oneObject), true)
+	err := g.ValidateInvokeReturnTypes(reflect.TypeOf(oneObject))
 	require.Contains(t, err.Error(), "ctor: func() (*graph.Child1, error), object type: *graph.Child1: node already exist for the constructor")
 }
 


### PR DESCRIPTION
#48 
Cooked up some code for `InvokeOnce` that will be helpful for discussion -

When `InvokeOnce` is called, it performs additional validations to check if return object types are already registered and cached in the graph. If object is cached, `InvokeOnce` skips `Invoke` and returns `ErrInvokeOnce` to the caller. 

It is up to the caller to choose to panic or ignore the error message knowing that method has not been invoked since object is already resolved in the graph.