### PR TITLE
Increased error checking for embedding In/Out pointers

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -186,6 +186,11 @@ func (c *Container) getReturnKeys(
 			if IsIn(k.t) {
 				return errors.New("can't provide parameter objects")
 			}
+			if k.t.Kind() == reflect.Ptr {
+				if IsIn(k.t.Elem()) {
+					return errors.New("can't provide pointers to parameter objects")
+				}
+			}
 			if _, ok := returnTypes[k]; ok {
 				return fmt.Errorf("returns multiple %v", k)
 			}
@@ -254,6 +259,14 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 	if IsIn(e.t) {
 		// We do not want parameter objects to be cached.
 		return c.createInObject(e.t)
+	}
+
+	if e.t.Kind() == reflect.Ptr {
+		if IsIn(e.t.Elem()) {
+			return _noValue, fmt.Errorf(
+				"depepdency %v is a pointer to dig.In, use value type instead", e.t,
+			)
+		}
 	}
 
 	n, ok := c.nodes[e.key]

--- a/dig.go
+++ b/dig.go
@@ -278,7 +278,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 	if e.t.Kind() == reflect.Ptr {
 		if IsIn(e.t.Elem()) {
 			return _noValue, fmt.Errorf(
-				"depepdency %v is a pointer to dig.In, use value type instead", e.t,
+				"dependency %v is a pointer to dig.In, use value type instead", e.t,
 			)
 		}
 	}

--- a/dig_test.go
+++ b/dig_test.go
@@ -1101,7 +1101,6 @@ func TestProvideFailures(t *testing.T) {
 		}
 
 		err := c.Provide(func() out { return out{String: "foo"} })
-		fmt.Println(c)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't embed *dig.Out pointers")
 	})

--- a/types.go
+++ b/types.go
@@ -28,10 +28,10 @@ import (
 var (
 	_noValue    reflect.Value
 	_errType    = reflect.TypeOf((*error)(nil)).Elem()
-	_inType     = reflect.TypeOf((*In)(nil)).Elem()
 	_inPtrType  = reflect.TypeOf((*In)(nil))
-	_outType    = reflect.TypeOf((*Out)(nil)).Elem()
+	_inType     = _inPtrType.Elem()
 	_outPtrType = reflect.TypeOf((*Out)(nil))
+	_outType    = _outPtrType.Elem()
 )
 
 // Special interface embedded inside dig sentinel values (dig.In, dig.Out) to

--- a/types.go
+++ b/types.go
@@ -26,10 +26,12 @@ import (
 )
 
 var (
-	_noValue reflect.Value
-	_errType = reflect.TypeOf((*error)(nil)).Elem()
-	_inType  = reflect.TypeOf((*In)(nil)).Elem()
-	_outType = reflect.TypeOf((*Out)(nil)).Elem()
+	_noValue    reflect.Value
+	_errType    = reflect.TypeOf((*error)(nil)).Elem()
+	_inType     = reflect.TypeOf((*In)(nil)).Elem()
+	_inPtrType  = reflect.TypeOf((*In)(nil))
+	_outType    = reflect.TypeOf((*Out)(nil)).Elem()
+	_outPtrType = reflect.TypeOf((*Out)(nil))
 )
 
 // Special interface embedded inside dig sentinel values (dig.In, dig.Out) to
@@ -104,6 +106,7 @@ func embedsType(i interface{}, e reflect.Type) bool {
 		if t == e {
 			return true
 		}
+
 		if t.Kind() != reflect.Struct {
 			continue
 		}

--- a/types.go
+++ b/types.go
@@ -86,6 +86,12 @@ func IsOut(o interface{}) bool {
 
 // Returns true if t embeds e or if any of the types embedded by t embed e.
 func embedsType(i interface{}, e reflect.Type) bool {
+	// TODO: this function doesn't consider e being a pointer.
+	// given `type A foo { *In }`, this function would return false for
+	// embedding dig.In, which makes for some extra error checking in places
+	// that call this funciton. Might be worthwhile to consider reflect.Indirect
+	// usage to clean up the callers.
+
 	if i == nil {
 		return false
 	}

--- a/types.go
+++ b/types.go
@@ -29,9 +29,9 @@ var (
 	_noValue    reflect.Value
 	_errType    = reflect.TypeOf((*error)(nil)).Elem()
 	_inPtrType  = reflect.TypeOf((*In)(nil))
-	_inType     = _inPtrType.Elem()
+	_inType     = reflect.TypeOf(In{})
 	_outPtrType = reflect.TypeOf((*Out)(nil))
-	_outType    = _outPtrType.Elem()
+	_outType    = reflect.TypeOf(Out{})
 )
 
 // Special interface embedded inside dig sentinel values (dig.In, dig.Out) to


### PR DESCRIPTION
Well this sure is messy, but there is massive complexity in just how many cases there are:

- Embedding pointers to In/Out
- Using pointers as params/returns
- Embedding pointers to objects that embed In/Out
- Embedding pointers to objects that embed pointers to In/Out
- ????

I wrote some e2e tests that in general I expect to fail and pass and reversed it from there. This obviously adds some tech debt that should be cleaned up.

Fixes #131 
