### PR TITLE
param: Pointers are not parameter objects

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -116,7 +116,7 @@ func (c *Container) provideInstance(val interface{}) error {
 	if vtype == _errType {
 		return errors.New("can't provide errors")
 	}
-	if vtype.Implements(_parameterObjectType) {
+	if isParameterObject(vtype) {
 		return errors.New("can't provide parameter objects")
 	}
 	if _, ok := c.nodes[vtype]; ok {
@@ -135,7 +135,7 @@ func (c *Container) provideConstructor(ctor interface{}, ctype reflect.Type) err
 			// Don't register errors into the container.
 			continue
 		}
-		if rt.Implements(_parameterObjectType) {
+		if isParameterObject(rt) {
 			return errors.New("can't provide parameter objects")
 		}
 		if _, ok := returnTypes[rt]; ok {
@@ -180,7 +180,7 @@ func (c *Container) get(t reflect.Type) (reflect.Value, error) {
 		return v, nil
 	}
 
-	if t.Implements(_parameterObjectType) {
+	if isParameterObject(t) {
 		// We do not want parameter objects to be cached.
 		return c.createParamObject(t)
 	}
@@ -270,7 +270,7 @@ func newNode(provides reflect.Type, ctor interface{}, ctype reflect.Type) (node,
 
 // Retrives the dependencies for the parameter of a constructor.
 func getCtorParamDependencies(t reflect.Type) (deps []reflect.Type) {
-	if !t.Implements(_parameterObjectType) {
+	if !isParameterObject(t) {
 		deps = append(deps, t)
 		return
 	}
@@ -334,17 +334,14 @@ type parameterObject interface {
 	parameterObject()
 }
 
+func isParameterObject(t reflect.Type) bool {
+	return t.Implements(_parameterObjectType) && t.Kind() == reflect.Struct
+}
+
 // Returns a new Param parent object with all the dependency fields
 // populated from the dig container.
 func (c *Container) createParamObject(t reflect.Type) (reflect.Value, error) {
 	dest := reflect.New(t).Elem()
-	result := dest
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-		dest.Set(reflect.New(t))
-		dest = dest.Elem()
-	}
-
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if f.PkgPath != "" {
@@ -357,12 +354,12 @@ func (c *Container) createParamObject(t reflect.Type) (reflect.Value, error) {
 			case "true", "yes":
 				v = reflect.Zero(f.Type)
 			default:
-				return result, fmt.Errorf(
+				return dest, fmt.Errorf(
 					"could not get field %v (type %v) of %v: %v", f.Name, f.Type, t, err)
 			}
 		}
 
 		dest.Field(i).Set(v)
 	}
-	return result, nil
+	return dest, nil
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -483,10 +483,9 @@ func TestCanProvideErrorLikeType(t *testing.T) {
 			c := New()
 			require.NoError(t, c.Provide(tt), "provide must not fail")
 
-			require.NoError(t, c.Invoke(
-				func(err *someError) {
-					assert.NotNil(t, err, "invoke received nil")
-				}), "invoke must not fail")
+			require.NoError(t, c.Invoke(func(err *someError) {
+				assert.NotNil(t, err, "invoke received nil")
+			}), "invoke must not fail")
 		})
 	}
 }
@@ -510,10 +509,9 @@ func TestCantProvideParameterObjects(t *testing.T) {
 
 		c := New()
 		require.NoError(t, c.Provide(args), "provide failed")
-		require.NoError(t, c.Invoke(
-			func(a *Args) {
-				require.True(t, args == a, "args must match")
-			}), "invoke failed")
+		require.NoError(t, c.Invoke(func(a *Args) {
+			require.True(t, args == a, "args must match")
+		}), "invoke failed")
 	})
 
 	t.Run("constructor", func(t *testing.T) {
@@ -536,10 +534,9 @@ func TestCantProvideParameterObjects(t *testing.T) {
 		require.NoError(t, c.Provide(func() (*Args, error) {
 			return args, nil
 		}), "provide failed")
-		require.NoError(t, c.Invoke(
-			func(a *Args) {
-				require.True(t, args == a, "args must match")
-			}), "invoke failed")
+		require.NoError(t, c.Invoke(func(a *Args) {
+			require.True(t, args == a, "args must match")
+		}), "invoke failed")
 	})
 }
 


### PR DESCRIPTION
This narrows down the definition of parameter objects to only structs
embedding `dig.Param`. Pointers to structs embedding `dig.Param` are
treated like any other struct pointer.

---

This is a PR against #73