### PR TITLE
[1/2] Add tests for user-facing behavior

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -265,7 +265,7 @@ func TestProvideRespectsConstructorErrors(t *testing.T) {
 }
 
 func TestCantProvideUntypedNil(t *testing.T) {
-	t.Fatalf("Calling Container.Provide(nil) crashes the main testing thread. Failing early.")
+	t.Skip("Calling Container.Provide(nil) crashes the main testing thread")
 	t.Parallel()
 	c := New()
 	assert.Error(t, c.Provide(nil))

--- a/dig_test.go
+++ b/dig_test.go
@@ -35,9 +35,11 @@ func TestEndToEndSuccess(t *testing.T) {
 
 	t.Run("pointer", func(t *testing.T) {
 		c := New()
-		require.NoError(t, c.Provide(&bytes.Buffer{}), "provide failed")
-		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
-			require.NotNil(t, b, "invoke got nil buffer")
+		b := &bytes.Buffer{}
+		require.NoError(t, c.Provide(b), "provide failed")
+		require.NoError(t, c.Invoke(func(got *bytes.Buffer) {
+			require.NotNil(t, got, "invoke got nil buffer")
+			require.True(t, got == b, "invoke got wrong buffer")
 		}), "invoke failed")
 	})
 
@@ -54,11 +56,14 @@ func TestEndToEndSuccess(t *testing.T) {
 
 	t.Run("pointer constructor", func(t *testing.T) {
 		c := New()
+		var b *bytes.Buffer
 		require.NoError(t, c.Provide(func() *bytes.Buffer {
-			return &bytes.Buffer{}
+			b = &bytes.Buffer{}
+			return b
 		}), "provide failed")
-		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
-			require.NotNil(t, b, "invoke got nil buffer")
+		require.NoError(t, c.Invoke(func(got *bytes.Buffer) {
+			require.NotNil(t, got, "invoke got nil buffer")
+			require.True(t, got == b, "invoke got wrong buffer")
 		}), "invoke failed")
 	})
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -330,7 +330,6 @@ func TestProvideKnownTypesFails(t *testing.T) {
 			for _, second := range provideArgs {
 				assert.Error(t, c.Provide(second), "second provide must fail")
 			}
-
 		})
 	}
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -287,9 +287,9 @@ func TestProvideCycleFails(t *testing.T) {
 	type A struct{}
 	type B struct{}
 	type C struct{}
-	newA := func(C) A { return A{} }
-	newB := func(A) B { return B{} }
-	newC := func(B) C { return C{} }
+	newA := func(*C) *A { return &A{} }
+	newB := func(*A) *B { return &B{} }
+	newC := func(*B) *C { return &C{} }
 
 	c := New()
 	assert.NoError(t, c.Provide(newA))
@@ -307,13 +307,13 @@ func TestIncompleteGraphIsOkay(t *testing.T) {
 	type A struct{}
 	type B struct{}
 	type C struct{}
-	newA := func() A { return A{} }
-	newC := func(B) C { return C{} }
+	newA := func() *A { return &A{} }
+	newC := func(*B) *C { return &C{} }
 
 	c := New()
 	assert.NoError(t, c.Provide(newA), "provide failed")
 	assert.NoError(t, c.Provide(newC), "provide failed")
-	assert.NoError(t, c.Invoke(func(A) {}), "invoke failed")
+	assert.NoError(t, c.Invoke(func(*A) {}), "invoke failed")
 }
 
 func TestProvideFuncsWithoutReturnsFails(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -70,9 +70,9 @@ func TestEndToEndSuccess(t *testing.T) {
 	t.Run("struct", func(t *testing.T) {
 		t.Skip("Not yet supported.")
 		c := New()
-		buf := &bytes.Buffer{}
+		var buf bytes.Buffer
 		buf.WriteString("foo")
-		require.NoError(t, c.Provide(*buf), "provide failed")
+		require.NoError(t, c.Provide(buf), "provide failed")
 		require.NoError(t, c.Invoke(func(b bytes.Buffer) {
 			// ensure we're getting back the buffer we put in
 			require.Equal(t, "foo", buf.String(), "invoke got new buffer")
@@ -82,9 +82,9 @@ func TestEndToEndSuccess(t *testing.T) {
 	t.Run("struct constructor", func(t *testing.T) {
 		t.Skip("Not yet supported.")
 		c := New()
-		buf := &bytes.Buffer{}
+		var buf bytes.Buffer
 		buf.WriteString("foo")
-		require.NoError(t, c.Provide(*buf), "provide failed")
+		require.NoError(t, c.Provide(buf), "provide failed")
 		require.NoError(t, c.Invoke(func(b bytes.Buffer) {
 			// ensure we're getting back the buffer we put in
 			require.Equal(t, "foo", buf.String(), "invoke got new buffer")

--- a/dig_test.go
+++ b/dig_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndToEndSuccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pointer", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(&bytes.Buffer{}), "provide failed")
+		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
+			require.NotNil(t, b, "invoke got nil buffer")
+		}), "invoke failed")
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		// Dig shouldn't forbid this - it's perfectly reasonable to explicitly
+		// provide a typed nil, since that's often a convenient way to supply a
+		// default no-op implementation.
+		c := New()
+		require.NoError(t, c.Provide((*bytes.Buffer)(nil)), "provide failed")
+		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
+			require.Nil(t, b, "expected to get nil buffer")
+		}), "invoke failed")
+	})
+
+	t.Run("pointer constructor", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() *bytes.Buffer {
+			return &bytes.Buffer{}
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
+			require.NotNil(t, b, "invoke got nil buffer")
+		}), "invoke failed")
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		t.Skip("Not yet supported.")
+		c := New()
+		buf := &bytes.Buffer{}
+		buf.WriteString("foo")
+		require.NoError(t, c.Provide(*buf), "provide failed")
+		require.NoError(t, c.Invoke(func(b bytes.Buffer) {
+			// ensure we're getting back the buffer we put in
+			require.Equal(t, "foo", buf.String(), "invoke got new buffer")
+		}), "invoke failed")
+	})
+
+	t.Run("struct constructor", func(t *testing.T) {
+		t.Skip("Not yet supported.")
+		c := New()
+		buf := &bytes.Buffer{}
+		buf.WriteString("foo")
+		require.NoError(t, c.Provide(*buf), "provide failed")
+		require.NoError(t, c.Invoke(func(b bytes.Buffer) {
+			// ensure we're getting back the buffer we put in
+			require.Equal(t, "foo", buf.String(), "invoke got new buffer")
+		}), "invoke failed")
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		c := New()
+		bufs := []*bytes.Buffer{{}, {}}
+		require.NoError(t, c.Provide(bufs), "provide failed")
+		require.NoError(t, c.Invoke(func(bs []*bytes.Buffer) {
+			require.Equal(t, 2, len(bs), "invoke got unexpected number of buffers")
+		}), "invoke failed")
+	})
+
+	t.Run("slice constructor", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() []*bytes.Buffer {
+			return []*bytes.Buffer{{}, {}}
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(bs []*bytes.Buffer) {
+			require.Equal(t, 2, len(bs), "invoke got unexpected number of buffers")
+		}), "invoke failed")
+	})
+
+	t.Run("array", func(t *testing.T) {
+		c := New()
+		bufs := [1]*bytes.Buffer{{}}
+		require.NoError(t, c.Provide(bufs), "provide failed")
+		require.NoError(t, c.Invoke(func(bs [1]*bytes.Buffer) {
+			require.NotNil(t, bs[0], "invoke got new array")
+		}), "invoke failed")
+	})
+
+	t.Run("array constructor", func(t *testing.T) {
+		c := New()
+		bufs := [1]*bytes.Buffer{{}}
+		require.NoError(t, c.Provide(bufs), "provide failed")
+		require.NoError(t, c.Invoke(func(bs [1]*bytes.Buffer) {
+			require.NotNil(t, bs[0], "invoke got new array")
+		}), "invoke failed")
+	})
+
+	t.Run("map", func(t *testing.T) {
+		c := New()
+		m := map[string]string{}
+		require.NoError(t, c.Provide(m), "provide failed")
+		require.NoError(t, c.Invoke(func(m map[string]string) {
+			require.NotNil(t, m, "invoke got zero value map")
+		}), "invoke failed")
+	})
+
+	t.Run("map constructor", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() map[string]string {
+			return map[string]string{}
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(m map[string]string) {
+			require.NotNil(t, m, "invoke got zero value map")
+		}), "invoke failed")
+	})
+
+	t.Run("channel", func(t *testing.T) {
+		t.Skip("Not yet supported.")
+		c := New()
+		ch := make(chan int)
+		require.NoError(t, c.Provide(ch), "provide failed")
+		require.NoError(t, c.Invoke(func(ch chan int) {
+			require.NotNil(t, ch, "invoke got nil chan")
+		}), "invoke failed")
+	})
+
+	t.Run("channel constructor", func(t *testing.T) {
+		t.Skip("Not yet supported.")
+		c := New()
+		require.NoError(t, c.Provide(func() chan int {
+			return make(chan int)
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(ch chan int) {
+			require.NotNil(t, ch, "invoke got nil chan")
+		}), "invoke failed")
+	})
+
+	t.Run("func constructor", func(t *testing.T) {
+		t.Skip("Not yet supported.")
+		// Functions passed directly to Provide are treated as constructors,
+		// but we can still put functions into the container with constructors.
+		// This makes injecting builders simple.
+		c := New()
+		require.NoError(t, c.Provide(func() func(int) {
+			return func(int) {}
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(f func(int)) {
+			require.NotNil(t, f, "invoke got nil function pointer")
+		}), "invoke failed")
+	})
+
+	t.Run("interface", func(t *testing.T) {
+		// TODO: This doesn't work as a reasonable user would expect, since
+		// passing an io.Writer as interface{} erases information. (Put
+		// differently, we go from having an io.Writer satisfied by a
+		// *bytes.Buffer to having an interface{} satisfied by *bytes.Buffer;
+		// the fact that the io.Writer interface was involved is lost forever.)
+		c := New()
+		var w io.Writer = &bytes.Buffer{}
+		require.NoError(t, c.Provide(w), "provide failed")
+		require.Error(t, c.Invoke(func(w io.Writer) {
+		}), "expected relying on provided interface to fail")
+		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
+			assert.NotNil(t, b, "expected to get concrete type of interface")
+		}), "expected relying on concrete type to succeed")
+
+	})
+
+	t.Run("interface constructor", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() io.Writer {
+			return &bytes.Buffer{}
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(w io.Writer) {
+			require.NotNil(t, w, "invoke got nil interface")
+		}), "invoke failed")
+	})
+
+	t.Run("multiple-type constructor", func(t *testing.T) {
+		c := New()
+		constructor := func() (*bytes.Buffer, []int, error) {
+			return &bytes.Buffer{}, []int{42}, nil
+		}
+		consumer := func(b *bytes.Buffer, nums []int) {
+			assert.NotNil(t, b, "invoke got nil buffer")
+			assert.Equal(t, 1, len(nums), "invoke got empty slice")
+		}
+		require.NoError(t, c.Provide(constructor), "provide failed")
+		require.NoError(t, c.Invoke(consumer), "invoke failed")
+	})
+
+	t.Run("collections and instances of same type", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() []*bytes.Buffer {
+			return []*bytes.Buffer{{}}
+		}), "providing collection failed")
+		require.NoError(t, c.Provide(func() *bytes.Buffer {
+			return &bytes.Buffer{}
+		}), "providing pointer failed")
+	})
+}
+
+func TestProvideRespectsConstructorErrors(t *testing.T) {
+	t.Run("constructor succeeds", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() (*bytes.Buffer, error) {
+			return &bytes.Buffer{}, nil
+		}), "provide failed")
+		require.NoError(t, c.Invoke(func(b *bytes.Buffer) {
+			require.NotNil(t, b, "invoke got nil buffer")
+		}), "invoke failed")
+	})
+	t.Run("constructor fails", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() (*bytes.Buffer, error) {
+			return nil, errors.New("oh no")
+		}), "provide failed")
+
+		var called bool
+		err := c.Invoke(func(b *bytes.Buffer) { called = true })
+		assert.Contains(t, err.Error(), "oh no", "expected to bubble up constructor error")
+		assert.False(t, called, "shouldn't call invoked function when deps aren't available")
+	})
+}
+
+func TestCantProvideUntypedNil(t *testing.T) {
+	t.Fatalf("Calling Container.Provide(nil) crashes the main testing thread. Failing early.")
+	t.Parallel()
+	c := New()
+	assert.Error(t, c.Provide(nil))
+}
+
+func TestCantProvideErrors(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	assert.Error(t, c.Provide(func() error { return errors.New("foo") }))
+	// TODO: This is another case where we're losing type information, which
+	// (again) makes the provide-instance path behave differently from the
+	// provide-constructor path. This is fixable by not allowing users to
+	// provide types that *implement* error, but let's discuss a holistic
+	// solution.
+	assert.NoError(t, c.Provide(errors.New("foo")))
+}
+
+func TestProvideKnownTypesFails(t *testing.T) {
+	t.Parallel()
+	c := New()
+	assert.NoError(t, c.Provide(func() *bytes.Buffer { return nil }))
+	assert.Error(t, c.Provide(func() *bytes.Buffer { return nil }))
+}
+
+func TestProvideCycleFails(t *testing.T) {
+	t.Parallel()
+
+	// A <- B <- C
+	// |         ^
+	// |_________|
+	type A struct{}
+	type B struct{}
+	type C struct{}
+	newA := func(C) A { return A{} }
+	newB := func(A) B { return B{} }
+	newC := func(B) C { return C{} }
+
+	c := New()
+	assert.NoError(t, c.Provide(newA))
+	assert.NoError(t, c.Provide(newB))
+	err := c.Provide(newC)
+	require.Error(t, err, "expected error when introducing cycle")
+	require.Contains(t, err.Error(), "cycle")
+}
+
+func TestIncompleteGraphIsOkay(t *testing.T) {
+	t.Parallel()
+
+	// A <- B <- C
+	// Even if we don't provide B, we should be able to resolve A.
+	type A struct{}
+	type B struct{}
+	type C struct{}
+	newA := func() A { return A{} }
+	newC := func(B) C { return C{} }
+
+	c := New()
+	assert.NoError(t, c.Provide(newA), "provide failed")
+	assert.NoError(t, c.Provide(newC), "provide failed")
+	assert.NoError(t, c.Invoke(func(A) {}), "invoke failed")
+}
+
+func TestProvideFuncsWithoutReturnsFails(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	assert.Error(t, c.Provide(func(*bytes.Buffer) {}))
+}
+
+func TestInvokesUseCachedObjects(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	calls := 0
+	buf := &bytes.Buffer{}
+	require.NoError(t, c.Provide(func() *bytes.Buffer { return buf }))
+
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, c.Invoke(func(b *bytes.Buffer) {
+			calls++
+			require.Equal(t, buf, b, "invoke got different buffer pointer")
+		}), "invoke %d failed", i)
+		require.Equal(t, i+1, calls, "invoked function not called")
+	}
+}
+
+func TestInvokeFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmet dependency", func(t *testing.T) {
+		c := New()
+		assert.Error(t, c.Invoke(func(*bytes.Buffer) {}))
+	})
+
+	t.Run("returned error", func(t *testing.T) {
+		c := New()
+		assert.Error(t, c.Invoke(func() error { return errors.New("oh no") }))
+	})
+
+	t.Run("many returns", func(t *testing.T) {
+		c := New()
+		assert.Error(t, c.Invoke(func() (int, error) { return 42, errors.New("oh no") }))
+	})
+}

--- a/dig_test.go
+++ b/dig_test.go
@@ -93,20 +93,28 @@ func TestEndToEndSuccess(t *testing.T) {
 
 	t.Run("slice", func(t *testing.T) {
 		c := New()
-		bufs := []*bytes.Buffer{{}, {}}
+		b1 := &bytes.Buffer{}
+		b2 := &bytes.Buffer{}
+		bufs := []*bytes.Buffer{b1, b2}
 		require.NoError(t, c.Provide(bufs), "provide failed")
 		require.NoError(t, c.Invoke(func(bs []*bytes.Buffer) {
 			require.Equal(t, 2, len(bs), "invoke got unexpected number of buffers")
+			require.True(t, b1 == bs[0], "first item did not match")
+			require.True(t, b2 == bs[1], "second item did not match")
 		}), "invoke failed")
 	})
 
 	t.Run("slice constructor", func(t *testing.T) {
 		c := New()
+		b1 := &bytes.Buffer{}
+		b2 := &bytes.Buffer{}
 		require.NoError(t, c.Provide(func() []*bytes.Buffer {
-			return []*bytes.Buffer{{}, {}}
+			return []*bytes.Buffer{b1, b2}
 		}), "provide failed")
 		require.NoError(t, c.Invoke(func(bs []*bytes.Buffer) {
 			require.Equal(t, 2, len(bs), "invoke got unexpected number of buffers")
+			require.True(t, b1 == bs[0], "first item did not match")
+			require.True(t, b2 == bs[1], "second item did not match")
 		}), "invoke failed")
 	})
 


### PR DESCRIPTION
# ☮️ 🙏 😇 🙇   I come in peace  :bow:😇 🙏 ☮️ 

TL;DR: This PR adds integration tests, which fail. Fixing the tests requires
enough refactoring that I separated it into in a follow-on PR.

As I was working on Fx modules that use dig, I noticed some behavior that
surprised me. In exploring dig's code, I realized that many of my assumptions
about how the library should behave aren't covered by dig's testing suite.

In this PR, I've added a bunch of end-to-end tests in the top-level dig package.
Those tests *only* use the public `Provide` and `Invoke` APIs to verify that the
behaviors Fx needs work correctly. I haven't altered any of dig's production
code.

Unfortunately, these tests exposed a number of bugs:

```
$ go test . | grep FAIL

    # Container.Provide(nil) panics.
--- FAIL: TestCantProvideUntypedNil (0.00s)

    # The container allows us to provide errors, but only via some code paths.
--- FAIL: TestCantProvideErrors (0.00s)

    # All types in the graph must have their deps satisfied, even if nobody's
    # using them.
--- FAIL: TestIncompleteGraphIsOkay (0.00s)

--- FAIL: TestEndToEndSuccess (0.00s)
    # We can't provide slices or maps from standard constructor functions, but
    # we can provide instances. Elaborate constructors like `func() []Foo, int,
    # error` also work correctly.
    --- FAIL: TestEndToEndSuccess/slice_constructor (0.00s)
    --- FAIL: TestEndToEndSuccess/map_constructor (0.00s)

    # We can't provide both []*Foo and *Foo, since dig considers them the same
    # type.
    --- FAIL: TestEndToEndSuccess/collections_and_instances_of_same_type (0.00s)
```

This is concerning to me, since dig has 89% code coverage. Fixing these bugs and
structuring the code so that we can confidently refactor without breaking
user-facing behavior was a larger change, so I've broken it out into a separate
PR.