### PR TITLE
Added benchmarks for container API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ until the constructor for `config.Provider` can be fully satisfied.
 If resolution is not possible, for instance one of the required dependencies has
 does not have a constructor and doesn't appear in the graph, an error will be returned.
 
+## Benchmarks
+Benchmark_CtorInvoke-8                          	 1000000	      2137 ns/op	     304 B/op	      10 allocs/op
+Benchmark_CtorInvokeWithObjects-8               	 1000000	      1497 ns/op	     200 B/op	       6 allocs/op
+Benchmark_InvokeCtorWithMapsSlicesAndArrays-8   	  500000	      2571 ns/op	     440 B/op	       9 allocs/op
+Benchmark_CtorProvideAndResolve-8               	 1000000	      2183 ns/op	     320 B/op	      11 allocs/op
+Benchmark_CtorResolve-8                         	 1000000	      1903 ns/op	     216 B/op	       7 allocs/op
+Benchmark_ResolveCtors-8                        	  500000	      2252 ns/op	     344 B/op	      14 allocs/op
+
+
 [doc]: https://godoc.org/go.uber.org/dig
 [doc-img]: https://godoc.org/go.uber.org/dig?status.svg
 [cov]: https://coveralls.io/github/uber-go/dig?branch=master

--- a/container_benchmark_test.go
+++ b/container_benchmark_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import "testing"
+
+func benchInvokeFunc(g1 *Grandchild1) (*Parent1, error) {
+	return &Parent1{
+		c1: &Child1{
+			gc1: g1,
+		},
+	}, nil
+}
+
+func Benchmark_CtorInvoke(b *testing.B) {
+	c := New()
+	c.Provide(
+		NewGrandchild1,
+	)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Invoke(benchInvokeFunc)
+	}
+}
+
+func Benchmark_CtorInvokeWithObjects(b *testing.B) {
+	c := New()
+	c.Provide(
+		&Grandchild1{},
+	)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Invoke(benchInvokeFunc)
+	}
+}
+
+func Benchmark_InvokeCtorWithMapsAndSlices(b *testing.B) {
+	c := New()
+	c.Provide(
+		testslice,
+		testarray,
+		testmap,
+		threeObjects,
+	)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Invoke(func(t1 []int, t2 [2]string, t3 map[string]int, c1 *Child1) {})
+	}
+}
+
+func Benchmark_CtorProvideAndResolve(b *testing.B) {
+	c := New()
+	c.Provide(
+		NewGrandchild1,
+		benchInvokeFunc,
+	)
+	var p1 *Parent1
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Resolve(&p1)
+	}
+}
+
+func Benchmark_CtorResolve(b *testing.B) {
+	c := New()
+	c.Provide(
+		&Grandchild1{},
+		benchInvokeFunc,
+	)
+	var p1 *Parent1
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Resolve(&p1)
+	}
+}
+
+func Benchmark_ResolveCtors(b *testing.B) {
+	c := New()
+	c.Provide(
+		NewParent1,
+		NewChild1,
+		NewGrandchild1,
+	)
+	var p1 Parent1
+	var c1 Child1
+	var g1 Grandchild1
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Resolve(&p1)
+		c.Resolve(&c1)
+		c.Resolve(&g1)
+	}
+}

--- a/container_benchmark_test.go
+++ b/container_benchmark_test.go
@@ -31,83 +31,91 @@ func benchInvokeFunc(g1 *Grandchild1) (*Parent1, error) {
 }
 
 func Benchmark_CtorInvoke(b *testing.B) {
-	c := New()
-	c.Provide(
-		NewGrandchild1,
-	)
-
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c := New()
+		c.Provide(
+			NewGrandchild1,
+		)
+		b.StartTimer()
 		c.Invoke(benchInvokeFunc)
 	}
 }
 
 func Benchmark_CtorInvokeWithObjects(b *testing.B) {
-	c := New()
-	c.Provide(
-		&Grandchild1{},
-	)
-
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c := New()
+		c.Provide(
+			&Grandchild1{},
+		)
+		b.StartTimer()
 		c.Invoke(benchInvokeFunc)
 	}
 }
 
-func Benchmark_InvokeCtorWithMapsAndSlices(b *testing.B) {
-	c := New()
-	c.Provide(
-		testslice,
-		testarray,
-		testmap,
-		threeObjects,
-	)
-
+func Benchmark_InvokeCtorWithMapsSlicesAndArrays(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c := New()
+		c.Provide(
+			testslice,
+			testarray,
+			testmap,
+			threeObjects,
+		)
+		b.StartTimer()
 		c.Invoke(func(t1 []int, t2 [2]string, t3 map[string]int, c1 *Child1) {})
 	}
 }
 
 func Benchmark_CtorProvideAndResolve(b *testing.B) {
-	c := New()
-	c.Provide(
-		NewGrandchild1,
-		benchInvokeFunc,
-	)
-	var p1 *Parent1
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c := New()
+		c.Provide(
+			NewGrandchild1,
+			benchInvokeFunc,
+		)
+		var p1 *Parent1
+		b.StartTimer()
 		c.Resolve(&p1)
 	}
 }
 
 func Benchmark_CtorResolve(b *testing.B) {
-	c := New()
-	c.Provide(
-		&Grandchild1{},
-		benchInvokeFunc,
-	)
-	var p1 *Parent1
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c := New()
+		c.Provide(
+			&Grandchild1{},
+			benchInvokeFunc,
+		)
+		var p1 *Parent1
+		b.StartTimer()
 		c.Resolve(&p1)
 	}
 }
 
 func Benchmark_ResolveCtors(b *testing.B) {
-	c := New()
-	c.Provide(
-		NewParent1,
-		NewChild1,
-		NewGrandchild1,
-	)
-	var p1 Parent1
-	var c1 Child1
-	var g1 Grandchild1
-
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c := New()
+		c.Provide(
+			NewParent1,
+			NewChild1,
+			NewGrandchild1,
+		)
+		b.StartTimer()
+		var p1 Parent1
+		var c1 Child1
+		var g1 Grandchild1
 		c.Resolve(&p1)
 		c.Resolve(&c1)
 		c.Resolve(&g1)

--- a/doc.go
+++ b/doc.go
@@ -28,9 +28,35 @@
 //
 // BETA. Expect potential API changes.
 //
+// Conatiner
+//
+// package dig exposes type Container as an object capable of resolving a
+// directional dependency graph.
+//
+//
+// To create one:
+//
+//   import "go.uber.org/dig"
+//
+//   func main() {
+//   	c := dig.New()
+//   	// dig container `c` is ready to use!
+//   }
+//
+// Objects in the container are identified by their reflect.Type and **everything
+// is treated as a singleton
+// **, meaning there can be only one object in the graph
+// of a given type.
+//
+//
+// For more advanced use cases, consider using a factory pattern. That is to say,
+// have one object shared as a singleton, capable of creating many instances
+// of the same type on demand.
+//
+//
 // Provide
 //
-// Provide adds an object, or a constructor of an object to the container.
+// Provide adds an object, or a constructor of an object, to the container.
 //
 // There are two ways to Provide an object:
 //
@@ -74,11 +100,11 @@
 //   }
 //
 //   c := dig.New()
-//   err := c.Provide(&Type1{Name: "I am an thing"})
+//   err := c.Provide(&Type1{Name: "I am a thing"})
 //   // dig container is now able to provide *Type1 as a dependency
 //   // to other constructors that require it.
 //
-// Provide an Maps, slices or arrays
+// Providing Maps and Slices
 //
 // Dig also support maps, slices and arrays as objects to
 // resolve, or provided as a dependency to the constructor.
@@ -125,18 +151,15 @@
 // does not have a constructor and doesn't appear in the graph, an error will be returned.
 //
 //
-// There are future plans to do named retrievals to support multiple
-// objects of the same type in the container.
+// Benchmarks
 //
+// Benchmark_CtorInvoke-8                               1000000          2137 ns/op         304 B/op         10 allocs/op
+// Benchmark_CtorInvokeWithObjects-8                    1000000          1497 ns/op         200 B/op          6 allocs/op
+// Benchmark_InvokeCtorWithMapsSlicesAndArrays-8         500000          2571 ns/op         440 B/op          9 allocs/op
+// Benchmark_CtorProvideAndResolve-8                    1000000          2183 ns/op         320 B/op         11 allocs/op
+// Benchmark_CtorResolve-8                              1000000          1903 ns/op         216 B/op          7 allocs/op
+// Benchmark_ResolveCtors-8                              500000          2252 ns/op         344 B/op         14 allocs/op
 //
-//   type Type1 struct {
-//   	Name string
-//   }
-//
-//   c := dig.New()
-//   err := c.Provide(&Type1{Name: "I am an thing"})
-//   // dig container is now able to provide *Type1 as a dependency
-//   // to other constructors that require it.
 //
 //
 package dig


### PR DESCRIPTION
```
Benchmark_CtorInvoke-8                          	 1000000	      2137 ns/op	     304 B/op	      10 allocs/op
Benchmark_CtorInvokeWithObjects-8               	 1000000	      1497 ns/op	     200 B/op	       6 allocs/op
Benchmark_InvokeCtorWithMapsSlicesAndArrays-8   	  500000	      2571 ns/op	     440 B/op	       9 allocs/op
Benchmark_CtorProvideAndResolve-8               	 1000000	      2183 ns/op	     320 B/op	      11 allocs/op
Benchmark_CtorResolve-8                         	 1000000	      1903 ns/op	     216 B/op	       7 allocs/op
Benchmark_ResolveCtors-8                        	  500000	      2252 ns/op	     344 B/op	      14 allocs/op
```