### PR TITLE
Fix detectCyles duplicate dependencies bug

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -435,8 +435,8 @@ func TestEndToEndSuccess(t *testing.T) {
 		c := New()
 
 		require.NoError(t, c.Provide(func() A { return A{} }), "provide failed")
-		require.NoError(t, c.Provide(func(_ A) B { return B{} }), "provide failed")
-		require.NoError(t, c.Provide(func(_ A, _ B) C { return C{} }), "provide failed")
+		require.NoError(t, c.Provide(func(A) B { return B{} }), "provide failed")
+		require.NoError(t, c.Provide(func(A, B) C { return C{} }), "provide failed")
 	})
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -426,6 +426,18 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Nil(t, p.T5, "optional type not in the graph should return nil")
 		}))
 	})
+
+	t.Run("nested dependencies", func(t *testing.T) {
+		type A struct{}
+		type B struct{}
+		type C struct{}
+
+		c := New()
+
+		require.NoError(t, c.Provide(func() A { return A{} }), "provide failed")
+		require.NoError(t, c.Provide(func(dep0 A) B { return B{} }), "provide failed")
+		require.NoError(t, c.Provide(func(dep0 A, dep1 B) C { return C{} }), "provide failed")
+	})
 }
 
 func TestProvideConstructorErrors(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -435,8 +435,8 @@ func TestEndToEndSuccess(t *testing.T) {
 		c := New()
 
 		require.NoError(t, c.Provide(func() A { return A{} }), "provide failed")
-		require.NoError(t, c.Provide(func(dep0 A) B { return B{} }), "provide failed")
-		require.NoError(t, c.Provide(func(dep0 A, dep1 B) C { return C{} }), "provide failed")
+		require.NoError(t, c.Provide(func(_ A) B { return B{} }), "provide failed")
+		require.NoError(t, c.Provide(func(_ A, _ B) C { return C{} }), "provide failed")
 	})
 }
 


### PR DESCRIPTION
This refactors the cycle detection `seen` map to use a linear search over the path. There was previously an error when multiple dependencies depended on the same types, as reflected in the added unit test.