### PR TITLE
Add RootCause to retrieve original error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v1.1.0 (unreleased)
 
-- No changes yet
+- Added support for disabling wrapping of constructor errors with the
+  `WrapErrors` option.
 
 ## v1.0.0 (2017-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## v1.1.0 (unreleased)
 
-- Added support for disabling wrapping of constructor errors with the
-  `WrapErrors` option.
+- Added the `dig.RootCause` function which allows retrieving the original
+  constructor error that caused an `Invoke` failure.
 
 ## v1.0.0 (2017-07-31)
 

--- a/dig.go
+++ b/dig.go
@@ -119,10 +119,6 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 // The function may return an error to indicate failure. The error will be
 // returned to the caller as-is.
 func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
-	return c.invoke(function, opts...)
-}
-
-func (c *Container) invoke(function interface{}, opts ...InvokeOption) error {
 	ftype := reflect.TypeOf(function)
 	if ftype == nil {
 		return errors.New("can't invoke an untyped nil")

--- a/dig.go
+++ b/dig.go
@@ -45,11 +45,6 @@ type Option interface {
 	unimplemented()
 }
 
-// optionFunc is a function-based implementation of Option.
-type optionFunc func(*Container)
-
-func (f optionFunc) applyOption(c *Container) { f(c) }
-
 // A ProvideOption modifies the default behavior of Provide. It's included for
 // future functionality; currently, there are no concrete implementations.
 type ProvideOption interface {

--- a/dig.go
+++ b/dig.go
@@ -42,7 +42,7 @@ type key struct {
 // Option configures a Container. It's included for future functionality;
 // currently, there are no concrete implementations.
 type Option interface {
-	applyOption(*Container)
+	unimplemented()
 }
 
 // optionFunc is a function-based implementation of Option.
@@ -67,8 +67,6 @@ type Container struct {
 	nodes map[key]*node
 	cache map[key]reflect.Value
 
-	wrapErrors bool
-
 	// TODO: for advanced use-case, add an index
 	// This will allow retrieval of a single type, without specifying the exact
 	// tag, provided there is only one object of that given type
@@ -81,27 +79,10 @@ type Container struct {
 
 // New constructs a Container.
 func New(opts ...Option) *Container {
-	c := &Container{
-		nodes:      make(map[key]*node),
-		cache:      make(map[key]reflect.Value),
-		wrapErrors: true,
+	return &Container{
+		nodes: make(map[key]*node),
+		cache: make(map[key]reflect.Value),
 	}
-
-	for _, opt := range opts {
-		opt.applyOption(c)
-	}
-	return c
-}
-
-// WrapErrors enables or disables wrapping of errors returned by user
-// functions.
-//
-// If enabled, errors returned by user-provided constructors will be wrapped
-// with more contextual information to aid in debugging the failure.
-//
-// Defaults to true.
-func WrapErrors(shouldWrap bool) Option {
-	return optionFunc(func(c *Container) { c.wrapErrors = shouldWrap })
 }
 
 // Provide teaches the container how to build values of one or more types and
@@ -143,12 +124,7 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 // The function may return an error to indicate failure. The error will be
 // returned to the caller as-is.
 func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
-	err := c.invoke(function, opts...)
-	// If error wrapping wasn't requested, return the root cause.
-	if !c.wrapErrors {
-		err = errRootCause(err)
-	}
-	return err
+	return c.invoke(function, opts...)
 }
 
 func (c *Container) invoke(function interface{}, opts ...InvokeOption) error {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1292,6 +1292,7 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected invoke error")
 		assert.Contains(t, err.Error(), "couldn't get arguments for constructor", "unexpected error text")
+		assert.Contains(t, err.Error(), ": failed", "unexpected error text")
 		assert.Equal(t, errFailed, RootCause(err), "root cause must match")
 	})
 
@@ -1418,6 +1419,7 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(A) { panic("impossible") })
 
 		require.Error(t, err, "expected Invoke error")
+		assert.Contains(t, err.Error(), ": great sadness")
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
 	})
 
@@ -1438,6 +1440,7 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(B) { panic("impossible") })
 
 		require.Error(t, err, "expected Invoke error")
+		assert.Contains(t, err.Error(), ": great sadness")
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
 	})
 
@@ -1459,6 +1462,7 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(params) { panic("impossible") })
 
 		require.Error(t, err, "expected Invoke error")
+		assert.Contains(t, err.Error(), ": great sadness")
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
 	})
 
@@ -1485,6 +1489,7 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(B) { panic("impossible") })
 
 		require.Error(t, err, "expected Invoke error")
+		assert.Contains(t, err.Error(), ": great sadness")
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
 	})
 }

--- a/error.go
+++ b/error.go
@@ -65,17 +65,12 @@ func errWrapf(err error, msg string, args ...interface{}) error {
 		return nil
 	}
 
-	rootCause := err
-	if we, ok := err.(wrappedError); ok {
-		rootCause = we.rootCause
-	}
-
 	if len(args) > 0 {
 		msg = fmt.Sprintf(msg, args...)
 	}
 
 	return wrappedError{
-		rootCause: rootCause,
+		rootCause: RootCause(err),
 		err:       fmt.Errorf("%v: %v", msg, err),
 	}
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import "fmt"
+
+// errRootCause returns the root cause of the provided error.
+//
+// Returns the error as-is if no root cause is known.
+func errRootCause(err error) error {
+	if we, ok := err.(wrappedError); ok {
+		return we.rootCause
+	}
+	return err
+}
+
+// errWrapf wraps an existing error with more contextual information.
+//
+// The message for the returned error is the provided error prepended with the
+// provided message, separated by a ":".
+//
+// The given error is treated as the root cause of the returned error,
+// retrievable by using errRootCause. If the provided error knew its root
+// cause, that knowledge is retained in the returned error.
+//
+//   errRootCaus(errWrapf(errWrapf(err, ...), ...)) == err
+//
+// Use errWrapf in the rest of dig in place of fmt.Errorf if the message ends
+// with ": <original error>".
+func errWrapf(err error, msg string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	rootCause := err
+	if we, ok := err.(wrappedError); ok {
+		rootCause = we.rootCause
+	}
+
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args...)
+	}
+
+	return wrappedError{
+		rootCause: rootCause,
+		err:       fmt.Errorf("%v: %v", msg, err),
+	}
+}
+
+// wrappedError is a wrapper around error that tracks the root cause of the
+// error.
+//
+// The root cause will be retained between errWrapf calls and retrievable by
+// using errRootCause.
+type wrappedError struct {
+	rootCause error
+	err       error
+}
+
+func (e wrappedError) Error() string {
+	return e.err.Error()
+}

--- a/error.go
+++ b/error.go
@@ -22,6 +22,20 @@ package dig
 
 import "fmt"
 
+// wrappedError is a wrapper around error that tracks the root cause of the
+// error.
+//
+// The root cause will be retained between errWrapf calls and retrievable by
+// using RootCause.
+type wrappedError struct {
+	rootCause error
+	err       error
+}
+
+func (e wrappedError) Error() string {
+	return e.err.Error()
+}
+
 // RootCause returns the original error that caused the provided dig failure.
 //
 // RootCause may be used on errors returned by Invoke to get the original
@@ -64,18 +78,4 @@ func errWrapf(err error, msg string, args ...interface{}) error {
 		rootCause: rootCause,
 		err:       fmt.Errorf("%v: %v", msg, err),
 	}
-}
-
-// wrappedError is a wrapper around error that tracks the root cause of the
-// error.
-//
-// The root cause will be retained between errWrapf calls and retrievable by
-// using RootCause.
-type wrappedError struct {
-	rootCause error
-	err       error
-}
-
-func (e wrappedError) Error() string {
-	return e.err.Error()
 }

--- a/error.go
+++ b/error.go
@@ -22,10 +22,11 @@ package dig
 
 import "fmt"
 
-// errRootCause returns the root cause of the provided error.
+// RootCause returns the original error that caused the provided dig failure.
 //
-// Returns the error as-is if no root cause is known.
-func errRootCause(err error) error {
+// RootCause may be used on errors returned by Invoke to get the original
+// error returned by a constructor or invoked function.
+func RootCause(err error) error {
 	if we, ok := err.(wrappedError); ok {
 		return we.rootCause
 	}
@@ -38,10 +39,10 @@ func errRootCause(err error) error {
 // provided message, separated by a ":".
 //
 // The given error is treated as the root cause of the returned error,
-// retrievable by using errRootCause. If the provided error knew its root
+// retrievable by using RootCause. If the provided error knew its root
 // cause, that knowledge is retained in the returned error.
 //
-//   errRootCaus(errWrapf(errWrapf(err, ...), ...)) == err
+//   RootCause(errWrapf(errWrapf(err, ...), ...)) == err
 //
 // Use errWrapf in the rest of dig in place of fmt.Errorf if the message ends
 // with ": <original error>".
@@ -69,7 +70,7 @@ func errWrapf(err error, msg string, args ...interface{}) error {
 // error.
 //
 // The root cause will be retained between errWrapf calls and retrievable by
-// using errRootCause.
+// using RootCause.
 type wrappedError struct {
 	rootCause error
 	err       error

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrWrapf(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		err := errWrapf(nil, "hi")
+		assert.NoError(t, err, "expected no error")
+		assert.NoError(t, errRootCause(err), "root cause must be nil")
+	})
+
+	t.Run("single wrap", func(t *testing.T) {
+		err := errors.New("great sadness")
+		werr := errWrapf(err, "something went %s", "wrong")
+
+		assert.Equal(t, err, errRootCause(werr), "root cause must match")
+		assert.Equal(t, "something went wrong: great sadness", werr.Error(),
+			"error message must match")
+	})
+
+	t.Run("double wrap", func(t *testing.T) {
+		err := errors.New("great sadness")
+
+		werr := errWrapf(err, "something went %s", "wrong")
+		werr = errWrapf(werr, "something else went wrong")
+
+		assert.Equal(t, err, errRootCause(werr), "root cause must match")
+		assert.Equal(t, "something else went wrong: something went wrong: great sadness", werr.Error(),
+			"error message must match")
+	})
+}

--- a/error_test.go
+++ b/error_test.go
@@ -31,14 +31,14 @@ func TestErrWrapf(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		err := errWrapf(nil, "hi")
 		assert.NoError(t, err, "expected no error")
-		assert.NoError(t, errRootCause(err), "root cause must be nil")
+		assert.NoError(t, RootCause(err), "root cause must be nil")
 	})
 
 	t.Run("single wrap", func(t *testing.T) {
 		err := errors.New("great sadness")
 		werr := errWrapf(err, "something went %s", "wrong")
 
-		assert.Equal(t, err, errRootCause(werr), "root cause must match")
+		assert.Equal(t, err, RootCause(werr), "root cause must match")
 		assert.Equal(t, "something went wrong: great sadness", werr.Error(),
 			"error message must match")
 	})
@@ -49,7 +49,7 @@ func TestErrWrapf(t *testing.T) {
 		werr := errWrapf(err, "something went %s", "wrong")
 		werr = errWrapf(werr, "something else went wrong")
 
-		assert.Equal(t, err, errRootCause(werr), "root cause must match")
+		assert.Equal(t, err, RootCause(werr), "root cause must match")
 		assert.Equal(t, "something else went wrong: something went wrong: great sadness", werr.Error(),
 			"error message must match")
 	})


### PR DESCRIPTION
This adds a new `dig.RootCause(error) error` function which retrieves the
original error that caused an Invoke to fail.

See #145 for motivation but the gist of it is, this makes it possible to
retrieve and act upon the original error that a constructor of a dependency
returned when an Invoke call is made.

Implementation:
We use a custom error wrapper for `fmt.Errorf` calls which include the
original error at the end. So,

    return fmt.Errorf("something went wrong: %v", err)

Becomes,

    return errWrapf(err, "something went wrong")

The wrapper tracks the original `err` and `RootCause` is just an accessor for
it.

Because this came up offline: We're not using pkg/errors because we want to
return the error returned by the user-provided constructor. If we use pkg/
errors, and the user-provided constructor also uses pkg/errors, we won't
return what the user returned but rather, the root cause of that error.

Resolves #145