### PR TITLE
Named instances

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -257,6 +257,10 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 	}
 
 	for _, con := range constructed {
+		// Set the resolved object into the cache.
+		// This might look confusing at first like we're ignoring named types,
+		// but `con` in this case will be the dig.Out object, which will
+		// cause a recursion into the .set for each of it's memebers.
 		c.set(key{t: con.Type()}, con)
 	}
 	return c.cache[e.key], nil

--- a/dig.go
+++ b/dig.go
@@ -234,6 +234,9 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 
 	n, ok := c.nodes[e.key]
 	if !ok {
+		if e.optional {
+			return reflect.Zero(e.t), nil
+		}
 		return _noValue, fmt.Errorf("type %v isn't in the container", e.t)
 	}
 
@@ -274,14 +277,10 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 			return dest, err
 		}
 
-		v, err := c.get(edge{key: key{t: f.Type, name: f.Tag.Get(_nameTag)}})
+		v, err := c.get(edge{key: key{t: f.Type, name: f.Tag.Get(_nameTag)}, optional: isOptional})
 		if err != nil {
-			if isOptional {
-				v = reflect.Zero(f.Type)
-			} else {
-				return dest, fmt.Errorf(
-					"could not get field %v (type %v) of %v: %v", f.Name, f.Type, t, err)
-			}
+			return dest, fmt.Errorf(
+				"could not get field %v (type %v) of %v: %v", f.Name, f.Type, t, err)
 		}
 
 		dest.Field(i).Set(v)

--- a/dig.go
+++ b/dig.go
@@ -378,22 +378,22 @@ func getConstructorDependencies(ctype reflect.Type) ([]edge, error) {
 	return deps, nil
 }
 
-func cycleError(cycle []reflect.Type, last reflect.Type) error {
+func cycleError(cycle []key, last key) error {
 	b := &bytes.Buffer{}
-	for _, t := range cycle {
-		fmt.Fprintf(b, "%v ->", t)
+	for _, k := range cycle {
+		fmt.Fprintf(b, "%v ->", k.t)
 	}
-	fmt.Fprintf(b, "%v", last)
+	fmt.Fprintf(b, "%v", last.t)
 	return errors.New(b.String())
 }
 
-func detectCycles(n *node, graph map[key]*node, path []reflect.Type) error {
+func detectCycles(n *node, graph map[key]*node, path []key) error {
 	for _, p := range path {
-		if p == n.t {
-			return cycleError(path, n.t)
+		if p == n.key {
+			return cycleError(path, n.key)
 		}
 	}
-	path = append(path, n.t)
+	path = append(path, n.key)
 	for _, dep := range n.deps {
 		depNode, ok := graph[dep.key]
 		if !ok {

--- a/dig.go
+++ b/dig.go
@@ -302,7 +302,6 @@ func (c *Container) set(k key, v reflect.Value) {
 	// dig.Out objects are not acted upon directly, but rather their memebers are considered
 	for i := 0; i < k.t.NumField(); i++ {
 		f := k.t.Field(i)
-		// TODO: READ THE TAGS!!!
 
 		// recurse into all fields, which may or may not be more dig.Out objects
 		fk := key{t: f.Type, name: f.Tag.Get(_nameTag)}

--- a/dig.go
+++ b/dig.go
@@ -368,8 +368,8 @@ func newNode(k key, ctor interface{}, ctype reflect.Type) (*node, error) {
 func getConstructorDependencies(ctype reflect.Type) ([]edge, error) {
 	var deps []edge
 	for i := 0; i < ctype.NumIn(); i++ {
-		err := traverseInTypes(ctype.In(i), func(t reflect.Type, opt bool) {
-			deps = append(deps, edge{key: key{t: t}, optional: opt})
+		err := traverseInTypes(ctype.In(i), func(e edge) {
+			deps = append(deps, e)
 		})
 		if err != nil {
 			return nil, err
@@ -408,9 +408,9 @@ func detectCycles(n *node, graph map[key]*node, path []key) error {
 
 // Traverse all fields starting with the given type.
 // Types that dig.In get recursed on. Returns the first error encountered.
-func traverseInTypes(t reflect.Type, fn func(ftype reflect.Type, optional bool)) error {
+func traverseInTypes(t reflect.Type, fn func(edge)) error {
 	if !isInObject(t) {
-		fn(t, false)
+		fn(edge{key: key{t: t}})
 		return nil
 	}
 
@@ -432,7 +432,7 @@ func traverseInTypes(t reflect.Type, fn func(ftype reflect.Type, optional bool))
 			return err
 		}
 
-		fn(f.Type, optional)
+		fn(edge{key: key{t: f.Type, name: f.Tag.Get(_nameTag)}, optional: optional})
 	}
 
 	return nil

--- a/dig.go
+++ b/dig.go
@@ -192,7 +192,7 @@ func (c *Container) getReturnKeys(
 
 // DFS traverse over all the types and execute the provided function.
 // Types that embed dig.Out get recursed on. Returns the first error encountered.
-func traverseOutTypes(k key, f func(k key) error) error {
+func traverseOutTypes(k key, f func(key) error) error {
 	if !isOutObject(k.t) {
 		// call the provided function on non-Out type
 		if err := f(k); err != nil {

--- a/dig.go
+++ b/dig.go
@@ -299,7 +299,7 @@ func (c *Container) set(k key, v reflect.Value) {
 		return
 	}
 
-	// dig.Out objects are not acted upon directly, but rather their memebers are considered
+	// dig.Out objects are not acted upon directly, but rather their members are considered
 	for i := 0; i < k.t.NumField(); i++ {
 		f := k.t.Field(i)
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -520,7 +520,6 @@ func TestEndToEndSuccess(t *testing.T) {
 				A2: A{2},
 			}
 		}))
-		fmt.Println(c)
 		require.NoError(t, c.Invoke(func(p param) {
 			assert.Equal(t, 1, p.A1.idx)
 			assert.Equal(t, 2, p.A2.idx)

--- a/dig_test.go
+++ b/dig_test.go
@@ -845,9 +845,18 @@ func TestProvideFailures(t *testing.T) {
 func TestInvokeFailures(t *testing.T) {
 	t.Parallel()
 
+	t.Run("invoke a non-function", func(t *testing.T) {
+		c := New()
+		err := c.Invoke("foo")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't invoke non-function foo")
+	})
+
 	t.Run("untyped nil", func(t *testing.T) {
 		c := New()
-		assert.Error(t, c.Invoke(nil))
+		err := c.Invoke(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't invoke an untyped nil")
 	})
 
 	t.Run("unmet dependency", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -462,6 +462,35 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.NotNil(t, a, "*A should be part of the container through Ret2->Ret1")
 		}))
 	})
+
+	t.Run("named instances", func(t *testing.T) {
+		c := New()
+		type A struct{ idx int }
+
+		// returns three named instances of A
+		type ret struct {
+			Out
+
+			A1 A `name:"first"`
+			A2 A `name:"second"`
+			A3 A `name:"third"`
+		}
+
+		// requires two specific named instances
+		type param struct {
+			In
+
+			A1 A `name:"first"`
+			A3 A `name:"third"`
+		}
+		require.NoError(t, c.Provide(func() ret {
+			return ret{A1: A{1}, A2: A{2}, A3: A{3}}
+		}), "provide for three named instances should succeed")
+		require.NoError(t, c.Invoke(func(p param) {
+			assert.Equal(t, 1, p.A1.idx)
+			assert.Equal(t, 3, p.A3.idx)
+		}), "invoke should succeed, pulling out two named instances")
+	})
 }
 
 func TestProvideConstructorErrors(t *testing.T) {

--- a/stringer.go
+++ b/stringer.go
@@ -59,7 +59,7 @@ func (n *node) String() string {
 
 func (k key) String() string {
 	if k.name != "" {
-		return fmt.Sprintf("%v %q", k.t, k.name)
+		return fmt.Sprintf("%v:%s", k.t, k.name)
 	}
 	return k.t.String()
 }

--- a/stringer.go
+++ b/stringer.go
@@ -46,7 +46,7 @@ func (c *Container) String() string {
 func (n *node) String() string {
 	deps := make([]string, len(n.deps))
 	for i, d := range n.deps {
-		deps[i] = fmt.Sprint(d.t)
+		deps[i] = fmt.Sprintf("%v opt:%v", d.key, d.optional)
 	}
 	return fmt.Sprintf(
 		"deps: %v, ctor: %v", deps, n.ctype,

--- a/stringer.go
+++ b/stringer.go
@@ -46,7 +46,11 @@ func (c *Container) String() string {
 func (n *node) String() string {
 	deps := make([]string, len(n.deps))
 	for i, d := range n.deps {
-		deps[i] = fmt.Sprintf("%v opt:%v", d.key, d.optional)
+		if d.optional {
+			deps[i] = fmt.Sprintf("%v opt: true", d.key)
+			continue
+		}
+		deps[i] = d.key.String()
 	}
 	return fmt.Sprintf(
 		"deps: %v, ctor: %v", deps, n.ctype,

--- a/stringer.go
+++ b/stringer.go
@@ -26,7 +26,7 @@ import (
 )
 
 // String representation of the entire Container
-func (c Container) String() string {
+func (c *Container) String() string {
 	b := &bytes.Buffer{}
 	fmt.Fprintln(b, "nodes: {")
 	for k, v := range c.nodes {
@@ -43,12 +43,19 @@ func (c Container) String() string {
 	return b.String()
 }
 
-func (n node) String() string {
+func (n *node) String() string {
 	deps := make([]string, len(n.deps))
 	for i, d := range n.deps {
-		deps[i] = fmt.Sprint(d.Type)
+		deps[i] = fmt.Sprint(d.t)
 	}
 	return fmt.Sprintf(
-		"deps: %v, constructor: %v", deps, n.ctype,
+		"deps: %v, ctor: %v", deps, n.ctype,
 	)
+}
+
+func (k key) String() string {
+	if k.name != "" {
+		return fmt.Sprintf("%v %q", k.t, k.name)
+	}
+	return k.t.String()
 }

--- a/stringer.go
+++ b/stringer.go
@@ -47,7 +47,9 @@ func (n *node) String() string {
 	deps := make([]string, len(n.deps))
 	for i, d := range n.deps {
 		if d.optional {
-			deps[i] = fmt.Sprintf("%v opt: true", d.key)
+			// ~tally.Scope means optional
+			// ~tally.Scope:foo means named optional
+			deps[i] = fmt.Sprintf("~%v", d.key)
 			continue
 		}
 		deps[i] = d.key.String()


### PR DESCRIPTION
On the third time of asking, here's one atomic PR that solves the rest of what's needed for #80 

Object are now uniquely identified by `reflect.Type:string`, everything else stems from there. Far cleaner than the lasts two attempts to get this in.

Optional edges are prepended with `~` now in the output, i.e. required A, named B and optional C look like this now: `deps: [A, B:foo, ~C]`

Fixes #80