### PR TITLE
Call variadic constructors without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - So that we can introduce new functionality after a 1.0 release, add a
   variadic options parameter to all public APIs.
+- Added support for functions with variadic arguments. These functions declare
+  a dependency on a slice of values of the variadic type.
 
 ## v1.0.0-rc1 (21 Jun 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - So that we can introduce new functionality after a 1.0 release, add a
   variadic options parameter to all public APIs.
-- Added support for functions with variadic arguments. These functions declare
-  a dependency on a slice of values of the variadic type.
+- Added support for functions with variadic arguments. These functions will be
+  called without supplying their variadic arguments.
 
 ## v1.0.0-rc1 (21 Jun 2017)
 


### PR DESCRIPTION
Dig constructors may now be variadic functions. These functions will be
called with their dependencies as usual and no arguments will be passed
for the variadic arguments.

So a constructor `New(*Foo, *Bar, ...Option) *Baz` will be treated as
`New(*Foo, *Bar) *Baz`.

See #120 for more discussion.