### PR TITLE
Better error messaging during mixed types usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added the `dig.RootCause` function which allows retrieving the original
   constructor error that caused an `Invoke` failure.
+- Errors from `Invoke` now attempt to hint to the user a precense of a very
+  similar type, for example a pointer to the requested type and vice versa.
 
 ## v1.0.0 (2017-07-31)
 

--- a/dig.go
+++ b/dig.go
@@ -293,6 +293,23 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		if e.optional {
 			return reflect.Zero(e.t), nil
 		}
+
+		// If the type being asked for is the pointer that is not found,
+		// check if the graph contains the value type element - perhaps the user
+		// accidentally included a splat and vice versa.
+		var typo reflect.Type
+		if e.t.Kind() == reflect.Ptr {
+			typo = e.t.Elem()
+		} else {
+			typo = reflect.PtrTo(e.t)
+		}
+
+		tk := key{t: typo, name: e.name}
+		if _, ok := c.nodes[tk]; ok {
+			return _noValue, fmt.Errorf(
+				"type %v is not in the container, did you mean to use %v that is present?", e.key, tk)
+		}
+
 		return _noValue, fmt.Errorf("type %v isn't in the container", e.key)
 	}
 

--- a/dig.go
+++ b/dig.go
@@ -290,6 +290,9 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 
 	n, ok := c.nodes[e.key]
 	if !ok {
+		// Unlike in the fallback case below, if a user makes an error requesting
+		// a mixed type for an optional parameter, a good error message "did you mean X?"
+		// will not be used and dig will return zero value.
 		if e.optional {
 			return reflect.Zero(e.t), nil
 		}

--- a/dig.go
+++ b/dig.go
@@ -310,7 +310,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		tk := key{t: typo, name: e.name}
 		if _, ok := c.nodes[tk]; ok {
 			return _noValue, fmt.Errorf(
-				"type %v is not in the container, did you mean to use %v that is present?", e.key, tk)
+				"type %v is not in the container, did you mean to use %v?", e.key, tk)
 		}
 
 		return _noValue, fmt.Errorf("type %v isn't in the container", e.key)

--- a/dig_test.go
+++ b/dig_test.go
@@ -1403,4 +1403,60 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Contains(t, err.Error(), "dig.in embeds *dig.In")
 		assert.Contains(t, err.Error(), "embed dig.In value instead")
 	})
+
+	t.Run("requesting a value or pointer when other is present", func(t *testing.T) {
+		type A struct{}
+		type outA struct {
+			Out
+
+			A `name:"hello"`
+		}
+		type B struct{}
+
+		cases := []struct {
+			name        string
+			provide     interface{}
+			invoke      interface{}
+			errContains []string
+		}{
+			{
+				name:        "value missing, pointer present",
+				provide:     func() *A { return &A{} },
+				invoke:      func(A) {},
+				errContains: []string{"dig.A is not in the container, did you mean to use *dig.A"},
+			},
+			{
+				name:        "pointer missing, value present",
+				provide:     func() A { return A{} },
+				invoke:      func(*A) {},
+				errContains: []string{"*dig.A is not in the container, did you mean to use dig.A"},
+			},
+			{
+				name:    "named pointer missing, value present",
+				provide: func() outA { return outA{A: A{}} },
+				invoke: func(struct {
+					In
+
+					*A `name:"hello"`
+				}) {
+				},
+				errContains: []string{
+					"*dig.A:hello is not in the container",
+					"did you mean to use dig.A:hello"},
+			},
+		}
+
+		for _, tc := range cases {
+			c := New()
+			t.Run(tc.name, func(t *testing.T) {
+				require.NoError(t, c.Provide(tc.provide))
+
+				err := c.Invoke(tc.invoke)
+				require.Error(t, err)
+				for _, e := range tc.errContains {
+					assert.Contains(t, err.Error(), e)
+				}
+			})
+		}
+	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -1420,19 +1420,19 @@ func TestInvokeFailures(t *testing.T) {
 			name        string
 			provide     interface{}
 			invoke      interface{}
-			errContains []string
+			errContains string
 		}{
 			{
 				name:        "value missing, pointer present",
 				provide:     func() *A { return &A{} },
 				invoke:      func(A) {},
-				errContains: []string{"dig.A is not in the container, did you mean to use *dig.A?"},
+				errContains: "dig.A is not in the container, did you mean to use *dig.A?",
 			},
 			{
 				name:        "pointer missing, value present",
 				provide:     func() A { return A{} },
 				invoke:      func(*A) {},
-				errContains: []string{"*dig.A is not in the container, did you mean to use dig.A?"},
+				errContains: "*dig.A is not in the container, did you mean to use dig.A?",
 			},
 			{
 				name:    "named pointer missing, value present",
@@ -1443,9 +1443,7 @@ func TestInvokeFailures(t *testing.T) {
 					*A `name:"hello"`
 				}) {
 				},
-				errContains: []string{
-					"*dig.A:hello is not in the container",
-					"did you mean to use dig.A:hello?"},
+				errContains: "*dig.A:hello is not in the container, did you mean to use dig.A:hello?",
 			},
 		}
 
@@ -1456,9 +1454,7 @@ func TestInvokeFailures(t *testing.T) {
 
 				err := c.Invoke(tc.invoke)
 				require.Error(t, err)
-				for _, e := range tc.errContains {
-					assert.Contains(t, err.Error(), e)
-				}
+				assert.Contains(t, err.Error(), tc.errContains)
 			})
 		}
 	})

--- a/dig_test.go
+++ b/dig_test.go
@@ -1426,13 +1426,13 @@ func TestInvokeFailures(t *testing.T) {
 				name:        "value missing, pointer present",
 				provide:     func() *A { return &A{} },
 				invoke:      func(A) {},
-				errContains: []string{"dig.A is not in the container, did you mean to use *dig.A"},
+				errContains: []string{"dig.A is not in the container, did you mean to use *dig.A?"},
 			},
 			{
 				name:        "pointer missing, value present",
 				provide:     func() A { return A{} },
 				invoke:      func(*A) {},
-				errContains: []string{"*dig.A is not in the container, did you mean to use dig.A"},
+				errContains: []string{"*dig.A is not in the container, did you mean to use dig.A?"},
 			},
 			{
 				name:    "named pointer missing, value present",
@@ -1445,7 +1445,7 @@ func TestInvokeFailures(t *testing.T) {
 				},
 				errContains: []string{
 					"*dig.A:hello is not in the container",
-					"did you mean to use dig.A:hello"},
+					"did you mean to use dig.A:hello?"},
 			},
 		}
 
@@ -1461,6 +1461,7 @@ func TestInvokeFailures(t *testing.T) {
 				}
 			})
 		}
+	})
 
 	t.Run("direct dependency error", func(t *testing.T) {
 		type A struct{}


### PR DESCRIPTION
This is something that has been mentioned several times - it's very easy
to request a wrong type on accident - is it a pointer? is it value type?
In a large enough framework base it's a giant mix of both. This adds a
much better error message when dig is able to detect an easily
correctable case.

Fixes #147