### PR TITLE
Support constructors with variadic arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - So that we can introduce new functionality after a 1.0 release, add a
   variadic options parameter to all public APIs.
+- Added support for functions with variadic arguments. These functions declare
+  a dependency on a slice of values of the variadic type.
 
 ## v1.0.0-rc1 (21 Jun 2017)
 


### PR DESCRIPTION
This adds support for functions with a variadic number of arguments to
be Provided and Invoked. We will declare a dependency on a slice of the
variadic type when a variadic function is encountered.

In a follow up PR, we will make this dependency optional rather than required.

See: #120