### PR TITLE
Export isInObject and isOutObject as IsIn and IsOut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   variadic options parameter to all public APIs.
 - Added support for functions with variadic arguments. These functions will be
   called without supplying their variadic arguments.
-- Export `IsIn` and `IsOut` package level functions.
+- Exported `IsIn` and `IsOut` functions to check if types are `dig.In` or
+  `dig.Out` compatible.
 
 ## v1.0.0-rc1 (21 Jun 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   variadic options parameter to all public APIs.
 - Added support for functions with variadic arguments. These functions will be
   called without supplying their variadic arguments.
+- Export `IsIn` and `IsOut` package level functions.
 
 ## v1.0.0-rc1 (21 Jun 2017)
 

--- a/dig.go
+++ b/dig.go
@@ -183,7 +183,7 @@ func (c *Container) getReturnKeys(
 			}
 
 			// Tons of error checking
-			if isInObject(k.t) {
+			if IsIn(k.t) {
 				return errors.New("can't provide parameter objects")
 			}
 			if _, ok := returnTypes[k]; ok {
@@ -210,7 +210,7 @@ func (c *Container) getReturnKeys(
 // DFS traverse over all the types and execute the provided function.
 // Types that embed dig.Out get recursed on. Returns the first error encountered.
 func traverseOutTypes(k key, f func(key) error) error {
-	if !isOutObject(k.t) {
+	if !IsOut(k.t) {
 		// call the provided function on non-Out type
 		if err := f(k); err != nil {
 			return err
@@ -244,7 +244,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		return v, nil
 	}
 
-	if isInObject(e.t) {
+	if IsIn(e.t) {
 		// We do not want parameter objects to be cached.
 		return c.createInObject(e.t)
 	}
@@ -314,7 +314,7 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 
 // Set the value in the cache after a node resolution
 func (c *Container) set(k key, v reflect.Value) {
-	if !isOutObject(k.t) {
+	if !IsOut(k.t) {
 		// do not cache error types
 		if k.t != _errType {
 			c.cache[k] = v
@@ -453,7 +453,7 @@ func detectCycles(n *node, graph map[key]*node, path []key) error {
 // Traverse all fields starting with the given type.
 // Types that dig.In get recursed on. Returns the first error encountered.
 func traverseInTypes(t reflect.Type, fn func(edge)) error {
-	if !isInObject(t) {
+	if !IsIn(t) {
 		fn(edge{key: key{t: t}})
 		return nil
 	}
@@ -464,7 +464,7 @@ func traverseInTypes(t reflect.Type, fn func(edge)) error {
 			continue // skip private fields
 		}
 
-		if isInObject(f.Type) {
+		if IsIn(f.Type) {
 			if err := traverseInTypes(f.Type, fn); err != nil {
 				return err
 			}

--- a/types.go
+++ b/types.go
@@ -67,13 +67,13 @@ func isError(t reflect.Type) bool {
 }
 
 // IsIn returns true if passed in type embeds dig.In either directly
-// or through another struct field.
+// or through another embedded field.
 func IsIn(t reflect.Type) bool {
 	return embedsType(t, _inType)
 }
 
 // IsOut returns true if passed in type embeds dig.Out either directly
-// or through another struct field.
+// or through another embedded field.
 func IsOut(t reflect.Type) bool {
 	return embedsType(t, _outType)
 }

--- a/types.go
+++ b/types.go
@@ -66,11 +66,15 @@ func isError(t reflect.Type) bool {
 	return t.Implements(_errType)
 }
 
-func isInObject(t reflect.Type) bool {
+// IsIn returns true if passed in type embeds dig.In either directly
+// or through another struct field.
+func IsIn(t reflect.Type) bool {
 	return embedsType(t, _inType)
 }
 
-func isOutObject(t reflect.Type) bool {
+// IsOut returns true if passed in type embeds dig.Out either directly
+// or through another struct field.
+func IsOut(t reflect.Type) bool {
 	return embedsType(t, _outType)
 }
 


### PR DESCRIPTION
This allows other libraries to authoritatively check if a type is
dig.In/Out without duplicating the logic (and potentially having it
drift apart in the future releases).

https://github.com/uber-go/fx/issues/540