### PR TITLE
Add test covering primitives

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -444,11 +444,13 @@ func TestEndToEndSuccess(t *testing.T) {
 		c := New()
 		require.NoError(t, c.Provide(func() string { return "piper" }), "string provide failed")
 		require.NoError(t, c.Provide(func() int { return 42 }), "int provide failed")
+		require.NoError(t, c.Provide(func() int64 { return 24 }), "int provide failed")
 		require.NoError(t, c.Provide(func() time.Duration {
 			return 10 * time.Second
 		}), "time.Duration provide failed")
-		require.NoError(t, c.Invoke(func(i int, s string, d time.Duration) {
+		require.NoError(t, c.Invoke(func(i64 int64, i int, s string, d time.Duration) {
 			assert.Equal(t, 42, i)
+			assert.Equal(t, int64(24), i64)
 			assert.Equal(t, "piper", s)
 			assert.Equal(t, 10*time.Second, d)
 		}))

--- a/dig_test.go
+++ b/dig_test.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -443,9 +444,13 @@ func TestEndToEndSuccess(t *testing.T) {
 		c := New()
 		require.NoError(t, c.Provide(func() string { return "piper" }), "string provide failed")
 		require.NoError(t, c.Provide(func() int { return 42 }), "int provide failed")
-		require.NoError(t, c.Invoke(func(i int, s string) {
+		require.NoError(t, c.Provide(func() time.Duration {
+			return 10 * time.Second
+		}), "time.Duration provide failed")
+		require.NoError(t, c.Invoke(func(i int, s string, d time.Duration) {
 			assert.Equal(t, 42, i)
 			assert.Equal(t, "piper", s)
+			assert.Equal(t, 10*time.Second, d)
 		}))
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -438,6 +438,16 @@ func TestEndToEndSuccess(t *testing.T) {
 		require.NoError(t, c.Provide(func(A) B { return B{} }), "provide failed")
 		require.NoError(t, c.Provide(func(A, B) C { return C{} }), "provide failed")
 	})
+
+	t.Run("primitives", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() string { return "piper" }), "string provide failed")
+		require.NoError(t, c.Provide(func() int { return 42 }), "int provide failed")
+		require.NoError(t, c.Invoke(func(i int, s string) {
+			assert.Equal(t, 42, i)
+			assert.Equal(t, "piper", s)
+		}))
+	})
 }
 
 func TestProvideConstructorErrors(t *testing.T) {


### PR DESCRIPTION
Out of curiosity I wanted to see if we supported primitives, might as well check it in.

This looks silly right now (since you'd only be able to have one string type in the graph), however in combination with the incoming named instances through `dig.Out` will be quite powerful without the need to typealias constantly