### PR TITLE
Error on private fields inside dig.In/Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v1.0.0-rc3 (unreleased)
 
-- `Provide` and `Invoke` will now error out if `dig.In` or `dig.Out` structs
-  contain private fields. Previously these fields were ignored which often led
-  to confusion.
+- `Provide` and `Invoke` will now fail if `dig.In` or `dig.Out` structs
+  contain unexported fields. Previously these fields were ignored which often
+  led to confusion.
 
 ## v1.0.0-rc2 (21 Jul 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v1.0.0-rc3 (unreleased)
 
-- No changes yet.
+- `Provide` and `Invoke` will now error out if `dig.In` or `dig.Out` structs
+  contain private fields. Previously these fields were ignored which often led
+  to confusion.
 
 ## v1.0.0-rc2 (21 Jul 2017)
 

--- a/dig.go
+++ b/dig.go
@@ -300,8 +300,16 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 	dest := reflect.New(t).Elem()
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
+
+		if f.Type == _inType {
+			// skip over the dig.In embed itself
+			continue
+		}
+
 		if f.PkgPath != "" {
-			continue // skip private fields
+			return dest, fmt.Errorf(
+				"private fields not allowed in dig.In, did you mean to export %q?",
+				fmt.Sprintf("%v %v", f.Name, f.Type))
 		}
 
 		isOptional, err := isFieldOptional(t, f)

--- a/dig.go
+++ b/dig.go
@@ -222,8 +222,15 @@ func traverseOutTypes(k key, f func(key) error) error {
 		field := k.t.Field(i)
 		ft := field.Type
 
+		if field.Type == _outType {
+			// do not recurse into dig.Out itself, it will contain digSentinel only
+			continue
+		}
+
 		if field.PkgPath != "" {
-			continue // skip private fields
+			return fmt.Errorf(
+				"private fields not allowed in dig.Out, did you mean to export %q?",
+				fmt.Sprintf("%v %v", field.Name, field.Type))
 		}
 
 		// keep recursing to traverse all the embedded objects

--- a/dig.go
+++ b/dig.go
@@ -229,8 +229,8 @@ func traverseOutTypes(k key, f func(key) error) error {
 
 		if field.PkgPath != "" {
 			return fmt.Errorf(
-				"private fields not allowed in dig.Out, did you mean to export %q?",
-				fmt.Sprintf("%v %v", field.Name, field.Type))
+				"private fields not allowed in dig.Out, did you mean to export %q (%v) from %v",
+				field.Name, field.Type, k.t)
 		}
 
 		// keep recursing to traverse all the embedded objects
@@ -308,8 +308,8 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 
 		if f.PkgPath != "" {
 			return dest, fmt.Errorf(
-				"private fields not allowed in dig.In, did you mean to export %q?",
-				fmt.Sprintf("%v %v", f.Name, f.Type))
+				"private fields not allowed in dig.In, did you mean to export %q (%v) from %v?",
+				f.Name, f.Type, t)
 		}
 
 		isOptional, err := isFieldOptional(t, f)

--- a/dig_test.go
+++ b/dig_test.go
@@ -1321,4 +1321,25 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Contains(t, err.Error(), "a2 dig.A")
 		assert.Contains(t, err.Error(), "did you mean to export")
 	})
+
+	t.Run("embedded private member gets an error", func(t *testing.T) {
+		c := New()
+		type A struct{}
+		type Embed struct {
+			In
+
+			A1 A // all is good
+			a2 A // oops, private type
+		}
+		type in struct {
+			Embed
+		}
+		require.NoError(t, c.Provide(func() A { return A{} }))
+
+		err := c.Invoke(func(i in) { assert.Fail(t, "should never get in here") })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
+		assert.Contains(t, err.Error(), "a2 dig.A")
+		assert.Contains(t, err.Error(), "did you mean to export")
+	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -1078,7 +1078,7 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() out1 { return out1{a2: A{77}} })
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "private fields not allowed in dig.Out")
-		assert.Contains(t, err.Error(), "a2 dig.A")
+		assert.Contains(t, err.Error(), `"a2" (dig.A)`)
 		assert.Contains(t, err.Error(), "did you mean to export")
 	})
 }
@@ -1318,7 +1318,7 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(i in) { assert.Fail(t, "should never get in here") })
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
-		assert.Contains(t, err.Error(), "a2 dig.A")
+		assert.Contains(t, err.Error(), `"a2" (dig.A)`)
 		assert.Contains(t, err.Error(), "did you mean to export")
 	})
 
@@ -1339,7 +1339,5 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(i in) { assert.Fail(t, "should never get in here") })
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
-		assert.Contains(t, err.Error(), "a2 dig.A")
-		assert.Contains(t, err.Error(), "did you mean to export")
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -358,8 +358,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			Out
 			A  // value type A
 			*B // pointer type *B
-
-			foo string // private field to be ignored
 		}
 		myA := A{"string A"}
 		myB := &B{"string B"}
@@ -791,7 +789,10 @@ func TestEndToEndSuccess(t *testing.T) {
 		require.Error(t, err, "invoking with B param should error out")
 		assert.Contains(t, err.Error(), "B isn't in the container")
 	})
+
 }
+
+// --- END OF END TO END TESTS
 
 func TestProvideConstructorErrors(t *testing.T) {
 	t.Run("multiple-type constructor returns multiple objects of same type", func(t *testing.T) {
@@ -1070,6 +1071,23 @@ func TestProvideFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected error on the second provide")
 		assert.Contains(t, err.Error(), "provides *dig.A:foo, which is already in the container")
+	})
+
+	t.Run("out with private field should error", func(t *testing.T) {
+		c := New()
+
+		type A struct{ idx int }
+		type out1 struct {
+			Out
+
+			A1 A // should be ok
+			a2 A // oops, private field. should generate an error
+		}
+		err := c.Provide(func() out1 { return out1{a2: A{77}} })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "private fields not allowed in dig.Out")
+		assert.Contains(t, err.Error(), "a2 dig.A")
+		assert.Contains(t, err.Error(), "did you mean to export")
 	})
 }
 


### PR DESCRIPTION
As discussed in the issue, we no longer accept private fields on these structs as valid input. I tried to make the error message informative, pointing out the exact field and suggesting an export.

Original issue from Fx repo https://github.com/uber-go/fx/issues/565

Fixes #136 