### PR TITLE
optional: Fix support for constructors

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -284,7 +284,7 @@ func newNode(provides reflect.Type, ctor interface{}, ctype reflect.Type) (node,
 	}, nil
 }
 
-// Retrives the dependencies for a dig.In object
+// Retrieves the dependencies for a dig.In object
 func getInDependencies(t reflect.Type) ([]dep, error) {
 	deps := make([]dep, 0, t.NumField())
 	for i := 0; i < t.NumField(); i++ {

--- a/dig_test.go
+++ b/dig_test.go
@@ -427,6 +427,30 @@ func TestEndToEndSuccess(t *testing.T) {
 		}))
 	})
 
+	t.Run("constructor with optional", func(t *testing.T) {
+		type type1 struct{}
+		type type2 struct{}
+
+		type param struct {
+			In
+
+			T1 *type1 `optional:"true"`
+		}
+
+		c := New()
+
+		var gave *type2
+		require.NoError(t, c.Provide(func(p param) *type2 {
+			require.Nil(t, p.T1, "T1 must be nil")
+			gave = &type2{}
+			return gave
+		}), "provide failed")
+
+		require.NoError(t, c.Invoke(func(got *type2) {
+			require.True(t, got == gave, "type2 reference must be the same")
+		}), "invoke failed")
+	})
+
 	t.Run("nested dependencies", func(t *testing.T) {
 		type A struct{}
 		type B struct{}
@@ -707,6 +731,34 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err, "expected invoke error")
 		require.Contains(t, err.Error(), "could not get field T2")
 		require.Contains(t, err.Error(), "dig.type2 isn't in the container")
+	})
+
+	t.Run("unmet constructor dependency", func(t *testing.T) {
+		type type1 struct{}
+		type type2 struct{}
+		type type3 struct{}
+
+		type param struct {
+			In
+
+			T1 *type1
+			T2 *type2 `optional:"true"`
+		}
+
+		c := New()
+
+		require.NoError(t, c.Provide(func(p param) *type3 {
+			panic("function must not be called")
+		}), "provide failed")
+
+		err := c.Invoke(func(*type3) {
+			t.Fatal("function must not be called")
+		})
+		require.Error(t, err, "invoke must fail")
+		require.Contains(t, err.Error(), "missing dependencies for type *dig.type3")
+		require.Contains(t, err.Error(), "container is missing types: [*dig.type1]")
+		// We don't expect type2 to be mentioned in the list because it's
+		// optional
 	})
 
 	t.Run("invalid optional tag", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -777,6 +777,30 @@ func TestInvokeFailures(t *testing.T) {
 		require.Contains(t, err.Error(), `invalid value "no" for "optional" tag on field Buffer`)
 	})
 
+	t.Run("constructor invalid optional tag", func(t *testing.T) {
+		type type1 struct{}
+
+		type nestedArgs struct {
+			In
+
+			Buffer *bytes.Buffer `optional:"no"`
+		}
+
+		type args struct {
+			In
+
+			Args nestedArgs
+		}
+
+		c := New()
+		err := c.Provide(func(a args) *type1 {
+			panic("function must not be called")
+		})
+
+		require.Error(t, err, "expected invoke error")
+		require.Contains(t, err.Error(), `invalid value "no" for "optional" tag on field Buffer`)
+	})
+
 	t.Run("returned error", func(t *testing.T) {
 		c := New()
 		assert.Error(t, c.Invoke(func() error { return errors.New("oh no") }))


### PR DESCRIPTION
The current implementation of optionals has a bug which causes failures
if a constructor for a provided type has `dig.In` struct with optional
parameters.

That is, given,

    type param struct {
        In

        Buffer *bytes.Buffer `optional:"true"`
    }

    c.Provide(func(p param) *Something { ... })

The following will fail, complaining that `*bytes.Buffer` isn't
available in the container.

    c.Invoke(func(*Something) { .. })

This fixes this issue by storing more information about node
dependencies: specifically, whether they are required or optional.

Test Plan: A failing test case was added before the fix was implemented.