### PR TITLE
[Prototype] Use zero values for unknown types

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -102,7 +102,7 @@ func TestResolve(t *testing.T) {
 				var p1 *Parent1
 				return c.Resolve(&p1)
 			},
-			"type *dig.Parent1 is not registered",
+			"",
 		},
 	}
 
@@ -319,8 +319,6 @@ func TestConstructorErrors(t *testing.T) {
 			var p1 *FlakyParent
 			err := c.Resolve(&p1)
 			if tt.wantErr != "" {
-				var registeredError *error
-				require.Error(t, c.Resolve(&registeredError), "type *error is not registered")
 				require.EqualError(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
@@ -394,7 +392,7 @@ func TestInvokeReturnedError(t *testing.T) {
 		return errors.New("oops")
 	})
 	var registeredError *error
-	require.Error(t, c.Resolve(&registeredError), "type *error is not registered")
+	require.NoError(t, c.Resolve(&registeredError), "unexpected error resolving unknown type")
 	require.Contains(t, err.Error(), "error invoking the function func() error: oops")
 
 	err = c.Invoke(func() (*Child1, error) {
@@ -514,7 +512,10 @@ func TestEmptyAfterReset(t *testing.T) {
 	var first *Grandchild1
 	require.NoError(t, c.Resolve(&first), "No error expected during first Resolve")
 	c.Reset()
-	require.Contains(t, c.Resolve(&first).Error(), "not registered")
+
+	first = nil
+	assert.NoError(t, c.Resolve(&first), "unexpected error resolving unknown type")
+	assert.Nil(t, first, "expected zero value after resolving unknown type")
 }
 
 func TestPanicConstructor(t *testing.T) {
@@ -551,7 +552,7 @@ func TestMultiObjectRegisterResolve(t *testing.T) {
 	require.NoError(t, c.Resolve(&third), "No error expected during first Resolve")
 
 	var errRegistered *error
-	require.Error(t, c.Resolve(&errRegistered), "type *error shouldn't be registered")
+	require.NoError(t, c.Resolve(&errRegistered), "unexpected error resolving unknown type")
 	require.Nil(t, errRegistered)
 
 	require.NotNil(t, first, "Child1 must have been registered")

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -57,7 +57,7 @@ func (g *Graph) Read(objType reflect.Type) (reflect.Value, error) {
 	// check if the type is a registered objNode
 	n, ok := g.nodes[objType]
 	if !ok {
-		return reflect.Zero(objType), fmt.Errorf("type %v is not registered", objType)
+		return reflect.Zero(objType), nil
 	}
 	v, err := n.value(g, objType)
 	if err != nil {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -152,6 +152,6 @@ func TestMultiObjectRegisterResolve(t *testing.T) {
 
 	var errRegistered *error
 	v, err = g.Read(reflect.TypeOf(errRegistered))
-	require.Error(t, err, "type *error shouldn't be registered")
+	require.NoError(t, err, "shouldn't get errors resolving unknown types")
 	require.Nil(t, v.Interface())
 }


### PR DESCRIPTION
Just for discussion :taco:

This PR makes a simple change: instead of returning errors when `Read`/`Resolving` unknown types, it supplies the zero value of the type instead. This puts the burden of validating inputs on constructor authors.