### PR TITLE
dig.Param: Recurse into nested parameter objects

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -181,7 +181,7 @@ func (c *Container) get(t reflect.Type) (reflect.Value, error) {
 	}
 
 	if t.Implements(_parameterObjectType) {
-		// No caching
+		// We do not want parameter objects to be cached.
 		return c.createParamObject(t)
 	}
 

--- a/dig.go
+++ b/dig.go
@@ -257,7 +257,7 @@ type node struct {
 func newNode(provides reflect.Type, ctor interface{}, ctype reflect.Type) (node, error) {
 	deps := make([]reflect.Type, 0, ctype.NumIn())
 	for i := 0; i < ctype.NumIn(); i++ {
-		deps = append(deps, getCtorParamDependencies(ctype.In(i))...)
+		deps = append(deps, getConstructorDependencies(ctype.In(i))...)
 	}
 
 	return node{
@@ -269,23 +269,20 @@ func newNode(provides reflect.Type, ctor interface{}, ctype reflect.Type) (node,
 }
 
 // Retrives the dependencies for the parameter of a constructor.
-func getCtorParamDependencies(t reflect.Type) (deps []reflect.Type) {
+func getConstructorDependencies(t reflect.Type) []reflect.Type {
 	if !t.Implements(_parameterObjectType) {
-		deps = append(deps, t)
-		return
+		return []reflect.Type{t}
 	}
 
-	deps = make([]reflect.Type, 0, t.NumField())
+	deps := make([]reflect.Type, 0, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if f.PkgPath != "" {
 			continue // skip private fields
 		}
-
-		deps = append(deps, getCtorParamDependencies(f.Type)...)
+		deps = append(deps, getConstructorDependencies(f.Type)...)
 	}
-
-	return
+	return deps
 }
 
 func cycleError(cycle []reflect.Type, last reflect.Type) error {

--- a/dig.go
+++ b/dig.go
@@ -354,6 +354,8 @@ func getParameterDependencies(t reflect.Type) ([]reflect.Type, error) {
 	return deps, nil
 }
 
+// Returns a new Param parent object with all the dependency fields
+// populated from the dig container.
 func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 	dest := reflect.New(t).Elem()
 	result := dest

--- a/dig.go
+++ b/dig.go
@@ -174,6 +174,7 @@ func (c *Container) isAcyclic(n node) error {
 	return detectCycles(n, c.nodes, nil, make(map[reflect.Type]struct{}))
 }
 
+// Retrieve a type from the container
 func (c *Container) get(t reflect.Type) (reflect.Value, error) {
 	if v, ok := c.cache[t]; ok {
 		return v, nil
@@ -239,7 +240,7 @@ func (c *Container) constructorArgs(ctype reflect.Type) ([]reflect.Value, error)
 
 		t := ctype.In(i)
 		if t.Implements(_parameterObjectType) {
-			arg, err = c.getParameterObject(t)
+			arg, err = c.createParamObject(t)
 		} else {
 			arg, err = c.get(t)
 		}
@@ -356,7 +357,7 @@ func getParameterDependencies(t reflect.Type) ([]reflect.Type, error) {
 
 // Returns a new Param parent object with all the dependency fields
 // populated from the dig container.
-func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
+func (c *Container) createParamObject(t reflect.Type) (reflect.Value, error) {
 	dest := reflect.New(t).Elem()
 	result := dest
 	for t.Kind() == reflect.Ptr {
@@ -376,7 +377,7 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 			err error
 		)
 		if f.Type.Implements(_parameterObjectType) {
-			v, err = c.getParameterObject(f.Type)
+			v, err = c.createParamObject(f.Type)
 		} else {
 			v, err = c.get(f.Type)
 		}

--- a/dig_test.go
+++ b/dig_test.go
@@ -326,10 +326,10 @@ func TestEndToEndSuccess(t *testing.T) {
 
 		require.NoError(t, c.Invoke(func(p *someParam) {
 			require.NotNil(t, p, "someParam must not be nil")
-			require.NotNil(t, p.Buffer, "someParam must not be nil")
-			require.NotNil(t, p.Another, "someParam must not be nil")
-			require.NotNil(t, p.Another.Buffer, "someParam must not be nil")
-			require.True(t, p.Buffer == p.Another.Buffer, "buffer must be the same")
+			require.NotNil(t, p.Buffer, "someParam.Buffer must not be nil")
+			require.NotNil(t, p.Another, "anotherParam must not be nil")
+			require.NotNil(t, p.Another.Buffer, "anotherParam.Buffer must not be nil")
+			require.True(t, p.Buffer == p.Another.Buffer, "buffers must be the same")
 		}), "invoke must not fail")
 	})
 


### PR DESCRIPTION
This change adds support to parameter objects for recursing into fields that
are also parameter objects. That is, this change allows the following,

    type OutputConfig struct {
        dig.Param

        Writer io.Writer
    }

    type Config struct {
        dig.Param

        Input io.Reader
        Output OutputConfig
    }

    func NewTransport(cfg Config) (*Transport, error) { .. }

Besides the usefulness of treating fields similar to constructor parameters,
there's another motivating use case for this: Aliasing `dig.Param`. Without
this change, we have special handling for the `dig.Param` type, opting it out
of resolution from `dig`. If a library author wants to use their own type in
place of `dig.Param` (for example, `fx.Param`), they can't quite do this
because any alias of `dig.Param` is a different type; one which the library
does not special-case.

    package fx

    type Param dig.Param

    type Config struct {
        Param

        Input io.Reader
    }

    // The above with fail because dig doesn't know how to resolve fx.Param.

With this change, Fx will be able to support the following.

    package fx

    type Param struct{ dig.Param }

    type Config struct {
        Param

        // ..
    }