### PR TITLE
Fix dig.Out error handling when multiple instances have the same type

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -195,7 +195,9 @@ func traverseOutTypes(t reflect.Type, f func(t reflect.Type) error) error {
 		}
 
 		// keep recursing to traverse all the embedded objects
-		traverseOutTypes(ft, f)
+		if err := traverseOutTypes(ft, f); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -672,6 +672,30 @@ func TestInvokesUseCachedObjects(t *testing.T) {
 	}
 }
 
+func TestProvideFailures(t *testing.T) {
+	t.Run("out returning multiple instances of the same type", func(t *testing.T) {
+		c := New()
+		type A struct{ idx int }
+		type ret struct {
+			Out
+
+			A1 A // sampe type A provided three times
+			A2 A
+			A3 A
+		}
+
+		err := c.Provide(func() ret {
+			return ret{
+				A1: A{idx: 1},
+				A2: A{idx: 2},
+				A3: A{idx: 3},
+			}
+		})
+		require.Error(t, err, "provide must return error")
+		require.Contains(t, err.Error(), "returns multiple dig.A")
+	})
+}
+
 func TestInvokeFailures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Stumbled upon this while working on named instances.

Added a regression test as well, which fails without this code change.