### PR TITLE
Set a 98% coverage target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 coverage:
-  range: 50..90
+  range: 70..98
   round: down
   precision: 2
 
@@ -7,7 +7,7 @@ coverage:
     project:                   # measuring the overall project coverage
       default:                 # context, you can create multiple ones with custom titles
         enabled: yes           # must be yes|true to enable this status
-        target: 90             # specify the target coverage for each commit status
+        target: 98             # specify the target coverage for each commit status
                                #   option: "auto" (must increase from parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
         if_not_found: success  # if parent is not found report status as success, error, or failure


### PR DESCRIPTION
Given that dig has to be rock solid, set a high target

At the moment it's 99+, so only a few lines here and there will ever be
allowed uncovered. We can adjust from here on as we see fit, but 90% for
this kind of a library is very low