### PR TITLE
Manual sentinel value detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 go:
   - 1.7
   - 1.8
+  - tip
 go_import_path: go.uber.org/dig
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.5 (unreleased)
 
+- Structs compatible with `dig.In` and `dig.Out` may now be generated using
+  `reflect.StructOf`.
+
 ## v0.4 (12 Jun 2017)
 
 - **[Breaking]** Remove `Must*` funcs to greatly reduce API surface area.

--- a/dig_test.go
+++ b/dig_test.go
@@ -676,7 +676,7 @@ func TestEndToEndSuccess(t *testing.T) {
 		})
 
 		fn := reflect.MakeFunc(
-			reflect.FuncOf(nil /* params */, []reflect.Type{outType}, false /* variadict */),
+			reflect.FuncOf(nil /* params */, []reflect.Type{outType}, false /* variadic */),
 			func([]reflect.Value) []reflect.Value {
 				result := reflect.New(outType).Elem()
 				result.Field(1).Set(reflect.ValueOf(&A{Value: 1}))

--- a/utils_for_go19_test.go
+++ b/utils_for_go19_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.9
+
+package dig
+
+import "reflect"
+
+func anonymousField(t reflect.Type) reflect.StructField {
+	return reflect.StructField{
+		Name:      t.Name(),
+		Anonymous: true,
+		Type:      t,
+	}
+}

--- a/utils_for_go19_test.go
+++ b/utils_for_go19_test.go
@@ -25,9 +25,5 @@ package dig
 import "reflect"
 
 func anonymousField(t reflect.Type) reflect.StructField {
-	return reflect.StructField{
-		Name:      t.Name(),
-		Anonymous: true,
-		Type:      t,
-	}
+	return reflect.StructField{Name: t.Name(), Anonymous: true, Type: t}
 }

--- a/utils_for_pre_go19_test.go
+++ b/utils_for_pre_go19_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build !go1.9
+
+package dig
+
+import "reflect"
+
+func anonymousField(t reflect.Type) reflect.StructField {
+	return reflect.StructField{Anonymous: true, Type: t}
+}


### PR DESCRIPTION
This changes our detection of `dig.In` and `dig.Out` structs from
relying on Go's automatic wrapper method generation to a manual check
for that embedded value. We do this by simply performing a breadth first
search of embedded fields of a struct.

Note about performance: There usually won't be a lot of embedding in
constructor struct types so the function should return very quickly. If
performance ever becomes an issue, we can memoize types that are known
to embed `dig.In` or `dig.Out` in a global cache similar to how
`encoding/json` caches reflection information for types.

By not relying on wrapper method generation, we are able to support
struct types generated with `reflect.StructOf`, as a documented
limitation of these structs is,

> StructOf currently does not generate wrapper methods for embedded
> fields. This limitation may be lifted in a future version.

This opens up more complex use cases where reflection is required to
generate the `Invoke`d or `Provide`d function.

---

Also note that I added tip to .travis.yml so that we can verify this
behavior with Go 1.9 and newer.