### PR TITLE
Add variadic options parameter to public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v1.0.0-rc2 (unreleased)
 
-- No changes yet.
+- So that we can introduce new functionality after a 1.0 release, add a
+  variadic options parameter to all public APIs.
 
 ## v1.0.0-rc1 (21 Jun 2017)
 

--- a/dig.go
+++ b/dig.go
@@ -42,16 +42,20 @@ type key struct {
 // Option configures a Container. It's included for future functionality;
 // currently, there are no concrete implementations.
 type Option interface {
-	apply(*Container)
+	unimplemented()
 }
 
 // A ProvideOption modifies the default behavior of Provide. It's included for
 // future functionality; currently, there are no concrete implementations.
-type ProvideOption interface{}
+type ProvideOption interface {
+	unimplemented()
+}
 
 // An InvokeOption modifies the default behavior of Invoke. It's included for
 // future functionality; currently, there are no concrete implementations.
-type InvokeOption interface{}
+type InvokeOption interface {
+	unimplemented()
+}
 
 // A Container is a directed, acyclic graph of dependencies. Dependencies are
 // constructed on-demand and returned from a cache thereafter, so they're

--- a/dig.go
+++ b/dig.go
@@ -39,6 +39,20 @@ type key struct {
 	name string
 }
 
+// Option configures a Container. It's included for future functionality;
+// currently, there are no concrete implementations.
+type Option interface {
+	apply(*Container)
+}
+
+// A ProvideOption modifies the default behavior of Provide. It's included for
+// future functionality; currently, there are no concrete implementations.
+type ProvideOption interface{}
+
+// An InvokeOption modifies the default behavior of Invoke. It's included for
+// future functionality; currently, there are no concrete implementations.
+type InvokeOption interface{}
+
 // A Container is a directed, acyclic graph of dependencies. Dependencies are
 // constructed on-demand and returned from a cache thereafter, so they're
 // effectively singletons.
@@ -56,7 +70,7 @@ type Container struct {
 }
 
 // New constructs a ready-to-use Container.
-func New() *Container {
+func New(opts ...Option) *Container {
 	return &Container{
 		nodes: make(map[key]*node),
 		cache: make(map[key]reflect.Value),
@@ -75,7 +89,7 @@ func New() *Container {
 //
 // All non-functions (including structs, pointers, Go's built-in collections,
 // and primitive types like ints) are inserted into the Container as-is.
-func (c *Container) Provide(constructor interface{}) error {
+func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) error {
 	ctype := reflect.TypeOf(constructor)
 	if ctype == nil {
 		return errors.New("can't provide an untyped nil")
@@ -95,7 +109,7 @@ func (c *Container) Provide(constructor interface{}) error {
 //
 // Passing anything other than a function to Invoke returns an error
 // immediately.
-func (c *Container) Invoke(function interface{}) error {
+func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 	ftype := reflect.TypeOf(function)
 	if ftype == nil {
 		return errors.New("can't invoke an untyped nil")


### PR DESCRIPTION
We're fairly confident that the core APIs meet our current needs, but we
should leave space for future expansion. To avoid breaking changes,
let's introduce functional options even though we don't currently have
any implementations.

Fixes #117.