### PR TITLE
[WIP] [3/4] Swap the map key for a custom struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 .PHONY: lint
-lint:
+lint: license
 ifdef SHOULD_LINT
 	@rm -rf lint.log
 	@echo "Checking formatting..."

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 .PHONY: lint
-lint: license
+lint:
 ifdef SHOULD_LINT
 	@rm -rf lint.log
 	@echo "Checking formatting..."

--- a/dig.go
+++ b/dig.go
@@ -330,6 +330,11 @@ func (c *Container) constructorArgs(ctype reflect.Type) ([]reflect.Value, error)
 	return args, nil
 }
 
+// Graph node represents a single return type from a constructor.
+// One constructor function returning multiple types get adeed to the graph
+// as multiple individual nodes. When one type is required to be initialized,
+// all nodes in the graph beloning to the constructor get inserted into the
+// cache.
 type node struct {
 	provides reflect.Type
 	ctor     interface{}

--- a/dig_test.go
+++ b/dig_test.go
@@ -50,7 +50,7 @@ func TestEndToEndSuccess(t *testing.T) {
 		}), "invoke failed")
 	})
 
-	t.Run("nil pointer constructor", func(t *testing.T) {
+	t.Run("nil pointer fails", func(t *testing.T) {
 		// Dig shouldn't forbid this - it's perfectly reasonable to explicitly
 		// provide a typed nil, since that's often a convenient way to supply a
 		// default no-op implementation.

--- a/dig_test.go
+++ b/dig_test.go
@@ -462,6 +462,21 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.NotNil(t, a, "*A should be part of the container through Ret2->Ret1")
 		}))
 	})
+
+	t.Run("optional type and type are the same thing", func(t *testing.T) {
+		c := New()
+		type A struct{}
+		type Param struct {
+			In
+
+			OptionalA *A `optional:"true"`
+		}
+		require.NoError(t, c.Provide(func() *A { return &A{} }))
+		require.NoError(t, c.Invoke(func(p Param) {
+			fmt.Println(c)
+			require.NotNil(t, p.OptionalA, "*A is present in the graph and should not be nil")
+		}))
+	})
 }
 
 func TestProvideConstructorErrors(t *testing.T) {

--- a/key.go
+++ b/key.go
@@ -21,38 +21,22 @@
 package dig
 
 import (
-	"bytes"
-	"fmt"
+	"reflect"
 )
 
-// String representation of the entire Container
-func (c Container) String() string {
-	b := &bytes.Buffer{}
-	fmt.Fprintln(b, "nodes: {")
-	for k, v := range c.nodes {
-		fmt.Fprintln(b, "\t", k, "->", v)
-	}
-	fmt.Fprintln(b, "}")
-
-	fmt.Fprintln(b, "cache: {")
-	for k, v := range c.cache {
-		fmt.Fprintln(b, "\t", k, "=>", v)
-	}
-	fmt.Fprintln(b, "}")
-
-	return b.String()
+// Used to unieuqly identify a dig node.
+type nodeKey struct {
+	t reflect.Type
 }
 
-func (n node) String() string {
-	deps := make([]string, len(n.deps))
-	for i, d := range n.deps {
-		deps[i] = fmt.Sprint(d.Type)
-	}
-	return fmt.Sprintf(
-		"deps: %v, constructor: %v, key: %+v", deps, n.ctype, n.key,
-	)
-}
+// No opts available right now, but named instances are on deck.
+type keyOption func(nodeKey)
 
-func (k nodeKey) String() string {
-	return k.t.String()
+// Given a reflect type (and a collection of options) make a key.
+func key(t reflect.Type, opts ...keyOption) nodeKey {
+	k := nodeKey{t: t}
+	for _, opt := range opts {
+		opt(k)
+	}
+	return k
 }

--- a/key.go
+++ b/key.go
@@ -26,17 +26,23 @@ import (
 
 // Used to unieuqly identify a dig node.
 type nodeKey struct {
-	t reflect.Type
+	t        reflect.Type
+	optional bool
 }
 
-// No opts available right now, but named instances are on deck.
-type keyOption func(nodeKey)
+type keyOption func(*nodeKey)
+
+func optional(opt bool) keyOption {
+	return func(k *nodeKey) {
+		k.optional = opt
+	}
+}
 
 // Given a reflect type (and a collection of options) make a key.
 func key(t reflect.Type, opts ...keyOption) nodeKey {
-	k := nodeKey{t: t}
+	k := nodeKey{t: t, optional: false}
 	for _, opt := range opts {
-		opt(k)
+		opt(&k)
 	}
 	return k
 }

--- a/stringer.go
+++ b/stringer.go
@@ -30,13 +30,13 @@ func (c Container) String() string {
 	b := &bytes.Buffer{}
 	fmt.Fprintln(b, "nodes: {")
 	for k, v := range c.nodes {
-		fmt.Fprintln(b, "\t", k, "->", v)
+		fmt.Fprintln(b, "\t", k.t, "->", v)
 	}
 	fmt.Fprintln(b, "}")
 
 	fmt.Fprintln(b, "cache: {")
 	for k, v := range c.cache {
-		fmt.Fprintln(b, "\t", k, "=>", v)
+		fmt.Fprintln(b, "\t", k.t, "=>", v)
 	}
 	fmt.Fprintln(b, "}")
 
@@ -46,7 +46,7 @@ func (c Container) String() string {
 func (n node) String() string {
 	deps := make([]string, len(n.deps))
 	for i, d := range n.deps {
-		deps[i] = fmt.Sprint(d.Type)
+		deps[i] = fmt.Sprint(d.t)
 	}
 	return fmt.Sprintf(
 		"deps: %v, constructor: %v, key: %+v", deps, n.ctype, n.key,
@@ -54,5 +54,5 @@ func (n node) String() string {
 }
 
 func (k nodeKey) String() string {
-	return k.t.String()
+	return fmt.Sprintf("t: %v, opt: %v", k.t, k.optional)
 }


### PR DESCRIPTION
Third pr in the #80 series. Getting there!

This no longer uses `reflect.Type` to uniquely identify an object in the graph, all the options are considered (right now only the optional true/false, but soon a string to identify the name as well).

At the moment, this has a side-effect: `optional Type1` and `Type1` are considered different nodes and can co-exist. I haven't thought all the way through if this should be fixed, or if it's actually a good thing. Let me know what you think.

This PR also removed the `dep struct`, as node dependencies now know the exact key of their dependencies.

Looks rather invasive, but in most cases it's pretty straight forward swap from `reflect.Type` usage to `nodeKey`