### PR TITLE
Rewrite godocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ lint:
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@echo "Checking for license headers..."
 	@DRY_RUN=1 ./check_license.sh | tee -a lint.log
-	@$(MAKE) gendoc
 	@[ ! -s lint.log ]
 
 .PHONY: test
@@ -53,10 +52,3 @@ ci: test
 BENCH ?= .
 bench:
 	@$(foreach pkg,$(PKGS),go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) $(pkg);)
-
-.PHONY: gendoc
-gendoc:
-	@echo "Generating doc.go from README.md..."
-	@find . -name README.md -not -path "./vendor/*" | xargs -I% md-to-godoc -input=%
-	@# doc.go gets regenerated, so refresh its license
-	@update-license doc.go

--- a/dig.go
+++ b/dig.go
@@ -80,7 +80,8 @@ func New(opts ...Option) *Container {
 	}
 }
 
-// Provide teaches the container how to build values of one or more types.
+// Provide teaches the container how to build values of one or more types and
+// expresses their dependency types.
 //
 // The first argument of Provide is a function which accepts zero or more
 // parameters and returns one or more results. The function may optionally
@@ -108,12 +109,13 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 	return nil
 }
 
-// Invoke runs the given function immediately, supplying its arguments from
-// the container. All types requested by the function will be instantiated,
-// and their dependencies will be instantiated in the process.
+// Invoke runs the given function after instantiating its dependencies.
+// Any arguments that the function has are treated as its dependencies and
+// they are instantiated in an unspecified order along with any dependencies
+// that they might have.
 //
-// The provided function may return an error to indicate failure. The error
-// will be returned to the caller as-is.
+// The function may return an error to indicate failure. The error will be
+// returned to the caller as-is.
 func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 	ftype := reflect.TypeOf(function)
 	if ftype == nil {

--- a/dig.go
+++ b/dig.go
@@ -83,17 +83,17 @@ func New(opts ...Option) *Container {
 // Provide teaches the container how to build values of one or more types and
 // expresses their dependency types.
 //
-// The first argument of Provide is a function which accepts zero or more
+// The first argument of Provide is a function that accepts zero or more
 // parameters and returns one or more results. The function may optionally
 // return an error to indicate that it failed to build the value. This
 // function will be treated as the constructor for all the types it returns.
 // This function will be called AT MOST ONCE when a type produced by it, or a
-// type which depends on this function's output, is requested via Invoke. If
-// the same types are requested multiple times, the previously produced value
-// will be reused.
+// type that consumes this function's output, is requested via Invoke. If the
+// same types are requested multiple times, the previously produced value will
+// be reused.
 //
 // In addition to accepting vanilla constructors, Provide also accepts
-// constructors which accept dig.In structs as dependencies and/or return
+// constructors that accept dig.In structs as dependencies and/or return
 // dig.Out results.
 func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) error {
 	ctype := reflect.TypeOf(constructor)

--- a/dig.go
+++ b/dig.go
@@ -92,9 +92,10 @@ func New(opts ...Option) *Container {
 // same types are requested multiple times, the previously produced value will
 // be reused.
 //
-// In addition to accepting vanilla constructors, Provide also accepts
-// constructors that accept dig.In structs as dependencies and/or return
-// dig.Out results.
+// In addition to accepting constructors that accept dependencies as separate
+// arguments and produce results as separate return values, Provide also
+// accepts constructors that specify dependencies as dig.In structs and/or
+// specify results as dig.Out structs.
 func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) error {
 	ctype := reflect.TypeOf(constructor)
 	if ctype == nil {

--- a/dig.go
+++ b/dig.go
@@ -81,7 +81,7 @@ func New(opts ...Option) *Container {
 }
 
 // Provide teaches the container how to build values of one or more types and
-// expresses their dependency types.
+// expresses their dependencies.
 //
 // The first argument of Provide is a function that accepts zero or more
 // parameters and returns one or more results. The function may optionally

--- a/dig.go
+++ b/dig.go
@@ -111,9 +111,10 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 }
 
 // Invoke runs the given function after instantiating its dependencies.
-// Any arguments that the function has are treated as its dependencies and
-// they are instantiated in an unspecified order along with any dependencies
-// that they might have.
+//
+// Any arguments that the function has are treated as its dependencies. The
+// dependencies are instantiated in an unspecified order along with any
+// dependencies that they might have.
 //
 // The function may return an error to indicate failure. The error will be
 // returned to the caller as-is.

--- a/doc.go
+++ b/doc.go
@@ -26,8 +26,8 @@
 //
 // Container
 //
-// Dig exposes type Container as an object capable of resolving a directional
-// dependency graph. To create one, simply use the New function.
+// Dig exposes type Container as an object capable of resolving a directed
+// dependency graph. Use the New function to create one.
 //
 //   c := dig.New()
 //
@@ -49,9 +49,9 @@
 //     // ...
 //   }
 //
-// Multiple constructors can rely on the same type. Types in the container are
-// treated as singletons, so the constructors for them will be called at most
-// once when requested by another type.
+// Multiple constructors can rely on the same type. The container creates a
+// singleton for each retained type, instantiating it at most once when
+// requested directly or as a dependency of another type.
 //
 //   err := c.Provide(func(conn *sql.DB) *CommentGateway {
 //     // ...
@@ -200,6 +200,9 @@
 //
 // Constructors which declare dependencies as optional MUST handle the case of
 // that dependency being missing.
+//
+// The optional tag also allows adding new dependencies without breaking
+// existing consumers of the constructor.
 //
 // Named Values
 //

--- a/doc.go
+++ b/doc.go
@@ -27,7 +27,7 @@
 // Container
 //
 // Dig exposes type Container as an object capable of resolving a directed
-// dependency graph. Use the New function to create one.
+// acyclic dependency graph. Use the New function to create one.
 //
 //   c := dig.New()
 //

--- a/doc.go
+++ b/doc.go
@@ -175,7 +175,7 @@
 //
 // Optional Dependencies
 //
-// Often times constructors don't have a hard dependency on some types and
+// Constructors often don't have a hard dependency on some types and
 // are able to operate in a degraded state when that dependency is missing.
 // Dig supports declaring dependencies as optional by adding an
 // `optional:"true"` tag to fields of a dig.In struct.

--- a/doc.go
+++ b/doc.go
@@ -60,7 +60,7 @@
 //     // ...
 //   }
 //
-// Constructors can declare any number of dependencies in their parameters and
+// Constructors can declare any number of dependencies as parameters and
 // optionally, return errors.
 //
 //   err := c.Provide(func(u *UserGateway, c *CommentGateway) (*RequestHandler, error) {
@@ -83,6 +83,18 @@
 //   if err != nil {
 //     // ...
 //   }
+//
+// Constructors that accept a variadic number of arguments are treated as if
+// they don't have those arguments. That is,
+//
+//   func NewVoteGateway(db *sql.DB, options ...Option) *VoteGateway
+//
+// Is treated the same as,
+//
+//   func NewVoteGateway(db *sql.DB) *VoteGateway
+//
+// The constructor will be called with all other dependencies and no variadic
+// arguments.
 //
 // Invoke
 //

--- a/doc.go
+++ b/doc.go
@@ -36,7 +36,7 @@
 // Constructors for different types are added to the container by using the
 // Provide method. A constructor can declare a dependency on another type by
 // simply adding it as a function parameter. Dependencies for a type can be
-// added to the graph both, before and after that type was added.
+// added to the graph both, before and after the type was added.
 //
 //   err := c.Provide(func(conn *sql.DB) (*UserGateway, error) {
 //     // ...
@@ -87,7 +87,7 @@
 // Invoke
 //
 // Types added to to the container may be consumed by using the Invoke method.
-// Invoke accepts a function which accepts one or more parameters and
+// Invoke accepts any function that accepts one or more parameters and
 // optionally, returns an error. Dig calls the function with the requested
 // type, instantiating only those types that were requested by the function.
 // The call fails if any type or its dependencies (both direct and transitive)
@@ -107,7 +107,7 @@
 //     // ...
 //   }
 //
-// If the invoked function returns an error, that error is propagated to the
+// Any error returned by the invoked function is propagated back to the
 // caller.
 //
 // Parameter Objects
@@ -121,11 +121,11 @@
 //   }
 //
 // A pattern employed to improve readability in a situation like this is to
-// create a struct which lists all the parameters of the function as fields
-// and changing the function to accept that struct instead. This is referred
-// to as a parameter object.
+// create a struct that lists all the parameters of the function as fields and
+// changing the function to accept that struct instead. This is referred to as
+// a parameter object.
 //
-// Dig has first class support for parameter objects: any struct that embeds
+// Dig has first class support for parameter objects: any struct embedding
 // dig.In gets treated as a parameter object. The following is equivalent to
 // the constructor above.
 //
@@ -152,8 +152,8 @@
 // Result Objects
 //
 // Result objects are the flip side of parameter objects. These are structs
-// which represent multiple outputs from a single function as fields in the
-// struct. Structs that embed dig.Out get treated as result objects.
+// that represent multiple outputs from a single function as fields in the
+// struct. Structs embedding dig.Out get treated as result objects.
 //
 //   func SetupGateways(conn *sql.DB) (*UserGateway, *CommentGateway, *PostGateway, error) {
 //     // ...
@@ -178,8 +178,10 @@
 // Often times constructors don't have a hard dependency on some types and
 // are able to operate in a degraded state when that dependency is missing.
 // Dig supports declaring dependencies as optional by adding an
-// `optional:"true"` tag to fields of a dig.In struct.  Fields in a dig.In
-// structs which have that tag are treated as optional by Dig.
+// `optional:"true"` tag to fields of a dig.In struct.
+//
+// Fields in a dig.In structs that have the `optional:"true"` tag are treated
+// as optional by Dig.
 //
 //   type UserGatewayParams struct {
 //     dig.In
@@ -189,7 +191,7 @@
 //   }
 //
 // If an optional field is not available in the container, the constructor
-// will receive a zero value for that field.
+// will receive a zero value for the field.
 //
 //   func NewUserGateway(p UserGatewayParams, log *log.Logger) (*UserGateway, error) {
 //     if p.Cache != nil {
@@ -198,8 +200,8 @@
 //     // ...
 //   }
 //
-// Constructors which declare dependencies as optional MUST handle the case of
-// that dependency being missing.
+// Constructors that declare dependencies as optional MUST handle the case of
+// those dependencies being absent.
 //
 // The optional tag also allows adding new dependencies without breaking
 // existing consumers of the constructor.
@@ -210,8 +212,9 @@
 // multiple values of the same type to the container with the use of
 // `name:".."` tags on fields of dig.In and dig.Out structs.
 //
-// A constructor which produces a dig.Out struct can tag any field with
-// `name:".."` to have that value added to the graph under the specified name.
+// A constructor that produces a dig.Out struct can tag any field with
+// `name:".."` to have the corresponding value added to the graph under the
+// specified name.
 //
 //   type ConnectionResult {
 //     dig.Out
@@ -235,7 +238,7 @@
 //     ReadFromConn *sql.DB `name:"ro"`
 //   }
 //
-// The name tag may be combined with the optional tag to declare that
+// The name tag may be combined with the optional tag to declare the
 // dependency optional.
 //
 //   type GatewayParams struct {

--- a/doc.go
+++ b/doc.go
@@ -18,121 +18,235 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package dig is the dig: Dependency Injection Framework for Go.
-//
-// package dig provides an opinionated way of resolving object dependencies.
+// Package dig provides an opinionated way of resolving object dependencies.
 //
 // Status
 //
-// BETA. Expect potential API changes.
+// STABLE. No breaking changes will be made in this major version.
 //
 // Container
 //
-// package dig exposes type Container as an object capable of resolving a
-// directional dependency graph.
+// Dig exposes type Container as an object capable of resolving a directional
+// dependency graph. To create one, simply use the New function.
 //
-//
-// To create one:
-//
-//   import "go.uber.org/dig"
-//
-//   func main() {
-//   	c := dig.New()
-//   	// dig container `c` is ready to use!
-//   }
-//
-// **All objects in the container are treated as a singletons**, meaning there can be
-// only one object in the graph of a given type.
-//
-//
-// There are plans to expand the API to support multiple objects of the same type
-// in the container, but for time being consider using a factory pattern.
-//
+//   c := dig.New()
 //
 // Provide
 //
-// The Provide method adds a constructor of an object (or objects), to the container.
-// A constructor can be a function returning any number of objects and, optionally,
-// an error.
+// Constructors for different types are added to the container by using the
+// Provide method. A constructor can declare a dependency on another type by
+// simply adding it as a function parameter. Dependencies for a type can be
+// added to the graph both, before and after that type was added.
 //
-//
-// Each argument to the constructor is registered as a **dependency** in the graph.
-//
-//   type A struct {}
-//   type B struct {}
-//   type C struct {}
-//
-//   c := dig.New()
-//   constructor := func (*A, *B) *C {
-//     // At this point, *A and *B have been resolved through the graph
-//     // and can be used to provide an object of type *C
-//     return &C{}
+//   err := c.Provide(func(conn *sql.DB) (*UserGateway, error) {
+//     // ...
+//   })
+//   if err != nil {
+//     // ...
 //   }
-//   err := c.Provide(constructor)
-//   // dig container is now able to provide *C to any constructor.
-//   //
-//   // However, note that in the current example *A and *B
-//   // have not been provided, meaning that the resolution of type
-//   // *C will result in an error, because types *A and *B can not
-//   // be instantiated.
 //
-// Advanced Provide
+//   if err := c.Provide(newDBConnection); err != nil {
+//     // ...
+//   }
 //
-// // TODO: docs on dig.In usage
-// // TODO: docs on dig.Out usage
+// Multiple constructors can rely on the same type. Types in the container are
+// treated as singletons, so the constructors for them will be called at most
+// once when requested by another type.
 //
+//   err := c.Provide(func(conn *sql.DB) *CommentGateway {
+//     // ...
+//   })
+//   if err != nil {
+//     // ...
+//   }
+//
+// Constructors can declare any number of dependencies in their parameters and
+// optionally, return errors.
+//
+//   err := c.Provide(func(u *UserGateway, c *CommentGateway) (*RequestHandler, error) {
+//     // ...
+//   })
+//   if err != nil {
+//     // ...
+//   }
+//
+//   if err := c.Provide(newHTTPServer); err != nil {
+//     // ...
+//   }
+//
+// Constructors can also return multiple results to add multiple types to the
+// container.
+//
+//   err := c.Provide(func(conn *sql.DB) (*UserGateway, *CommentGateway, error) {
+//     // ...
+//   })
+//   if err != nil {
+//     // ...
+//   }
 //
 // Invoke
 //
-// The Invoke API is the flip side of Provide and used to retrieve types from the container.
+// Types added to to the container may be consumed by using the Invoke method.
+// Invoke accepts a function which accepts one or more parameters and
+// optionally, returns an error. Dig calls the function with the requested
+// type, instantiating only those types that were requested by the function.
+// The call fails if any type or its dependencies (both direct and transitive)
+// were not available in the container.
 //
-// Invoke looks through the graph and resolves all the constructor parameters for execution.
-//
-// In order to successfully use use Invoke, the function must meet the following criteria:
-//
-// • Input to the Invoke must be a function
-//
-// • All arguments to the function must be types in the container
-//
-// • If an error is returned from an invoked function, it will be propagated to the caller
-//
-// Here is a fully working somewhat real-world Invoke example:
-//
-//   package main
-//
-//   import (
-//   	"go.uber.org/config"
-//   	"go.uber.org/dig"
-//   	"go.uber.org/zap"
-//   )
-//
-//   func main() {
-//   	c := dig.New()
-//
-//   	// Provide configuration object
-//   	c.Provide(func() config.Provider {
-//   		return config.NewYAMLProviderFromBytes([]byte("tag: Hello, world!"))
-//   	})
-//
-//   	// Provide a zap logger which relies on configuration
-//   	c.Provide(func(cfg config.Provider) (*zap.Logger, error) {
-//   		l, err := zap.NewDevelopment()
-//   		if err != nil {
-//   			return nil, err
-//   		}
-//   		return l.With(zap.String("iconic phrase", cfg.Get("tag").AsString())), nil
-//   	})
-//
-//   	// Invoke a function that requires a zap logger, which in turn requires config
-//   	c.Invoke(func(l *zap.Logger) {
-//   		l.Info("You've been invoked")
-//   		// Logger output:
-//   		//     INFO    You've been invoked     {"iconic phrase": "Hello, world!"}
-//   		//
-//   		// As we can see, Invoke caused the Logger to be created, which in turn
-//   		// required the configuration to be created.
-//   	})
+//   err := c.Invoke(func(l *log.Logger) {
+//     // ...
+//   })
+//   if err != nil {
+//     // ...
 //   }
 //
+//   err := c.Invoke(func(server *http.Server) error {
+//     // ...
+//   })
+//   if err != nil {
+//     // ...
+//   }
 //
+// If the invoked function returns an error, that error is propagated to the
+// caller.
+//
+// Parameter Objects
+//
+// Constructors declare their dependencies as function parameters. This can
+// very quickly become unreadable if the constructor has a lot of
+// dependencies.
+//
+//   func NewHandler(users *UserGateway, comments *CommentGateway, posts *PostGateway, votes *VoteGateway, authz *AuthZGateway) *Handler {
+//     // ...
+//   }
+//
+// A pattern employed to improve readability in a situation like this is to
+// create a struct which lists all the parameters of the function as fields
+// and changing the function to accept that struct instead. This is referred
+// to as a parameter object.
+//
+// Dig has first class support for parameter objects: any struct that embeds
+// dig.In gets treated as a parameter object. The following is equivalent to
+// the constructor above.
+//
+//   type HandlerParams struct {
+//     dig.In
+//
+//     Users    *UserGateway
+//     Comments *CommentGateway
+//     Posts    *PostGateway
+//     Votes    *VoteGateway
+//     AuthZ    *AuthZGateway
+//   }
+//
+//   func NewHandler(p HandlerParams) *Handler {
+//     // ...
+//   }
+//
+// Handlers can receive any combination of parameter objects and parameters.
+//
+//   func NewHandler(p HandlerParams, l *log.Logger) *Handler {
+//     // ...
+//   }
+//
+// Result Objects
+//
+// Result objects are the flip side of parameter objects. These are structs
+// which represent multiple outputs from a single function as fields in the
+// struct. Structs that embed dig.Out get treated as result objects.
+//
+//   func SetupGateways(conn *sql.DB) (*UserGateway, *CommentGateway, *PostGateway, error) {
+//     // ...
+//   }
+//
+// The above is equivalent to,
+//
+//  type Gateways struct {
+//    dig.Out
+//
+//    Users    *UserGateway
+//    Comments *CommentGateway
+//    Posts    *PostGateway
+//  }
+//
+//  func SetupGateways(conn *sql.DB) (Gateways, error) {
+//    // ...
+//  }
+//
+// Optional Dependencies
+//
+// Often times constructors don't have a hard dependency on some types and
+// are able to operate in a degraded state when that dependency is missing.
+// Dig supports declaring dependencies as optional by adding an
+// `optional:"true"` tag to fields of a dig.In struct.  Fields in a dig.In
+// structs which have that tag are treated as optional by Dig.
+//
+//   type UserGatewayParams struct {
+//     dig.In
+//
+//     Conn  *sql.DB
+//     Cache *redis.Client `optional:"true"`
+//   }
+//
+// If an optional field is not available in the container, the constructor
+// will receive a zero value for that field.
+//
+//   func NewUserGateway(p UserGatewayParams, log *log.Logger) (*UserGateway, error) {
+//     if p.Cache != nil {
+//       log.Print("Logging disabled")
+//     }
+//     // ...
+//   }
+//
+// Constructors which declare dependencies as optional MUST handle the case of
+// that dependency being missing.
+//
+// Named Values
+//
+// Some use cases call for multiple values of the same type. Dig allows adding
+// multiple values of the same type to the container with the use of
+// `name:".."` tags on fields of dig.In and dig.Out structs.
+//
+// A constructor which produces a dig.Out struct can tag any field with
+// `name:".."` to have that value added to the graph under the specified name.
+//
+//   type ConnectionResult {
+//     dig.Out
+//
+//     ReadWrite *sql.DB `name:"rw"`
+//     ReadOnly  *sql.DB `name:"ro"`
+//   }
+//
+//   func ConnectToDatabase(...) (ConnectionResult, error) {
+//     // ...
+//     return ConnectionResult{ReadWrite: rw, ReadOnly:  ro}, nil
+//   }
+//
+// Another constructor can consume these values by adding fields to a dig.In
+// struct with the same name AND type.
+//
+//   type GatewayParams struct {
+//     dig.In
+//
+//     WriteToConn  *sql.DB `name:"rw"`
+//     ReadFromConn *sql.DB `name:"ro"`
+//   }
+//
+// The name tag may be combined with the optional tag to declare that
+// dependency optional.
+//
+//   type GatewayParams struct {
+//     dig.In
+//
+//     WriteToConn  *sql.DB `name:"rw"`
+//     ReadFromConn *sql.DB `name:"ro" optional:"true"`
+//   }
+//
+//   func NewCommentGateway(p GatewayParams, log *log.Logger) (*CommentGateway, error) {
+//     if p.ReadFromConn == nil {
+//       log.Print("Warning: Using RW connection for reads")
+//       p.ReadFromConn = p.WriteToConn
+//     }
+//     // ...
+//   }
 package dig

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"go.uber.org/dig"
+)
+
+func Example_minimal() {
+	type Config struct {
+		Prefix string
+	}
+
+	c := dig.New()
+
+	// Provide a Config object. This can fail to decode.
+	err := c.Provide(func() (*Config, error) {
+		// In a real program, the configuration will probably be read from a
+		// file.
+		var cfg Config
+		err := json.Unmarshal([]byte(`{"prefix": "[foo] "}`), &cfg)
+		return &cfg, err
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Provide a way to build the logger based on the configuration.
+	err = c.Provide(func(cfg *Config) *log.Logger {
+		return log.New(os.Stdout, cfg.Prefix, 0)
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Invoke a function that requires the logger, which in turn builds the
+	// Config first.
+	err = c.Invoke(func(l *log.Logger) {
+		l.Print("You've been invoked")
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// [foo] You've been invoked
+}

--- a/types.go
+++ b/types.go
@@ -78,10 +78,10 @@ func isError(t reflect.Type) bool {
 	return t.Implements(_errType)
 }
 
-// IsIn checks if the given struct is a dig.In struct. A struct qualifies as a
-// dig.In struct if it embeds the dig.In type or if any struct that it embeds
-// is a dig.In struct. The parameter may be the reflect.Type of the struct
-// rather than the struct itself.
+// IsIn checks whether the given struct is a dig.In struct. A struct qualifies
+// as a dig.In struct if it embeds the dig.In type or if any struct that it
+// embeds is a dig.In struct. The parameter may be the reflect.Type of the
+// struct rather than the struct itself.
 //
 // A struct MUST qualify as a dig.In struct for its fields to support dig.In
 // tags.
@@ -92,10 +92,10 @@ func IsIn(o interface{}) bool {
 	return embedsType(o, _inType)
 }
 
-// IsOut checks if the given struct is a dig.Out struct. A struct qualifies as
-// a dig.Out struct if it embeds the dig.Out type or if any struct that it
-// embeds is a dig.Out struct. The parameter may be the reflect.Type of the
-// struct rather than the struct itself.
+// IsOut checks whether the given struct is a dig.Out struct. A struct
+// qualifies as a dig.Out struct if it embeds the dig.Out type or if any
+// struct that it embeds is a dig.Out struct. The parameter may be the
+// reflect.Type of the struct rather than the struct itself.
 //
 // A struct MUST qualify as a dig.Out struct for its fields to support dig.Out
 // tags.

--- a/types.go
+++ b/types.go
@@ -44,8 +44,8 @@ type digSentinel interface {
 // In may be embedded into structs to request dig to treat them as special
 // parameter structs. When a constructor accepts such a struct, instead of the
 // struct becoming a dependency for that constructor, all its fields become
-// dependencies instead. See the section on Parameter Objects above for more
-// information.
+// dependencies instead. See the section on Parameter Objects in the
+// package-level documentation for more information.
 //
 // Fields of the struct may optionally be tagged to customize the behavior of
 // dig. The following tags are supported,
@@ -63,8 +63,8 @@ type In struct{ digSentinel }
 // Out may be embedded into structs to request dig to treat them as special
 // result structs. When a constructor returns such a struct, instead of the
 // struct becoming a result of the constructor, all its fields become results
-// of the constructor. See the section on Result Objects above for more
-// information.
+// of the constructor. See the section on Result Objects in the package-level
+// documentation for more information.
 //
 // Fields of the struct may optionally be tagged to customize the behavior of
 // dig. The following tags are supported,

--- a/types.go
+++ b/types.go
@@ -83,8 +83,8 @@ func isError(t reflect.Type) bool {
 // embeds is a dig.In struct. The parameter may be the reflect.Type of the
 // struct rather than the struct itself.
 //
-// A struct MUST qualify as a dig.In struct for its fields to support dig.In
-// tags.
+// A struct MUST qualify as a dig.In struct for its fields to be treated
+// specially by dig.
 //
 // See the documentation for dig.In for a comprehensive list of supported
 // tags.
@@ -97,8 +97,8 @@ func IsIn(o interface{}) bool {
 // struct that it embeds is a dig.Out struct. The parameter may be the
 // reflect.Type of the struct rather than the struct itself.
 //
-// A struct MUST qualify as a dig.Out struct for its fields to support dig.Out
-// tags.
+// A struct MUST qualify as a dig.Out struct for its fields to be treated
+// specially by dig.
 //
 // See the documentation for dig.Out for a comprehensive list of supported
 // tags.

--- a/types.go
+++ b/types.go
@@ -42,10 +42,10 @@ type digSentinel interface {
 }
 
 // In may be embedded into structs to request dig to treat them as special
-// parameter structs. When a constructor accepts such a struct as an argument,
-// instead of the struct becoming a dependency for that constructor, all its
-// fields become dependencies instead. See the section on Parameter Objects
-// above for more information.
+// parameter structs. When a constructor accepts such a struct, instead of the
+// struct becoming a dependency for that constructor, all its fields become
+// dependencies instead. See the section on Parameter Objects above for more
+// information.
 //
 // Fields of the struct may optionally be tagged to customize the behavior of
 // dig. The following tags are supported,
@@ -61,10 +61,10 @@ type In struct{ digSentinel }
 // becoming part of the container, all members of the struct will.
 
 // Out may be embedded into structs to request dig to treat them as special
-// result structs. When a constructor produces such a struct as a result,
-// instead of the struct becoming a result of the constructor, all its fields
-// become results of the constructor. See the section on Result Objects above
-// for more information.
+// result structs. When a constructor returns such a struct, instead of the
+// struct becoming a result of the constructor, all its fields become results
+// of the constructor. See the section on Result Objects above for more
+// information.
 //
 // Fields of the struct may optionally be tagged to customize the behavior of
 // dig. The following tags are supported,

--- a/types.go
+++ b/types.go
@@ -41,45 +41,67 @@ type digSentinel interface {
 	digSentinel()
 }
 
-// In is an embeddable object that signals to dig that the struct
-// should be treated differently. Instead of itself becoming an object
-// in the graph, memebers of the struct are inserted into the graph.
+// In may be embedded into structs to request dig to treat them as special
+// parameter structs. When a constructor accepts such a struct as an argument,
+// instead of the struct becoming a dependency for that constructor, all its
+// fields become dependencies instead. See the section on Parameter Objects
+// above for more information.
 //
-// Tags on those memebers control their behavior. For example,
+// Fields of the struct may optionally be tagged to customize the behavior of
+// dig. The following tags are supported,
 //
-//    type Input struct {
-//      dig.In
-//
-//      S *Something
-//      T *Thingy `optional:"true"`
-//    }
-//
+//   name        Requests a value with the same name and type from the
+//               container. See Named Values for more information.
+//   optional    If set to true, indicates that the dependency is optional and
+//               the constructor gracefully handles its absence.
 type In struct{ digSentinel }
 
 // Out is an embeddable type that signals to dig that the returned
 // struct should be treated differently. Instead of the struct itself
 // becoming part of the container, all members of the struct will.
-type Out struct{ digSentinel }
 
-// TODO: better usage docs
-// Try to add some symmetry for In-Out docs as well.
+// Out may be embedded into structs to request dig to treat them as special
+// result structs. When a constructor produces such a struct as a result,
+// instead of the struct becoming a result of the constructor, all its fields
+// become results of the constructor. See the section on Result Objects above
+// for more information.
+//
+// Fields of the struct may optionally be tagged to customize the behavior of
+// dig. The following tags are supported,
+//
+//   name        Specifies the name of the value. Only a field on a dig.In
+//               struct with the same 'name' annotation can receive this
+//               value. See Named Values for more information.
+type Out struct{ digSentinel }
 
 func isError(t reflect.Type) bool {
 	return t.Implements(_errType)
 }
 
-// IsIn returns true if passed in type embeds dig.In either directly
-// or through another embedded field.
+// IsIn checks if the given struct is a dig.In struct. A struct qualifies as a
+// dig.In struct if it embeds the dig.In type or if any struct that it embeds
+// is a dig.In struct. The parameter may be the reflect.Type of the struct
+// rather than the struct itself.
 //
-// Parameter can be a struct directly, or reflect.Type of it.
+// A struct MUST qualify as a dig.In struct for its fields to support dig.In
+// tags.
+//
+// See the documentation for dig.In for a comprehensive list of supported
+// tags.
 func IsIn(o interface{}) bool {
 	return embedsType(o, _inType)
 }
 
-// IsOut returns true if passed in type embeds dig.Out either directly
-// or through another embedded field.
+// IsOut checks if the given struct is a dig.Out struct. A struct qualifies as
+// a dig.Out struct if it embeds the dig.Out type or if any struct that it
+// embeds is a dig.Out struct. The parameter may be the reflect.Type of the
+// struct rather than the struct itself.
 //
-// Parameter can be a struct directly, or reflect.Type of it.
+// A struct MUST qualify as a dig.Out struct for its fields to support dig.Out
+// tags.
+//
+// See the documentation for dig.Out for a comprehensive list of supported
+// tags.
 func IsOut(o interface{}) bool {
 	return embedsType(o, _outType)
 }


### PR DESCRIPTION
This rewrites most of the godocs of this library and documents
undocumented features (dig.In, dig.Out, etc.).

The package-level docs give a general overview of the library and
showcase different dig.In/dig.Out features by use case.

Entity-level docs for dig.In and dig.Out act as the authoritative
reference list of all tags supported by those structs and how they
behave.

---

Here's a rendering of the docs in PDF form: [dig - The Go Programming Language.pdf](https://github.com/uber-go/dig/files/1205574/dig.-.The.Go.Programming.Language.pdf)