### PR TITLE
Swap out dep for key, and a few other refactors

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -202,8 +202,35 @@ func (c *Container) isAcyclic(n node) error {
 	return detectCycles(n, c.nodes, nil)
 }
 
-// Retrieve a type from the container
-func (c *Container) get(t reflect.Type) (reflect.Value, error) {
+type keyOpt func(*key)
+
+// Specifies if absence of the object in the graph is ok on retrieval.
+func optional(opt bool) keyOpt {
+	return func(k *key) {
+		k.optional = opt
+	}
+}
+
+// Represents an edge in the graph.
+type key struct {
+	t        reflect.Type
+	optional bool
+}
+
+// Custom map get method for the underlying nodes.
+//
+// Behaves in the following ways:
+//     - get without any options will return a value from the graph, or an error
+//     - get for type not in the map with optional=true returns zero value for type.
+//     - get with a dig.In embed will construct a new object, and populate all the
+//       members based on the memebers, including a parse of the struct tags that
+//       drives the aforementioned behaviors.
+func (c *Container) get(t reflect.Type, opts ...keyOpt) (reflect.Value, error) {
+	k := key{t: t}
+	for _, opt := range opts {
+		opt(&k)
+	}
+
 	if isInObject(t) {
 		// We do not want parameter objects to be cached.
 		return c.createInObject(t)
@@ -211,6 +238,9 @@ func (c *Container) get(t reflect.Type) (reflect.Value, error) {
 
 	n, ok := c.nodes[t]
 	if !ok {
+		if k.optional {
+			return reflect.Zero(t), nil
+		}
 		return _noValue, fmt.Errorf("type %v isn't in the container", t)
 	}
 
@@ -237,6 +267,7 @@ func (c *Container) get(t reflect.Type) (reflect.Value, error) {
 	for _, con := range constructed {
 		c.set(con)
 	}
+
 	return c.nodes[t].value, nil
 }
 
@@ -250,27 +281,19 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 			continue // skip private fields
 		}
 
-		var isOptional bool
-		if tag := f.Tag.Get(_optionalTag); tag != "" {
-			var err error
-			isOptional, err = strconv.ParseBool(tag)
-			if err != nil {
-				return dest, fmt.Errorf(
-					"invalid value %q for %q tag on field %v of %v: %v",
-					tag, _optionalTag, f.Name, t, err)
-			}
-		}
-
-		v, err := c.get(f.Type)
+		// check for optional tag
+		isOptional, err := isFieldOptional(t, f)
 		if err != nil {
-			if isOptional {
-				v = reflect.Zero(f.Type)
-			} else {
-				return dest, fmt.Errorf(
-					"could not get field %v (type %v) of %v: %v", f.Name, f.Type, t, err)
-			}
+			return dest, err
 		}
 
+		// get the value from the map
+		v, err := c.get(f.Type, optional(isOptional))
+		if err != nil {
+			return dest, err
+		}
+
+		// set the dig.In fiels to the node value
 		dest.Field(i).Set(v)
 	}
 	return dest, nil
@@ -297,11 +320,11 @@ func (c *Container) set(v reflect.Value) {
 	}
 }
 
-func (c *Container) contains(deps []dep) error {
+func (c *Container) contains(deps []key) error {
 	var missing []reflect.Type
 	for _, d := range deps {
-		if _, ok := c.nodes[d.Type]; !ok && !d.Optional {
-			missing = append(missing, d.Type)
+		if _, ok := c.nodes[d.t]; !ok && !d.optional {
+			missing = append(missing, d.t)
 		}
 	}
 	if len(missing) > 0 {
@@ -334,13 +357,7 @@ type node struct {
 	ctype    reflect.Type  // node's type (also the key in the Graph map)
 	value    reflect.Value // cached value of the node
 	cached   bool          // quick check for if the value is cached
-	deps     []dep
-}
-
-// Represents a node's dependency (edge in the graph).
-type dep struct {
-	Type     reflect.Type
-	Optional bool
+	deps     []key
 }
 
 func newNode(provides reflect.Type, ctor interface{}, ctype reflect.Type) (node, error) {
@@ -354,11 +371,11 @@ func newNode(provides reflect.Type, ctor interface{}, ctype reflect.Type) (node,
 }
 
 // Retrieves the dependencies for a constructor
-func getConstructorDependencies(ctype reflect.Type) ([]dep, error) {
-	var deps []dep
+func getConstructorDependencies(ctype reflect.Type) ([]key, error) {
+	var deps []key
 	for i := 0; i < ctype.NumIn(); i++ {
 		err := traverseInTypes(ctype.In(i), func(t reflect.Type, opt bool) {
-			deps = append(deps, dep{Type: t, Optional: opt})
+			deps = append(deps, key{t: t, optional: opt})
 		})
 		if err != nil {
 			return nil, err
@@ -384,7 +401,7 @@ func detectCycles(n node, graph map[reflect.Type]node, path []reflect.Type) erro
 	}
 	path = append(path, n.provides)
 	for _, dep := range n.deps {
-		depNode, ok := graph[dep.Type]
+		depNode, ok := graph[dep.t]
 		if !ok {
 			continue
 		}

--- a/dig_test.go
+++ b/dig_test.go
@@ -702,7 +702,6 @@ func TestInvokeFailures(t *testing.T) {
 		})
 
 		require.Error(t, err, "expected invoke error")
-		require.Contains(t, err.Error(), "could not get field T2")
 		require.Contains(t, err.Error(), "dig.type2 isn't in the container")
 	})
 

--- a/stringer.go
+++ b/stringer.go
@@ -40,7 +40,7 @@ func (c Container) String() string {
 func (n node) String() string {
 	deps := make([]string, len(n.deps))
 	for i, d := range n.deps {
-		deps[i] = fmt.Sprint(d.Type)
+		deps[i] = fmt.Sprint(d.t)
 	}
 	if n.cached {
 		return fmt.Sprintf("deps: %v, constructor: %v, cachedValue: %v", deps, n.ctype, n.value)


### PR DESCRIPTION
A couple of more small hops towards #80 

Simplify the handling of optional tags by putting that responsibility
onto get.

Start documentation of the get behavior, before it gets expanded even
further to support named types.

PR against #105 , can be rebased after that lands or merged first.