### PR TITLE
[Prototype] Optional type

### DIFF
--- a/container.go
+++ b/container.go
@@ -50,6 +50,13 @@ type Container struct {
 	graph.Graph
 }
 
+// Optional struct implementing the DigOptional interface
+// Signaling to dig that it's ok to pass zero value into this parameter
+type Optional struct{}
+
+// DigOptional implementaiton of the interace
+func (Optional) DigOptional() bool { return true }
+
 // Invoke the function and resolve the dependencies immidiately without providing the
 // constructor to the graph. The Invoke function returns error object which can be
 // occurred during the execution

--- a/examples/optional/optional.go
+++ b/examples/optional/optional.go
@@ -19,7 +19,7 @@ func main() {
 	c.Provide(&type1{})
 	if err := c.Invoke(func(t1 *type1, t2 *type2) {
 		fmt.Println("t1", t1) // will get actual instance of type1
-		fmt.Println("t2", t2) // note nil, yet dig doesn't not error
+		fmt.Println("t2", t2) // note nil and dig doesn't error out, just provides zero value
 	}); err != nil {
 		panic(err)
 	}

--- a/examples/optional/optional.go
+++ b/examples/optional/optional.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"go.uber.org/dig"
+)
+
+// type1 is a "required" dig type by default
+type type1 struct{}
+
+// type2 embeds a dig.Optional object to signal it's ok to ignore in params
+type type2 struct {
+	dig.Optional
+}
+
+func main() {
+	c := dig.New()
+	c.Provide(&type1{})
+	if err := c.Invoke(func(t1 *type1, t2 *type2) {
+		fmt.Println("t1", t1) // will get actual instance of type1
+		fmt.Println("t2", t2) // note nil, yet dig doesn't not error
+	}); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
See `optional.go` for an illustration of what's going on. `type2` is optional and therefor there is no error during `Invoke`, since it gets a nil.

This adds a new interface called `DigOptional` and a type `dig.Optional` which can be embedded into a struct to signal an optional parameter.

This obviously doesn't address things like optional slices or maps (unless they are typealiased and this interface is satisfied).

Thoughts/comments?