### PR TITLE
Forbid all errors from entering graph

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -97,7 +97,7 @@ func (c *Container) Invoke(function interface{}) error {
 	if len(returned) == 0 {
 		return nil
 	}
-	if last := returned[len(returned)-1]; last.Type() == _errType {
+	if last := returned[len(returned)-1]; isError(last.Type()) {
 		if err, _ := last.Interface().(error); err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ func (c *Container) getReturnTypes(
 		outt := ctype.Out(i)
 
 		err := traverseOutTypes(outt, func(rt reflect.Type) error {
-			if rt == _errType {
+			if isError(rt) {
 				// Don't register errors into the container.
 				return nil
 			}
@@ -234,7 +234,7 @@ func (c *Container) get(t reflect.Type) (reflect.Value, error) {
 
 	// Provide-time validation ensures that all constructors return at least
 	// one value.
-	if err := constructed[len(constructed)-1]; err.Type() == _errType && err.Interface() != nil {
+	if err := constructed[len(constructed)-1]; isError(err.Type()) && err.Interface() != nil {
 		return _noValue, fmt.Errorf("constructor %v for type %v failed: %v", n.ctype, t, err.Interface())
 	}
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -529,22 +529,19 @@ func TestCantProvideUntypedNil(t *testing.T) {
 	assert.Error(t, c.Provide(nil))
 }
 
-func TestCanProvideErrorLikeType(t *testing.T) {
+func TestCantProvideErrorLikeType(t *testing.T) {
 	t.Parallel()
 
 	tests := []interface{}{
 		func() *os.PathError { return &os.PathError{} },
+		func() error { return &os.PathError{} },
 		func() (*os.PathError, error) { return &os.PathError{}, nil },
 	}
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%T", tt), func(t *testing.T) {
 			c := New()
-			require.NoError(t, c.Provide(tt), "provide must not fail")
-
-			require.NoError(t, c.Invoke(func(err *os.PathError) {
-				assert.NotNil(t, err, "invoke received nil")
-			}), "invoke must not fail")
+			assert.Error(t, c.Provide(tt), "providing errors should fail")
 		})
 	}
 }

--- a/types.go
+++ b/types.go
@@ -69,6 +69,10 @@ type digOutObject interface {
 	digOutObject()
 }
 
+func isError(t reflect.Type) bool {
+	return t.Implements(_errType)
+}
+
 func isInObject(t reflect.Type) bool {
 	return t.Implements(_inInterfaceType) && t.Kind() == reflect.Struct
 }


### PR DESCRIPTION
This PR amends our no-errors logic to exclude all types that implement
`error` from being provided into the graph (currently, we only forbid
functions that explicitly return `error`, but we allow things like `*os.PathError`).

To me, this makes the user-visible behavior simpler to explain: nothing
that implements `error` can be provided.