### PR TITLE
Allow optional dependencies to have missing deps

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -284,9 +284,10 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 
 		e := edge{key: key{t: f.Type, name: f.Tag.Get(_nameTag)}, optional: isOptional}
 		v, err := c.get(e)
-		if err != nil {
-			return dest, fmt.Errorf(
-				"could not get field %v (edge %v) of %v: %v", f.Name, e, t, err)
+		if isOptional && err != nil {
+			v = reflect.Zero(f.Type)
+		} else if err != nil {
+			return dest, fmt.Errorf("could not get field %v (edge %v) of %v: %v", f.Name, e, t, err)
 		}
 
 		dest.Field(i).Set(v)

--- a/dig_test.go
+++ b/dig_test.go
@@ -1093,7 +1093,7 @@ func TestInvokeFailures(t *testing.T) {
 		// Container has a constructor for *dep, but that constructor has unmet
 		// dependencies.
 		err := c.Provide(func(missing) *dep {
-			panic("function must not be called")
+			panic("constructor for *dep should not be called")
 		})
 		require.NoError(t, err, "unexpected provide error")
 
@@ -1106,6 +1106,37 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		assert.NoError(t, err, "unexpected invoke error")
 		assert.Equal(t, 1, count, "expected invoke function to be called")
+	})
+
+	t.Run("optional dep with failed transitive dep", func(t *testing.T) {
+		type failed struct{}
+		type dep struct{}
+
+		type params struct {
+			In
+
+			Dep *dep `optional:"true"`
+		}
+
+		c := New()
+
+		err := c.Provide(func() (*failed, error) {
+			return nil, errors.New("failed")
+		})
+		require.NoError(t, err, "unexpected provide error")
+
+		err = c.Provide(func(*failed) *dep {
+			panic("constructor for *dep should not be called")
+		})
+		require.NoError(t, err, "unexpected provide error")
+
+		// Should still be able to invoke a function that takes params, since *dep
+		// is optional.
+		err = c.Invoke(func(p params) {
+			panic("shouldn't execute invoked function")
+		})
+		require.Error(t, err, "expected invoke error")
+		assert.Contains(t, err.Error(), "couldn't get arguments for constructor", "unexpected error text")
 	})
 
 	t.Run("returned error", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1074,8 +1074,38 @@ func TestInvokeFailures(t *testing.T) {
 			panic("function must not be called")
 		})
 
-		require.Error(t, err, "expected invoke error")
+		require.Error(t, err, "expected provide error")
 		require.Contains(t, err.Error(), `invalid value "no" for "optional" tag on field Buffer`)
+	})
+
+	t.Run("optional dep with unmet transitive dep", func(t *testing.T) {
+		type missing struct{}
+		type dep struct{}
+
+		type params struct {
+			In
+
+			Dep *dep `optional:"true"`
+		}
+
+		c := New()
+
+		// Container has a constructor for *dep, but that constructor has unmet
+		// dependencies.
+		err := c.Provide(func(missing) *dep {
+			panic("function must not be called")
+		})
+		require.NoError(t, err, "unexpected provide error")
+
+		// Should still be able to invoke a function that takes params, since *dep
+		// is optional.
+		var count int
+		err = c.Invoke(func(p params) {
+			count++
+			assert.Nil(t, p.Dep, "expected optional dependency to be unmet")
+		})
+		assert.NoError(t, err, "unexpected invoke error")
+		assert.Equal(t, 1, count, "expected invoke function to be called")
 	})
 
 	t.Run("returned error", func(t *testing.T) {


### PR DESCRIPTION
If an Invoke takes an optional dependency on type `A`, but `A`'s
provided constructor has unmet dependencies, we should provide the zero
value. This makes optional params work as most users would expect.

Fixes #111.