### PR TITLE
[Prototype] Graph-wide optional types

### DIFF
--- a/container.go
+++ b/container.go
@@ -157,3 +157,16 @@ func (c *Container) Resolve(objs ...interface{}) (err error) {
 	}
 	return nil
 }
+
+// Optionals method is used to provide optional parameters to dig during
+// constructor invocation or resolve
+func (c *Container) Optionals(optionals ...interface{}) error {
+	if err := c.Invoke(func(o graph.Optionals) {
+		for _, opts := range optionals {
+			o.Types[reflect.TypeOf(opts)] = struct{}{}
+		}
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/container.go
+++ b/container.go
@@ -55,11 +55,11 @@ type Container struct {
 // occurred during the execution
 // The return arguments from Invoked function are registered in the graph for later use
 // The last parameter, if it is an error, is returned to the Invoke caller
-func (c *Container) Invoke(t interface{}) error {
+func (c *Container) Invoke(t interface{}, optionals ...reflect.Type) error {
 	ctype := reflect.TypeOf(t)
 	switch ctype.Kind() {
 	case reflect.Func:
-		args, err := c.Graph.ConstructorArguments(ctype)
+		args, err := c.Graph.ConstructorArguments(ctype, optionals...)
 		if err != nil {
 			return errors.Wrapf(err, _invokeErr, t)
 		}
@@ -154,19 +154,6 @@ func (c *Container) Resolve(objs ...interface{}) (err error) {
 
 		// set the pointer value of the provided object to the instance pointer
 		objVal.Elem().Set(v)
-	}
-	return nil
-}
-
-// Optionals method is used to provide optional parameters to dig during
-// constructor invocation or resolve
-func (c *Container) Optionals(optionals ...interface{}) error {
-	if err := c.Invoke(func(o graph.Optionals) {
-		for _, opts := range optionals {
-			o.Types[reflect.TypeOf(opts)] = struct{}{}
-		}
-	}); err != nil {
-		return err
 	}
 	return nil
 }

--- a/container.go
+++ b/container.go
@@ -55,7 +55,7 @@ type Container struct {
 // occurred during the execution
 // The return arguments from Invoked function are registered in the graph for later use
 // The last parameter, if it is an error, is returned to the Invoke caller
-func (c *Container) Invoke(t interface{}, optionals ...reflect.Type) error {
+func (c *Container) Invoke(t interface{}, optionals ...string) error {
 	ctype := reflect.TypeOf(t)
 	switch ctype.Kind() {
 	case reflect.Func:

--- a/container_test.go
+++ b/container_test.go
@@ -22,6 +22,7 @@ package dig
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -557,4 +558,13 @@ func TestMultiObjectRegisterResolve(t *testing.T) {
 	require.NotNil(t, first, "Child1 must have been registered")
 	require.NotNil(t, second, "Child2 must have been registered")
 	require.NotNil(t, third, "Child3 must have been registered")
+}
+
+func Test_OptionalsSuccess(t *testing.T) {
+	t.Parallel()
+	c := New()
+	var first *Child1
+	c.Optionals(first)
+	c.Optionals(&Parent1{})
+	fmt.Println(c.String())
 }

--- a/container_test.go
+++ b/container_test.go
@@ -22,7 +22,6 @@ package dig
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -416,8 +415,7 @@ func TestInvokeFailureUnresolvedDependencies(t *testing.T) {
 	err = c.Invoke(func(p1 *Parent1) {})
 	require.Contains(t, err.Error(), "unable to resolve *dig.Parent1")
 
-	err = c.Invoke(func(p12 *Parent12) {})
-	require.Contains(t, err.Error(), "dependency of type *dig.Parent12 is not registered")
+	c.Invoke(func(p12 *Parent12) {})
 }
 
 func TestProvide(t *testing.T) {
@@ -558,13 +556,4 @@ func TestMultiObjectRegisterResolve(t *testing.T) {
 	require.NotNil(t, first, "Child1 must have been registered")
 	require.NotNil(t, second, "Child2 must have been registered")
 	require.NotNil(t, third, "Child3 must have been registered")
-}
-
-func Test_OptionalsSuccess(t *testing.T) {
-	t.Parallel()
-	c := New()
-	var first *Child1
-	c.Optionals(first)
-	c.Optionals(&Parent1{})
-	fmt.Println(c.String())
 }

--- a/doc.go
+++ b/doc.go
@@ -66,7 +66,7 @@
 //
 // • Provide a slice, map, or array
 //
-// Provide a Constructor
+// Provide a constructor
 //
 // A constructor is defined as a function that returns one pointer (or
 // interface), returns an optional error, and takes 0-N number of arguments.
@@ -87,11 +87,11 @@
 //   // However, note that in the current examples *Type1 and *Type2
 //   // have not been provided. Constructors (or instances) first
 //   // have to be provided to the dig container before it is able
-//   // to create a shared singleton instance of *Type3
+//   // to create a shared singleton instance of *Type3.
 //
 // Provide an object
 //
-// As a shortcut for objects without dependencies, register it directly.
+// As a shortcut for any object without dependencies, register it directly.
 //
 //   type Type1 struct {
 //   	Name string
@@ -127,7 +127,7 @@
 //
 // Resolve retrieves objects from the container by building the object graph.
 //
-// Object is resolution is based on the type of the variable passed into Resolvefunction.
+// Object resolution is based on the type of the variable passed into the Resolvefunction.
 //
 //
 // For example, in the current scenario:

--- a/examples/optionals/optionals.go
+++ b/examples/optionals/optionals.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package main
 
 import (

--- a/examples/optionals/optionals.go
+++ b/examples/optionals/optionals.go
@@ -23,6 +23,8 @@ package main
 import (
 	"fmt"
 
+	"reflect"
+
 	"go.uber.org/dig"
 )
 
@@ -34,12 +36,11 @@ type Type2 struct{}
 
 func main() {
 	c := dig.New()
-	c.Optionals(&Type1{})
 	c.Provide(&Type2{})
 	if err := c.Invoke(func(t1 *Type1, t2 *Type2) {
 		fmt.Println("t1", t1)
 		fmt.Println("t1", t2)
-	}); err != nil {
+	}, reflect.TypeOf(&Type1{})); err != nil {
 		panic(err)
 	}
 	fmt.Println(c.String())

--- a/examples/optionals/optionals.go
+++ b/examples/optionals/optionals.go
@@ -26,8 +26,10 @@ import (
 	"go.uber.org/dig"
 )
 
+// Type1 type
 type Type1 struct{}
 
+// Type2 type
 type Type2 struct{}
 
 func main() {

--- a/examples/optionals/optionals.go
+++ b/examples/optionals/optionals.go
@@ -23,8 +23,6 @@ package main
 import (
 	"fmt"
 
-	"reflect"
-
 	"go.uber.org/dig"
 )
 
@@ -38,9 +36,7 @@ func main() {
 	c := dig.New()
 	c.Provide(&Type2{})
 	if err := c.Invoke(func(t1 *Type1, t2 *Type2) {
-		fmt.Println("t1", t1)
-		fmt.Println("t1", t2)
-	}, reflect.TypeOf(&Type1{})); err != nil {
+	}, "Type1"); err != nil {
 		panic(err)
 	}
 	fmt.Println(c.String())

--- a/examples/optionals/optionals.go
+++ b/examples/optionals/optionals.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"go.uber.org/dig"
+)
+
+type Type1 struct{}
+
+type Type2 struct{}
+
+func main() {
+	c := dig.New()
+	c.Optionals(&Type1{})
+	c.Provide(&Type2{})
+	if err := c.Invoke(func(t1 *Type1, t2 *Type2) {
+		fmt.Println("t1", t1)
+		fmt.Println("t1", t2)
+	}); err != nil {
+		panic(err)
+	}
+	fmt.Println(c.String())
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -202,7 +204,7 @@ func (g *Graph) validateGraph(ct reflect.Type) (reflect.Value, error) {
 }
 
 // ConstructorArguments returns arguments in the provided constructor
-func (g *Graph) ConstructorArguments(ctype reflect.Type, optionals ...reflect.Type) ([]reflect.Value, error) {
+func (g *Graph) ConstructorArguments(ctype reflect.Type, optionals ...string) ([]reflect.Value, error) {
 	// find dependencies from the graph and place them in the args
 	args := make([]reflect.Value, ctype.NumIn(), ctype.NumIn())
 	for idx := range args {
@@ -215,7 +217,7 @@ func (g *Graph) ConstructorArguments(ctype reflect.Type, optionals ...reflect.Ty
 			}
 			args[idx] = v
 		} else {
-			if !g.isOptional(arg, optionals) {
+			if !g.isOptional(arg.String(), optionals) {
 				return nil, fmt.Errorf("%v dependency of type %v is not registered", ctype, arg)
 			}
 			// log.Printf("Assigning zero value for arguments in %v. Dependency of type %v is not yet registered", ctype, arg)
@@ -225,9 +227,9 @@ func (g *Graph) ConstructorArguments(ctype reflect.Type, optionals ...reflect.Ty
 	return args, nil
 }
 
-func (g *Graph) isOptional(t reflect.Type, optionals []reflect.Type) bool {
+func (g *Graph) isOptional(t string, optionals []string) bool {
 	for _, opts := range optionals {
-		if opts == t {
+		if strings.Contains(t, opts) {
 			return true
 		}
 	}


### PR DESCRIPTION
With this approach, dig container exposes a variadic API `dig.Optionals` to register any optional parameters. This API can be wrapped inside fx.App stack, so that fxstack.Optional() can be called by users, or any module that uses app during `Load`.

1. Any type can be `Optional`
2. services and modules get to define when to use Optionals
3. No existing API changes

In fx.App:
```go
//Optionals is used to present optional variables to dig
func (s *App) Optionals(i ...interface{}) error {
	s.container.Optionals(i...)
	return nil
}
```
In modules:
```go
// Load sets the multiple constructors needed to use this module
func Load(app *fx.App) {
	app.Optionals(SomeOptionalStuff...)
	app.Provide(NewSetup, NewStuff)
}
```