### PR TITLE
Change exported IsIn/IsOut to use interface{}

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -183,7 +183,7 @@ func (c *Container) getReturnKeys(
 			}
 
 			// Tons of error checking
-			if isInType(k.t) {
+			if IsIn(k.t) {
 				return errors.New("can't provide parameter objects")
 			}
 			if _, ok := returnTypes[k]; ok {
@@ -210,7 +210,7 @@ func (c *Container) getReturnKeys(
 // DFS traverse over all the types and execute the provided function.
 // Types that embed dig.Out get recursed on. Returns the first error encountered.
 func traverseOutTypes(k key, f func(key) error) error {
-	if !isOutType(k.t) {
+	if !IsOut(k.t) {
 		// call the provided function on non-Out type
 		if err := f(k); err != nil {
 			return err
@@ -244,7 +244,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		return v, nil
 	}
 
-	if isInType(e.t) {
+	if IsIn(e.t) {
 		// We do not want parameter objects to be cached.
 		return c.createInObject(e.t)
 	}
@@ -314,7 +314,7 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 
 // Set the value in the cache after a node resolution
 func (c *Container) set(k key, v reflect.Value) {
-	if !isOutType(k.t) {
+	if !IsOut(k.t) {
 		// do not cache error types
 		if k.t != _errType {
 			c.cache[k] = v
@@ -453,7 +453,7 @@ func detectCycles(n *node, graph map[key]*node, path []key) error {
 // Traverse all fields starting with the given type.
 // Types that dig.In get recursed on. Returns the first error encountered.
 func traverseInTypes(t reflect.Type, fn func(edge)) error {
-	if !isInType(t) {
+	if !IsIn(t) {
 		fn(edge{key: key{t: t}})
 		return nil
 	}
@@ -464,7 +464,7 @@ func traverseInTypes(t reflect.Type, fn func(edge)) error {
 			continue // skip private fields
 		}
 
-		if isInType(f.Type) {
+		if IsIn(f.Type) {
 			if err := traverseInTypes(f.Type, fn); err != nil {
 				return err
 			}

--- a/dig.go
+++ b/dig.go
@@ -183,7 +183,7 @@ func (c *Container) getReturnKeys(
 			}
 
 			// Tons of error checking
-			if IsIn(k.t) {
+			if isInType(k.t) {
 				return errors.New("can't provide parameter objects")
 			}
 			if _, ok := returnTypes[k]; ok {
@@ -210,7 +210,7 @@ func (c *Container) getReturnKeys(
 // DFS traverse over all the types and execute the provided function.
 // Types that embed dig.Out get recursed on. Returns the first error encountered.
 func traverseOutTypes(k key, f func(key) error) error {
-	if !IsOut(k.t) {
+	if !isOutType(k.t) {
 		// call the provided function on non-Out type
 		if err := f(k); err != nil {
 			return err
@@ -244,7 +244,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		return v, nil
 	}
 
-	if IsIn(e.t) {
+	if isInType(e.t) {
 		// We do not want parameter objects to be cached.
 		return c.createInObject(e.t)
 	}
@@ -314,7 +314,7 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 
 // Set the value in the cache after a node resolution
 func (c *Container) set(k key, v reflect.Value) {
-	if !IsOut(k.t) {
+	if !isOutType(k.t) {
 		// do not cache error types
 		if k.t != _errType {
 			c.cache[k] = v
@@ -453,7 +453,7 @@ func detectCycles(n *node, graph map[key]*node, path []key) error {
 // Traverse all fields starting with the given type.
 // Types that dig.In get recursed on. Returns the first error encountered.
 func traverseInTypes(t reflect.Type, fn func(edge)) error {
-	if !IsIn(t) {
+	if !isInType(t) {
 		fn(edge{key: key{t: t}})
 		return nil
 	}
@@ -464,7 +464,7 @@ func traverseInTypes(t reflect.Type, fn func(edge)) error {
 			continue // skip private fields
 		}
 
-		if IsIn(f.Type) {
+		if isInType(f.Type) {
 			if err := traverseInTypes(f.Type, fn); err != nil {
 				return err
 			}

--- a/dig_test.go
+++ b/dig_test.go
@@ -956,15 +956,22 @@ func TestTypeCheckingEquality(t *testing.T) {
 		A
 	}
 	type in struct {
+		In
 		A
 	}
 	type out struct {
 		B
 	}
-	i := in{}
-	o := out{}
-	require.Equal(t, IsIn(i), isInType(reflect.TypeOf(i)))
-	require.Equal(t, IsOut(o), isOutType(reflect.TypeOf(o)))
+	tt := []interface{}{
+		in{},
+		out{},
+		A{},
+		B{},
+	}
+	for _, s := range tt {
+		require.Equal(t, IsIn(s), isInType(reflect.TypeOf(s)))
+		require.Equal(t, IsOut(s), isOutType(reflect.TypeOf(s)))
+	}
 }
 
 func TestInvokesUseCachedObjects(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -962,15 +962,19 @@ func TestTypeCheckingEquality(t *testing.T) {
 	type out struct {
 		B
 	}
-	tt := []interface{}{
-		in{},
-		out{},
-		A{},
-		B{},
+	tests := []struct {
+		item  interface{}
+		isIn  bool
+		isOut bool
+	}{
+		{in{}, true, false},
+		{out{}, false, true},
+		{A{}, false, false},
+		{B{}, false, true},
 	}
-	for _, s := range tt {
-		require.Equal(t, IsIn(s), isInType(reflect.TypeOf(s)))
-		require.Equal(t, IsOut(s), isOutType(reflect.TypeOf(s)))
+	for _, tt := range tests {
+		require.Equal(t, tt.isIn, IsIn(tt.item))
+		require.Equal(t, tt.isOut, IsOut(tt.item))
 	}
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -949,6 +949,24 @@ func TestProvideFuncsWithoutReturnsFails(t *testing.T) {
 	assert.Error(t, c.Provide(func(*bytes.Buffer) {}))
 }
 
+func TestTypeCheckingEquality(t *testing.T) {
+	type A struct{}
+	type B struct {
+		Out
+		A
+	}
+	type in struct {
+		A
+	}
+	type out struct {
+		B
+	}
+	i := in{}
+	o := out{}
+	require.Equal(t, IsIn(i), isInType(reflect.TypeOf(i)))
+	require.Equal(t, IsOut(o), isOutType(reflect.TypeOf(o)))
+}
+
 func TestInvokesUseCachedObjects(t *testing.T) {
 	t.Parallel()
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -971,6 +971,7 @@ func TestTypeCheckingEquality(t *testing.T) {
 		{out{}, false, true},
 		{A{}, false, false},
 		{B{}, false, true},
+		{nil, false, false},
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.isIn, IsIn(tt.item))

--- a/types.go
+++ b/types.go
@@ -68,12 +68,16 @@ func isError(t reflect.Type) bool {
 
 // IsIn returns true if passed in type embeds dig.In either directly
 // or through another embedded field.
+//
+// Can on structs directly and on reflect.Types of them.
 func IsIn(o interface{}) bool {
 	return embedsType(o, _inType)
 }
 
 // IsOut returns true if passed in type embeds dig.Out either directly
 // or through another embedded field.
+//
+// Can on structs directly and on reflect.Types of them.
 func IsOut(o interface{}) bool {
 	return embedsType(o, _outType)
 }

--- a/types.go
+++ b/types.go
@@ -69,25 +69,31 @@ func isError(t reflect.Type) bool {
 // IsIn returns true if passed in type embeds dig.In either directly
 // or through another embedded field.
 func IsIn(o interface{}) bool {
-	return embedsType(reflect.TypeOf(o), _inType)
-}
-
-func isInType(t reflect.Type) bool {
-	return embedsType(t, _inType)
+	return embedsType(o, _inType)
 }
 
 // IsOut returns true if passed in type embeds dig.Out either directly
 // or through another embedded field.
 func IsOut(o interface{}) bool {
-	return embedsType(reflect.TypeOf(o), _outType)
-}
-
-func isOutType(t reflect.Type) bool {
-	return embedsType(t, _outType)
+	return embedsType(o, _outType)
 }
 
 // Returns true if t embeds e or if any of the types embedded by t embed e.
-func embedsType(t reflect.Type, e reflect.Type) bool {
+func embedsType(i interface{}, e reflect.Type) bool {
+	if i == nil {
+		return false
+	}
+
+	var t reflect.Type
+
+	// maybe it's already reflect.Type
+	if mt, ok := i.(reflect.Type); ok {
+		t = mt
+	} else {
+		// if not just take the type
+		t = reflect.TypeOf(i)
+	}
+
 	// We are going to do a breadth-first search of all embedded fields.
 	types := list.New()
 	types.PushBack(t)

--- a/types.go
+++ b/types.go
@@ -69,7 +69,7 @@ func isError(t reflect.Type) bool {
 // IsIn returns true if passed in type embeds dig.In either directly
 // or through another embedded field.
 //
-// Can on structs directly and on reflect.Types of them.
+// Parameter can be a struct directly, or reflect.Type of it.
 func IsIn(o interface{}) bool {
 	return embedsType(o, _inType)
 }
@@ -77,7 +77,7 @@ func IsIn(o interface{}) bool {
 // IsOut returns true if passed in type embeds dig.Out either directly
 // or through another embedded field.
 //
-// Can on structs directly and on reflect.Types of them.
+// Parameter can be a struct directly, or reflect.Type of it.
 func IsOut(o interface{}) bool {
 	return embedsType(o, _outType)
 }

--- a/types.go
+++ b/types.go
@@ -68,13 +68,21 @@ func isError(t reflect.Type) bool {
 
 // IsIn returns true if passed in type embeds dig.In either directly
 // or through another embedded field.
-func IsIn(t reflect.Type) bool {
+func IsIn(o interface{}) bool {
+	return embedsType(reflect.TypeOf(o), _inType)
+}
+
+func isInType(t reflect.Type) bool {
 	return embedsType(t, _inType)
 }
 
 // IsOut returns true if passed in type embeds dig.Out either directly
 // or through another embedded field.
-func IsOut(t reflect.Type) bool {
+func IsOut(o interface{}) bool {
+	return embedsType(reflect.TypeOf(o), _outType)
+}
+
+func isOutType(t reflect.Type) bool {
 	return embedsType(t, _outType)
 }
 

--- a/types.go
+++ b/types.go
@@ -88,13 +88,10 @@ func embedsType(i interface{}, e reflect.Type) bool {
 		return false
 	}
 
-	var t reflect.Type
-
-	// maybe it's already reflect.Type
-	if mt, ok := i.(reflect.Type); ok {
-		t = mt
-	} else {
-		// if not just take the type
+	// maybe it's already a reflect.Type
+	t, ok := i.(reflect.Type)
+	if !ok {
+		// take the type if it's not
 		t = reflect.TypeOf(i)
 	}
 


### PR DESCRIPTION
This makes external experience a lot better to check when something is
and isn't an In/Out type.

Use the previous iteration of the function under the hood.

Changelog not needed, since this hasn't been released.