### PR TITLE
Test named and unnamed instances of the same type.

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -493,6 +493,31 @@ func TestEndToEndSuccess(t *testing.T) {
 		}), "invoke should succeed, pulling out two named instances")
 	})
 
+	t.Run("named and unnamed instances coexist", func(t *testing.T) {
+		c := New()
+		type A struct{ idx int }
+
+		type out struct {
+			Out
+
+			A `name:"foo"`
+		}
+
+		require.NoError(t, c.Provide(func() out { return out{A: A{1}} }))
+		require.NoError(t, c.Provide(func() A { return A{2} }))
+
+		type in struct {
+			In
+
+			A1 A `name:"foo"`
+			A2 A
+		}
+		require.NoError(t, c.Invoke(func(i in) {
+			assert.Equal(t, 1, i.A1.idx)
+			assert.Equal(t, 2, i.A2.idx)
+		}))
+	})
+
 	t.Run("named instances recurse", func(t *testing.T) {
 		c := New()
 		type A struct{ idx int }


### PR DESCRIPTION
A question came up if named and unnamed types can exist together in the
same graph, but there wasn't a test that really covered the behaviour.
This will make sure this is not something accidentally broken going
forward.