### PR TITLE
Add basic string output of the container

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -723,22 +723,3 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Error(t, c.Invoke(func() (int, error) { return 42, errors.New("oh no") }))
 	})
 }
-
-func TestStringer(t *testing.T) {
-	c := New()
-	type A struct{}
-	type B struct{}
-	require.NoError(t, c.Provide(func() (*A, *B) { return &A{}, &B{} }))
-	require.NoError(t, c.Invoke(func(a *A) {}))
-
-	b := &bytes.Buffer{}
-	fmt.Fprintln(b, c)
-	s := b.String()
-
-	assert.Contains(t, s, "*dig.A ->")
-	assert.Contains(t, s, "*dig.B ->")
-	assert.Contains(t, s, "func() (*dig.A, *dig.B)")
-
-	assert.Contains(t, s, "*dig.A =>")
-	assert.Contains(t, s, "*dig.B =>")
-}

--- a/dig_test.go
+++ b/dig_test.go
@@ -723,3 +723,18 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Error(t, c.Invoke(func() (int, error) { return 42, errors.New("oh no") }))
 	})
 }
+
+func TestStringer(t *testing.T) {
+	c := New()
+	type A struct{}
+	type B struct{}
+	require.NoError(t, c.Provide(func() (*A, *B) { return &A{}, &B{} }))
+
+	b := &bytes.Buffer{}
+	fmt.Fprintln(b, c)
+	s := b.String()
+
+	require.Contains(t, s, "*dig.A ->")
+	require.Contains(t, s, "*dig.B ->")
+	require.Contains(t, s, "func() (*dig.A, *dig.B)")
+}

--- a/dig_test.go
+++ b/dig_test.go
@@ -729,12 +729,16 @@ func TestStringer(t *testing.T) {
 	type A struct{}
 	type B struct{}
 	require.NoError(t, c.Provide(func() (*A, *B) { return &A{}, &B{} }))
+	require.NoError(t, c.Invoke(func(a *A) {}))
 
 	b := &bytes.Buffer{}
 	fmt.Fprintln(b, c)
 	s := b.String()
 
-	require.Contains(t, s, "*dig.A ->")
-	require.Contains(t, s, "*dig.B ->")
-	require.Contains(t, s, "func() (*dig.A, *dig.B)")
+	assert.Contains(t, s, "*dig.A ->")
+	assert.Contains(t, s, "*dig.B ->")
+	assert.Contains(t, s, "func() (*dig.A, *dig.B)")
+
+	assert.Contains(t, s, "*dig.A =>")
+	assert.Contains(t, s, "*dig.B =>")
 }

--- a/stringer.go
+++ b/stringer.go
@@ -6,7 +6,7 @@ import (
 )
 
 // String representation of the entire Container
-func (c *Container) String() string {
+func (c Container) String() string {
 	b := &bytes.Buffer{}
 	fmt.Fprintln(b, "nodes: {")
 	for k, v := range c.nodes {

--- a/stringer.go
+++ b/stringer.go
@@ -1,0 +1,23 @@
+package dig
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// String representation of the entire Container
+func (c *Container) String() string {
+	b := &bytes.Buffer{}
+	fmt.Fprintln(b, "{nodes:")
+	for k, v := range c.nodes {
+		fmt.Fprintln(b, k, "->", v)
+	}
+	fmt.Fprintln(b, "}")
+	return b.String()
+}
+
+func (n node) String() string {
+	return fmt.Sprintf(
+		"deps: %v, constructor: %v", n.deps, n.ctype,
+	)
+}

--- a/stringer.go
+++ b/stringer.go
@@ -8,11 +8,18 @@ import (
 // String representation of the entire Container
 func (c *Container) String() string {
 	b := &bytes.Buffer{}
-	fmt.Fprintln(b, "{nodes:")
+	fmt.Fprintln(b, "nodes: {")
 	for k, v := range c.nodes {
-		fmt.Fprintln(b, k, "->", v)
+		fmt.Fprintln(b, "\t", k, "->", v)
 	}
 	fmt.Fprintln(b, "}")
+
+	fmt.Fprintln(b, "cache: {")
+	for k, v := range c.cache {
+		fmt.Fprintln(b, "\t", k, "=>", v)
+	}
+	fmt.Fprintln(b, "}")
+
 	return b.String()
 }
 

--- a/stringer_test.go
+++ b/stringer_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestStringer(t *testing.T) {
+	t.Parallel()
+
 	c := New()
 	type A struct{}
 	type B struct{}

--- a/stringer_test.go
+++ b/stringer_test.go
@@ -1,0 +1,29 @@
+package dig
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringer(t *testing.T) {
+	c := New()
+	type A struct{}
+	type B struct{}
+	require.NoError(t, c.Provide(func() (*A, *B) { return &A{}, &B{} }))
+	require.NoError(t, c.Invoke(func(a *A) {}))
+
+	b := &bytes.Buffer{}
+	fmt.Fprintln(b, c)
+	s := b.String()
+
+	assert.Contains(t, s, "*dig.A ->")
+	assert.Contains(t, s, "*dig.B ->")
+	assert.Contains(t, s, "func() (*dig.A, *dig.B)")
+
+	assert.Contains(t, s, "*dig.A =>")
+	assert.Contains(t, s, "*dig.B =>")
+}


### PR DESCRIPTION
Bringing back what was removed as part of the refactor - an easy way to quickly see what's inside the container.