### PR TITLE
Invoke: Return errors as-is

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -102,8 +102,10 @@ func (c *Container) Invoke(function interface{}) error {
 	if len(returned) == 0 {
 		return nil
 	}
-	if last := returned[len(returned)-1]; last.Type() == _errType && last.Interface() != nil {
-		return fmt.Errorf("failed to execute %v (type %v): %v", function, ftype, last.Interface())
+	if last := returned[len(returned)-1]; last.Type() == _errType {
+		if err, _ := last.Interface().(error); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -881,11 +881,13 @@ func TestInvokeFailures(t *testing.T) {
 
 	t.Run("returned error", func(t *testing.T) {
 		c := New()
-		assert.Error(t, c.Invoke(func() error { return errors.New("oh no") }))
+		err := c.Invoke(func() error { return errors.New("oh no") })
+		require.Equal(t, errors.New("oh no"), err, "error must match")
 	})
 
 	t.Run("many returns", func(t *testing.T) {
 		c := New()
-		assert.Error(t, c.Invoke(func() (int, error) { return 42, errors.New("oh no") }))
+		err := c.Invoke(func() (int, error) { return 42, errors.New("oh no") })
+		require.Equal(t, errors.New("oh no"), err, "error must match")
 	})
 }


### PR DESCRIPTION
This changes Invoke to return the error returned by the function as-is
rather than wrapping it in Errorf. As a caller of Invoke, I would expect
my function's returned error to be returned back to me. Otherwise, I'm
losing a lot of information if my error object was richer than
`fmt.Errorf`'s string.

Further, the existing message didn't really add a lot of information: it
added the address of the function to the error message.

Depends on #95 so that tests don't fail.