### PR TITLE
Preparing v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v1.0.0-rc3 (unreleased)
+## v1.0.0 (31 Jul 2017)
+
+First stable release: no breaking changes will be made in the 1.x series.
 
 - `Provide` and `Invoke` will now fail if `dig.In` or `dig.Out` structs
   contain unexported fields. Previously these fields were ignored which often

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.0 (31 Jul 2017)
+## v1.0.0 (2017-07-31)
 
 First stable release: no breaking changes will be made in the 1.x series.
 
@@ -8,7 +8,7 @@ First stable release: no breaking changes will be made in the 1.x series.
   contain unexported fields. Previously these fields were ignored which often
   led to confusion.
 
-## v1.0.0-rc2 (21 Jul 2017)
+## v1.0.0-rc2 (2017-07-21)
 
 - Added variadic options to all public APIS so that new functionality can be
   introduced post v1.0.0 without introducing breaking changes.
@@ -17,11 +17,11 @@ First stable release: no breaking changes will be made in the 1.x series.
 - Exported `dig.IsIn` and `dig.IsOut` so that consuming libraries can check if
   a params or return struct embeds the `dig.In` and `dig.Out` types, respectively.
 
-## v1.0.0-rc1 (21 Jun 2017)
+## v1.0.0-rc1 (2017-06-21)
 
 - First release candidate.
 
-## v0.5.0 (19 Jun 2017)
+## v0.5.0 (2017-06-19)
 
 - `dig.In` and `dig.Out` now support named instances, i.e.:
 
@@ -37,7 +37,7 @@ First stable release: no breaking changes will be made in the 1.x series.
 - Structs compatible with `dig.In` and `dig.Out` may now be generated using
   `reflect.StructOf`.
 
-## v0.4.0 (12 Jun 2017)
+## v0.4.0 (2017-06-12)
 
 - **[Breaking]** Remove `Must*` funcs to greatly reduce API surface area.
 - **[Breaking]** Restrict the API surface to only `Provide` and `Invoke`.
@@ -49,7 +49,7 @@ First stable release: no breaking changes will be made in the 1.x series.
 - Add support for optional parameters through `optional:"true"` tag on `dig.In` objects.
 - Add support for value types and many built-ins (maps, slices, channels).
 
-## v0.3 (2 May 2017)
+## v0.3 (2017-05-02)
 
 - Rename `RegisterAll` and `MustRegisterAll` to `ProvideAll` and
   `MustProvideAll`.
@@ -58,13 +58,13 @@ First stable release: no breaking changes will be made in the 1.x series.
 - Add `Invoke` function to invoke provided function and insert return
   objects into the `dig.Graph`
 
-## v0.2 (27 Mar 2017)
+## v0.2 (2017-03-27)
 
 - Rename `Register` to `Provide` for clarity and to recude clash with other
   Register functions.
 - Rename `dig.Graph` to `dig.Container`.
 - Remove the package-level functions and the `DefaultGraph`.
 
-## v0.1 (23 Mar 2017)
+## v0.1 (2017-03-23)
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ A reflection based dependency injection toolkit for Go.
 * Resolving dependencies after the process has already started.
 * Exposing to user-land code as a [Service Locator](https://martinfowler.com/articles/injection.html#UsingAServiceLocator).
 
-## Status
+## Installation
 
-Almost stable: `v1.0.0-rc2`. Some breaking changes might occur before `v1.0.0`. See [CHANGELOG.md](CHANGELOG.md) for more info.
-
-## Install
+We recommend locking to [SemVer](http://semver.org/) range `^1` using [Glide](https://github.com/Masterminds/glide):
 
 ```
-go get -u go.uber.org/dig
+glide get 'go.uber.org/dig#^1'
 ```
+
+## Stability
+
+This library is `v1` and follows [SemVer](http://semver.org/) strictly.
+
+No breaking changes will be made to exported APIs before `v2.0.0`.
 
 [doc]: https://godoc.org/go.uber.org/dig
 [doc-img]: https://godoc.org/go.uber.org/dig?status.svg

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: fdd7122108d34cf543d2dd819f2c794d94d44245ab0ac8ff298a7720a5b93976
-updated: 2017-06-02T11:14:49.117711757-07:00
+updated: 2017-07-31T11:25:37.451934681-07:00
 imports: []
 testImports:
 - name: github.com/davecgh/go-spew
@@ -7,7 +7,7 @@ testImports:
   subpackages:
   - spew
 - name: github.com/golang/lint
-  version: a5f4a247366d8fc436941822e14fc3eac7727015
+  version: c5fb716d6688a859aae56d26d3e6070808df29f7
   subpackages:
   - golint
 - name: github.com/pmezard/go-difflib
@@ -17,7 +17,7 @@ testImports:
 - name: github.com/sectioneight/md-to-godoc
   version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
 - name: github.com/stretchr/testify
-  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
+  version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
   - assert
   - require

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dig
 
 // Version of the library
-const Version = "1.0.0-rc3"
+const Version = "1.0.0"


### PR DESCRIPTION
Let's cut `v1.0.0` now to unblock the fx `v1.0.0`.

Docs is an ongoing process that can come afterwards and be landed into master / go out in minor releases.