### PR TITLE
Bring back the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,97 @@
 
 `package dig` provides an opinionated way of resolving object dependencies.
 
+## Status
+
+BETA. Expect potential API changes.
+
+## Conatiner
+
+`package dig` exposes `type Container` as an object capable of resolving a
+directional dependency graph.
+
+To create one:
+```go
+import "go.uber.org/dig"
+
+func main() {
+	c := dig.New()
+	// dig container `c` is ready to use!
+}
+```
+
+Objects in the container are identified by their `reflect.Type` and **everything
+is treated as a singleton**, meaning there can be only one object in the graph
+of a given type.
+
+There are plans to expand the API to support multiple objects of the same type
+in the container, but for time being consider using a factory pattern.
+
+## Provide
+
+The `Provide` method adds an object, or a constructor of an object, to the container.
+
+### Provide a constructor
+
+Constructor can be a function returning any number of objects and, optionally,
+an error.
+
+Each argument to the constructor is registered as a **dependency** in the graph.
+
+```go
+type A struct {}
+type B struct {}
+type C struct {}
+
+c := dig.New()
+constructor := func (*A, *B) *C {
+  // At this point, *A and *B have been resolved through the graph
+  // and can be used to provide an object of type *C
+  return &C{}
+}
+err := c.Provide(constructor)
+// dig container is now able to provide *C to any constructor.
+//
+// However, note that in the current example *A and *B
+// have not been provided, meaning that the resolution of type
+// *C will result in an error, because types *A and *B can not
+// be instantiated.
+```
+
+### Provide an object
+
+As a shortcut for any object without dependencies, register it directly.
+
+```go
+type A struct {
+	Name string
+}
+
+c := dig.New()
+err := c.Provide(&A{Name: "Hello, dig!"})
+```
+
+## Invoke
+
+The `Invoke` API is the flip side of `Provide` and used to retrieve types from the container.
+
+`Invoke` looks through the graph and resolves all the constructor parameters for execution.
+
+In order to successfully use use `Invoke`, the function must meet the following criteria:
+
+1. Input to the `Invoke` must be a function
+1. All arguments to the function must be types in the container
+1. If an error is returned from an invoked function, it will be propagated to the caller
+
+```go
+// c := dig.New()
+// c.Provide config.Provider, zap.Logger, etc
+err := c.Invoke(func(cfg *config.Provider, l *zap.Logger) error {
+	// function body
+	return nil
+})
+```
+
 [doc]: https://godoc.org/go.uber.org/dig
 [doc-img]: https://godoc.org/go.uber.org/dig?status.svg
 [cov]: https://coveralls.io/github/uber-go/dig?branch=master

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ BETA. Expect potential API changes.
 directional dependency graph.
 
 To create one:
+
 ```go
 import "go.uber.org/dig"
 
@@ -26,9 +27,8 @@ func main() {
 }
 ```
 
-Objects in the container are identified by their `reflect.Type` and **everything
-is treated as a singleton**, meaning there can be only one object in the graph
-of a given type.
+**All objects in the container are treated as a singletons**, meaning there can be
+only one object in the graph of a given type.
 
 There are plans to expand the API to support multiple objects of the same type
 in the container, but for time being consider using a factory pattern.
@@ -39,7 +39,7 @@ The `Provide` method adds an object, or a constructor of an object, to the conta
 
 ### Provide a constructor
 
-Constructor can be a function returning any number of objects and, optionally,
+A constructor can be a function returning any number of objects and, optionally,
 an error.
 
 Each argument to the constructor is registered as a **dependency** in the graph.
@@ -117,7 +117,7 @@ func main() {
 		return l.With(zap.String("iconic phrase", cfg.Get("tag").AsString())), nil
 	})
 
-	// Invoke a function that requires both
+	// Invoke a function that requires a zap logger, which in turn requires config
 	c.Invoke(func(l *zap.Logger) {
 		l.Info("You've been invoked")
 		// Logger output:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 BETA. Expect potential API changes.
 
-## Conatiner
+## Container
 
 `package dig` exposes `type Container` as an object capable of resolving a
 directional dependency graph.


### PR DESCRIPTION
I borrowed most of the old readme, slightly edited it, and added an e2e `Invoke` example.