### PR TITLE
Fold the caching mechanism into node struct

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -34,12 +34,6 @@ func (c Container) String() string {
 	}
 	fmt.Fprintln(b, "}")
 
-	fmt.Fprintln(b, "cache: {")
-	for k, v := range c.cache {
-		fmt.Fprintln(b, "\t", k, "=>", v)
-	}
-	fmt.Fprintln(b, "}")
-
 	return b.String()
 }
 
@@ -48,7 +42,8 @@ func (n node) String() string {
 	for i, d := range n.deps {
 		deps[i] = fmt.Sprint(d.Type)
 	}
-	return fmt.Sprintf(
-		"deps: %v, constructor: %v", deps, n.ctype,
-	)
+	if n.cached {
+		return fmt.Sprintf("deps: %v, constructor: %v, cachedValue: %v", deps, n.ctype, n.value)
+	}
+	return fmt.Sprintf("deps: %v, constructor: %v, cached: %v", deps, n.ctype, n.cached)
 }

--- a/stringer_test.go
+++ b/stringer_test.go
@@ -54,6 +54,6 @@ func TestStringer(t *testing.T) {
 	assert.Contains(t, s, "func(*dig.B) *dig.C")
 
 	// cache
-	assert.Contains(t, s, "*dig.A =>")
-	assert.Contains(t, s, "*dig.B =>")
+	assert.Regexp(t, "dig.B -> .* cachedValue: &{}", s)
+	assert.Regexp(t, "dig.C -> .* cached: false", s)
 }


### PR DESCRIPTION
Inching ever closer to #80.

This removes the double-map nature of dig, and stores the cache values on the node directly. While it might seem like a meaningless diff, it actually paves the way to extend the graph to have multiple objects of the same type, tagged of course.

The nodes map will soon have to be switched to `nodes map[reflect.Type][]node` type, which obviously makes the cache very difficult to deal with. In this world, at least only one data structure has to be operated on at a time, without the need to sync with the cache.