### PR TITLE
Add support for optional parameters

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -380,8 +380,15 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 
 		v, err := c.get(f.Type)
 		if err != nil {
-			return result, fmt.Errorf(
-				"could not get field %v (type %v) of %v: %v", f.Name, f.Type, t, err)
+			// TODO: once other tags are avilabled (named=foo),
+			// probably should serialize the tags better, or at least scan the string
+			tag := f.Tag.Get("dig")
+			if tag == "optional" {
+				v = reflect.Zero(f.Type)
+			} else {
+				return result, fmt.Errorf(
+					"could not get field %v (type %v) of %v: %v", f.Name, f.Type, t, err)
+			}
 		}
 
 		dest.Field(i).Set(v)

--- a/dig.go
+++ b/dig.go
@@ -399,7 +399,7 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 func containsString(source []string, s string) bool {
 	res := false
 	for _, v := range source {
-		if v == s {
+		if strings.TrimSpace(v) == s {
 			return true
 		}
 	}

--- a/dig.go
+++ b/dig.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 )
 
 var (
@@ -381,8 +380,7 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 
 		v, err := c.get(f.Type)
 		if err != nil {
-			tags := strings.Split(f.Tag.Get("dig"), ",")
-			if containsString(tags, "optional") {
+			if f.Tag.Get("optional") == "true" {
 				v = reflect.Zero(f.Type)
 			} else {
 				return result, fmt.Errorf(
@@ -394,14 +392,4 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 	}
 
 	return result, nil
-}
-
-func containsString(source []string, s string) bool {
-	res := false
-	for _, v := range source {
-		if strings.TrimSpace(v) == s {
-			return true
-		}
-	}
-	return res
 }

--- a/dig.go
+++ b/dig.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 var (
@@ -380,10 +381,8 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 
 		v, err := c.get(f.Type)
 		if err != nil {
-			// TODO: once other tags are avilabled (named=foo),
-			// probably should serialize the tags better, or at least scan the string
-			tag := f.Tag.Get("dig")
-			if tag == "optional" {
+			tags := strings.Split(f.Tag.Get("dig"), ",")
+			if containsString(tags, "optional") {
 				v = reflect.Zero(f.Type)
 			} else {
 				return result, fmt.Errorf(
@@ -395,4 +394,14 @@ func (c *Container) getParameterObject(t reflect.Type) (reflect.Value, error) {
 	}
 
 	return result, nil
+}
+
+func containsString(source []string, s string) bool {
+	res := false
+	for _, v := range source {
+		if v == s {
+			return true
+		}
+	}
+	return res
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -365,7 +365,7 @@ func TestEndToEndSuccess(t *testing.T) {
 			Param
 
 			T1 *type1 // regular 'ol type
-			T2 *type2 `dig:"optional"`               // optional type NOT in the graph
+			T2 *type2 `dig:"optional,useless_tag"`   // optional type NOT in the graph
 			T3 *type3 `unrelated:"foo=42, optional"` // type in the graph with unrelated tag
 			T4 *type4 `dig:"optional"`               // optional type present in the graph
 		}

--- a/dig_test.go
+++ b/dig_test.go
@@ -356,6 +356,7 @@ func TestEndToEndSuccess(t *testing.T) {
 		type type2 struct{}
 		type type3 struct{}
 		type type4 struct{}
+		type type5 struct{}
 		constructor := func() (*type1, *type3, *type4) {
 			return &type1{}, &type3{}, &type4{}
 		}
@@ -365,9 +366,10 @@ func TestEndToEndSuccess(t *testing.T) {
 			Param
 
 			T1 *type1 // regular 'ol type
-			T2 *type2 `dig:"optional,useless_tag"`   // optional type NOT in the graph
-			T3 *type3 `unrelated:"foo=42, optional"` // type in the graph with unrelated tag
-			T4 *type4 `dig:"optional"`               // optional type present in the graph
+			T2 *type2 `dig:"optional,useless_tag"`      // optional type NOT in the graph
+			T3 *type3 `unrelated:"foo=42, optional"`    // type in the graph with unrelated tag
+			T4 *type4 `dig:"optional"`                  // optional type present in the graph
+			T5 *type5 `dig:"optional, again=pointless"` // optional type, not in graph, meaningless tag
 		}
 		require.NoError(t, c.Provide(constructor))
 		require.NoError(t, c.Invoke(func(p param) {
@@ -375,6 +377,7 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Nil(t, p.T2, "optional type not in the grap should return nil")
 			assert.NotNil(t, p.T3, "required type with unrelated tag not in the graph")
 			assert.NotNil(t, p.T4, "optional type in the graph should not return nil")
+			assert.Nil(t, p.T5, "optional type not in the graph should be nil")
 		}))
 
 	})

--- a/dig_test.go
+++ b/dig_test.go
@@ -356,7 +356,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		type type2 struct{}
 		type type3 struct{}
 		type type4 struct{}
-		type type5 struct{}
 		constructor := func() (*type1, *type3, *type4) {
 			return &type1{}, &type3{}, &type4{}
 		}
@@ -366,10 +365,9 @@ func TestEndToEndSuccess(t *testing.T) {
 			Param
 
 			T1 *type1 // regular 'ol type
-			T2 *type2 `dig:"optional,useless_tag"`      // optional type NOT in the graph
-			T3 *type3 `unrelated:"foo=42, optional"`    // type in the graph with unrelated tag
-			T4 *type4 `dig:"optional"`                  // optional type present in the graph
-			T5 *type5 `dig:"optional, again=pointless"` // optional type, not in graph, meaningless tag
+			T2 *type2 `optional:"true" useless_tag:"false"` // optional type NOT in the graph
+			T3 *type3 `unrelated:"foo=42, optional"`        // type in the graph with unrelated tag
+			T4 *type4 `optional:"true"`                     // optional type present in the graph
 		}
 		require.NoError(t, c.Provide(constructor))
 		require.NoError(t, c.Invoke(func(p param) {
@@ -377,9 +375,7 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Nil(t, p.T2, "optional type not in the grap should return nil")
 			assert.NotNil(t, p.T3, "required type with unrelated tag not in the graph")
 			assert.NotNil(t, p.T4, "optional type in the graph should not return nil")
-			assert.Nil(t, p.T5, "optional type not in the graph should be nil")
 		}))
-
 	})
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -365,9 +365,9 @@ func TestEndToEndSuccess(t *testing.T) {
 			Param
 
 			T1 *type1 // regular 'ol type
-			T2 *type2 `dig:"optional"`          // optional type NOT in the graph
-			T3 *type3 `unrelated:"some_tag=42"` // type in the graph with unrelated tag
-			T4 *type4 `dig:"optional"`          // optional type present in the graph
+			T2 *type2 `dig:"optional"`               // optional type NOT in the graph
+			T3 *type3 `unrelated:"foo=42, optional"` // type in the graph with unrelated tag
+			T4 *type4 `dig:"optional"`               // optional type present in the graph
 		}
 		require.NoError(t, c.Provide(constructor))
 		require.NoError(t, c.Invoke(func(p param) {


### PR DESCRIPTION
The refactor and Params made it quite trivial to add support and e2e
test for optional tags.

Reading the test explains the expected behavior quite well.

Stacked on #70, #72, #71