### PR TITLE
Basic tests for Go 1.9 aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: go
 sudo: false
-go:
-  - 1.7
-  - 1.8
-  - tip
 go_import_path: go.uber.org/dig
+
+matrix:
+  include:
+    - go: 1.7
+    - go: 1.8
+    - go: tip
+      env: LINT=1
+
 cache:
   directories:
     - vendor
 install:
   - make dependencies
 script:
-  - make lint
+  - test "$LINT" -eq 1 && make lint
   - make ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ cache:
 install:
   - make dependencies
 script:
-  - test "$LINT" -eq 1 && make lint
+  - test "$LINT" -eq 1 && make lint || echo "Skipping lint"
   - make ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
     - go: 1.7
     - go: 1.8
+    # TODO: Switch to Go 1.9 when released
     - go: tip
       env: LINT=1
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,7 @@
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor | grep -v examples)
 PKG_FILES ?= *.go
-
-# The linting tools evolve with each Go version, so run them only on the latest
-# stable release.
 GO_VERSION := $(shell go version | cut -d " " -f 3)
-GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 8
-ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
-SHOULD_LINT := true
-endif
 
 .PHONY: all
 all: lint test
@@ -32,7 +24,6 @@ endif
 
 .PHONY: lint
 lint:
-ifdef SHOULD_LINT
 	@rm -rf lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PKG_FILES) 2>&1 | tee lint.log
@@ -48,9 +39,6 @@ ifdef SHOULD_LINT
 	@DRY_RUN=1 ./check_license.sh | tee -a lint.log
 	@$(MAKE) gendoc
 	@[ ! -s lint.log ]
-else
-	@echo "Skipping linters on" $(GO_VERSION)
-endif
 
 .PHONY: test
 test:

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -48,6 +48,20 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 		}), "invoke failed")
 	})
 
+	t.Run("duplicate provide", func(t *testing.T) {
+		type A struct{}
+		type B = A
+
+		c := New()
+		require.NoError(t, c.Provide(func() A { 
+			return A{}
+		}), "A should not fail to provide")
+
+		require.Error(t, c.Provide(func() B {
+			return B{}
+		}), "B should fail to provide")
+	})
+
 	t.Run("named instances", func(t *testing.T) {
 		c := New()
 		type A1 struct{ s string }

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -26,8 +26,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEndToEndSuccessWithAliases(t *testing.T) {
@@ -50,7 +50,7 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 
 	t.Run("named instances", func(t *testing.T) {
 		c := New()
-		type A1 struct{s string}
+		type A1 struct{ s string }
 		type A2 = A1
 		type A3 = A2
 
@@ -98,4 +98,3 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 	})
 
 }
-

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -53,7 +53,7 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 		type B = A
 
 		c := New()
-		require.NoError(t, c.Provide(func() A { 
+		require.NoError(t, c.Provide(func() A {
 			return A{}
 		}), "A should not fail to provide")
 

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.9
+
+package dig
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndToEndSuccessWithAliases(t *testing.T) {
+	t.Run("pointer constructor", func(t *testing.T) {
+		type Buffer = *bytes.Buffer
+
+		c := New()
+
+		var b Buffer
+		require.NoError(t, c.Provide(func() *bytes.Buffer {
+			b = &bytes.Buffer{}
+			return b
+		}), "provide failed")
+
+		require.NoError(t, c.Invoke(func(got Buffer) {
+			require.NotNil(t, got, "invoke got nil buffer")
+			require.True(t, got == b, "invoke got wrong buffer")
+		}), "invoke failed")
+	})
+
+	t.Run("named instances", func(t *testing.T) {
+		c := New()
+		type A1 struct{s string}
+		type A2 = A1
+		type A3 = A2
+
+		type ret struct {
+			Out
+
+			A A1 `name:"a"`
+			B A2 `name:"b"`
+			C A3 `name:"c"`
+		}
+
+		type param struct {
+			In
+
+			A1 A1 `name:"a"`
+			B1 A2 `name:"b"`
+			C1 A3 `name:"c"`
+
+			A2 A3 `name:"a"`
+			B2 A1 `name:"b"`
+			C2 A2 `name:"c"`
+
+			A3 A2 `name:"a"`
+			B3 A3 `name:"b"`
+			C3 A1 `name:"c"`
+		}
+		require.NoError(t, c.Provide(func() ret {
+			return ret{A: A2{"a"}, B: A3{"b"}, C: A1{"c"}}
+		}), "provide for three named instances should succeed")
+
+		require.NoError(t, c.Invoke(func(p param) {
+			assert.Equal(t, "a", p.A1.s, "A1 should match")
+			assert.Equal(t, "b", p.B1.s, "B1 should match")
+			assert.Equal(t, "c", p.C1.s, "C1 should match")
+
+			assert.Equal(t, "a", p.A2.s, "A2 should match")
+			assert.Equal(t, "b", p.B2.s, "B2 should match")
+			assert.Equal(t, "c", p.C2.s, "C2 should match")
+
+			assert.Equal(t, "a", p.A3.s, "A3 should match")
+			assert.Equal(t, "b", p.B3.s, "B3 should match")
+			assert.Equal(t, "c", p.C3.s, "C3 should match")
+
+		}), "invoke should succeed, pulling out two named instances")
+	})
+
+}
+

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -57,9 +57,10 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 			return A{}
 		}), "A should not fail to provide")
 
-		require.Error(t, c.Provide(func() B {
-			return B{}
-		}), "B should fail to provide")
+		err := c.Provide(func() B { return B{} })
+		require.Error(t, err, "B should fail to provide")
+		assert.Contains(t, err.Error(), `can't provide func() dig.A`)
+		assert.Contains(t, err.Error(), `already in the container`)
 	})
 
 	t.Run("named instances", func(t *testing.T) {


### PR DESCRIPTION
This verifies the behavior of Dig with Go 1.9 aliases.

I had to change the Travis setup to run lint only for Go 1.9 because it fails
syntax check for other versions.

Resolves #134 
