### PR TITLE
Provide: Inspect constructor parameters upfront

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,8 @@ coverage:
                                #   option: "X%" a static target percentage to hit
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure
+
+    patch:
+      default:
+        enabled: yes
+        target: 95

--- a/dig.go
+++ b/dig.go
@@ -248,7 +248,7 @@ func traverseOutTypes(k key, f func(key) error) error {
 
 		if field.PkgPath != "" {
 			return fmt.Errorf(
-				"private fields not allowed in dig.Out, did you mean to export %q (%v) from %v",
+				"unexported fields not allowed in dig.Out, did you mean to export %q (%v) from %v",
 				field.Name, field.Type, k.t)
 		}
 
@@ -362,7 +362,7 @@ func (c *Container) createInObject(t reflect.Type) (reflect.Value, error) {
 
 		if f.PkgPath != "" {
 			return dest, fmt.Errorf(
-				"private fields not allowed in dig.In, did you mean to export %q (%v) from %v?",
+				"unexported fields not allowed in dig.In, did you mean to export %q (%v) from %v?",
 				f.Name, f.Type, t)
 		}
 

--- a/dig.go
+++ b/dig.go
@@ -316,7 +316,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		return _noValue, fmt.Errorf("type %v isn't in the container", e.key)
 	}
 
-	if err := c.contains(n.deps); err != nil {
+	if err := c.contains(n.Params.Dependencies()); err != nil {
 		if e.optional {
 			return reflect.Zero(e.t), nil
 		}
@@ -438,7 +438,9 @@ type node struct {
 
 	ctor  interface{}
 	ctype reflect.Type
-	deps  []edge
+
+	// Type information about constructor parameters.
+	Params paramList
 }
 
 type edge struct {
@@ -448,27 +450,17 @@ type edge struct {
 }
 
 func newNode(k key, ctor interface{}, ctype reflect.Type) (*node, error) {
-	deps, err := getConstructorDependencies(ctype)
-	return &node{
-		key:   k,
-		ctor:  ctor,
-		ctype: ctype,
-		deps:  deps,
-	}, err
-}
-
-// Retrieves the dependencies for a constructor
-func getConstructorDependencies(ctype reflect.Type) ([]edge, error) {
-	var deps []edge
-	for _, t := range getConstructorArgTypes(ctype) {
-		err := traverseInTypes(t, func(e edge) {
-			deps = append(deps, e)
-		})
-		if err != nil {
-			return nil, err
-		}
+	params, err := newParamList(ctype)
+	if err != nil {
+		return nil, err
 	}
-	return deps, nil
+
+	return &node{
+		key:    k,
+		ctor:   ctor,
+		ctype:  ctype,
+		Params: params,
+	}, err
 }
 
 // Retrieves the types of the arguments of a constructor in-order.
@@ -507,7 +499,7 @@ func detectCycles(n *node, graph map[key]*node, path []key) error {
 		}
 	}
 	path = append(path, n.key)
-	for _, dep := range n.deps {
+	for _, dep := range n.Params.Dependencies() {
 		depNode, ok := graph[dep.key]
 		if !ok {
 			continue
@@ -516,38 +508,6 @@ func detectCycles(n *node, graph map[key]*node, path []key) error {
 			return err
 		}
 	}
-	return nil
-}
-
-// Traverse all fields starting with the given type.
-// Types that dig.In get recursed on. Returns the first error encountered.
-func traverseInTypes(t reflect.Type, fn func(edge)) error {
-	if !IsIn(t) {
-		fn(edge{key: key{t: t}})
-		return nil
-	}
-
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-		if f.PkgPath != "" {
-			continue // skip private fields
-		}
-
-		if IsIn(f.Type) {
-			if err := traverseInTypes(f.Type, fn); err != nil {
-				return err
-			}
-			continue
-		}
-
-		optional, err := isFieldOptional(t, f)
-		if err != nil {
-			return err
-		}
-
-		fn(edge{key: key{t: f.Type, name: f.Tag.Get(_nameTag)}, optional: optional})
-	}
-
 	return nil
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1062,7 +1062,7 @@ func TestProvideFailures(t *testing.T) {
 		assert.Contains(t, err.Error(), "provides *dig.A:foo, which is already in the container")
 	})
 
-	t.Run("out with private field should error", func(t *testing.T) {
+	t.Run("out with unexported field should error", func(t *testing.T) {
 		c := New()
 
 		type A struct{ idx int }
@@ -1070,11 +1070,11 @@ func TestProvideFailures(t *testing.T) {
 			Out
 
 			A1 A // should be ok
-			a2 A // oops, private field. should generate an error
+			a2 A // oops, unexported field. should generate an error
 		}
 		err := c.Provide(func() out1 { return out1{a2: A{77}} })
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "private fields not allowed in dig.Out")
+		assert.Contains(t, err.Error(), "unexported fields not allowed in dig.Out")
 		assert.Contains(t, err.Error(), `"a2" (dig.A)`)
 		assert.Contains(t, err.Error(), "did you mean to export")
 	})
@@ -1330,25 +1330,25 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Contains(t, err.Error(), "dig.A:camelcase isn't in the container")
 	})
 
-	t.Run("in private member gets an error", func(t *testing.T) {
+	t.Run("in unexported member gets an error", func(t *testing.T) {
 		c := New()
 		type A struct{}
 		type in struct {
 			In
 
 			A1 A // all is good
-			a2 A // oops, private type
+			a2 A // oops, unexported type
 		}
 		require.NoError(t, c.Provide(func() A { return A{} }))
 
 		err := c.Invoke(func(i in) { assert.Fail(t, "should never get in here") })
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
+		assert.Contains(t, err.Error(), "unexported fields not allowed in dig.In")
 		assert.Contains(t, err.Error(), `"a2" (dig.A)`)
 		assert.Contains(t, err.Error(), "did you mean to export")
 	})
 
-	t.Run("in private member gets an error on Provide", func(t *testing.T) {
+	t.Run("in unexported member gets an error on Provide", func(t *testing.T) {
 		c := New()
 		type in struct {
 			In
@@ -1358,18 +1358,18 @@ func TestInvokeFailures(t *testing.T) {
 
 		err := c.Provide(func(in) int { return 0 })
 		require.Error(t, err, "Provide must fail")
-		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
+		assert.Contains(t, err.Error(), "unexported fields not allowed in dig.In")
 		assert.Contains(t, err.Error(), `"foo" (string)`)
 	})
 
-	t.Run("embedded private member gets an error", func(t *testing.T) {
+	t.Run("embedded unexported member gets an error", func(t *testing.T) {
 		c := New()
 		type A struct{}
 		type Embed struct {
 			In
 
 			A1 A // all is good
-			a2 A // oops, private type
+			a2 A // oops, unexported type
 		}
 		type in struct {
 			Embed
@@ -1378,10 +1378,10 @@ func TestInvokeFailures(t *testing.T) {
 
 		err := c.Invoke(func(i in) { assert.Fail(t, "should never get in here") })
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
+		assert.Contains(t, err.Error(), "unexported fields not allowed in dig.In")
 	})
 
-	t.Run("embedded private member gets an error", func(t *testing.T) {
+	t.Run("embedded unexported member gets an error", func(t *testing.T) {
 		c := New()
 		type param struct {
 			In

--- a/dig_test.go
+++ b/dig_test.go
@@ -1348,6 +1348,20 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Contains(t, err.Error(), "did you mean to export")
 	})
 
+	t.Run("in private member gets an error on Provide", func(t *testing.T) {
+		c := New()
+		type in struct {
+			In
+
+			foo string
+		}
+
+		err := c.Provide(func(in) int { return 0 })
+		require.Error(t, err, "Provide must fail")
+		assert.Contains(t, err.Error(), "private fields not allowed in dig.In")
+		assert.Contains(t, err.Error(), `"foo" (string)`)
+	})
+
 	t.Run("embedded private member gets an error", func(t *testing.T) {
 		c := New()
 		type A struct{}

--- a/param.go
+++ b/param.go
@@ -34,8 +34,6 @@ import (
 //                param.
 type (
 	param interface {
-		paramType()
-
 		// Comprehensive list of dependencies this parameter represents.
 		Dependencies() []edge
 	}
@@ -91,10 +89,6 @@ var (
 	_ param = paramObject{}
 	_ param = paramList{}
 )
-
-func (paramList) paramType()   {}
-func (paramSingle) paramType() {}
-func (paramObject) paramType() {}
 
 // newParamList builds a paramList from the provided constructor type.
 //

--- a/param.go
+++ b/param.go
@@ -36,10 +36,6 @@ type (
 	param interface {
 		param()
 
-		// Human-friendly name for this param type. We use this exclusively in
-		// error messages.
-		ParamTypeName() string
-
 		// Comprehensive list of dependencies this parameter represents.
 		Dependencies() []edge
 	}
@@ -99,10 +95,6 @@ var (
 func (paramList) param()   {}
 func (paramSingle) param() {}
 func (paramObject) param() {}
-
-func (paramList) ParamTypeName() string   { return "parameter list" }
-func (paramSingle) ParamTypeName() string { return "simple type" }
-func (paramObject) ParamTypeName() string { return "parameter object" }
 
 // newParamList builds a paramList from the provided constructor type.
 //
@@ -169,15 +161,8 @@ func newParamObject(t reflect.Type) (paramObject, error) {
 			return op, err
 		}
 
-		if name != "" || optional {
-			// If special tags were used, the field must be a simple type.
-			sp, ok := p.(paramSingle)
-			if !ok {
-				return op, fmt.Errorf(
-					"fields which use the `name` or `optional` tags must be simple types: "+
-						"field %q of %v is a %q", f.Name, t, p.ParamTypeName())
-			}
-
+		if sp, ok := p.(paramSingle); ok {
+			// Field tags apply only if the field is "simple"
 			sp.Name = name
 			sp.Optional = optional
 			p = sp

--- a/param.go
+++ b/param.go
@@ -34,7 +34,7 @@ import (
 //                param.
 type (
 	param interface {
-		param()
+		paramType()
 
 		// Comprehensive list of dependencies this parameter represents.
 		Dependencies() []edge
@@ -92,9 +92,9 @@ var (
 	_ param = paramList{}
 )
 
-func (paramList) param()   {}
-func (paramSingle) param() {}
-func (paramObject) param() {}
+func (paramList) paramType()   {}
+func (paramSingle) paramType() {}
+func (paramObject) paramType() {}
 
 // newParamList builds a paramList from the provided constructor type.
 //

--- a/param.go
+++ b/param.go
@@ -113,16 +113,13 @@ func (ps paramSingle) Dependencies() []edge {
 // paramObjectField is a single field of a dig.In struct.
 type paramObjectField struct {
 	// Name of the field in the struct.
-	//
-	// To clarify, this is the name of the *struct field*, not the name of
-	// the dig value requested by this field.
-	Name string
+	FieldName string
 
 	// Index of this field in the target struct.
 	//
 	// We need to track this separately because not all fields of the
 	// struct map to params.
-	Index int
+	FieldIndex int
 
 	// The dependency requested by this field.
 	Param param
@@ -175,9 +172,9 @@ func newParamObject(t reflect.Type) (paramObject, error) {
 		}
 
 		po.Fields = append(po.Fields, paramObjectField{
-			Name:  f.Name,
-			Index: i,
-			Param: p,
+			FieldName:  f.Name,
+			FieldIndex: i,
+			Param:      p,
 		})
 		po.deps = append(po.deps, p.Dependencies()...)
 	}

--- a/param.go
+++ b/param.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// The param interface represents a dependency for a constructor.
+//
+// The following implementations exist:
+//  paramList     All arguments of the constructor.
+//  paramSingle   An explicitly requested type.
+//  paramObject   dig.In struct where each field in the struct can be another
+//                param.
+type (
+	param interface {
+		param()
+
+		// Human-friendly name for this param type. We use this exclusively in
+		// error messages.
+		ParamTypeName() string
+
+		// Comprehensive list of dependencies this parameter represents.
+		Dependencies() []edge
+	}
+
+	// paramList holds all arguments of the constructor as params.
+	paramList struct {
+		ctype reflect.Type // type of the constructor
+
+		Params []param
+	}
+
+	// paramSingle is an explicitly requested type, optionally with a name.
+	//
+	// This object must be present in the graph as-is unless it's specified as
+	// optional.
+	paramSingle struct {
+		Name     string
+		Optional bool
+		Type     reflect.Type
+	}
+
+	// paramObject is a dig.In struct where each field is another param.
+	//
+	// This object is not expected in the graph as-is.
+	paramObject struct {
+		Type   reflect.Type
+		Fields []paramObjectField
+
+		deps []edge
+	}
+
+	// paramObjectField is a single field of a dig.In struct.
+	paramObjectField struct {
+		// Name of the field specified via a name:".." tag.
+		Name string
+
+		// Index of this field in the target struct.
+		//
+		// We need to track this separately because not all fields of the
+		// struct map to params.
+		Index int
+
+		// The dependency requested by this field.
+		Param param
+	}
+)
+
+var (
+	_ param = paramSingle{}
+	_ param = paramObject{}
+	_ param = paramList{}
+)
+
+func (paramList) param()   {}
+func (paramSingle) param() {}
+func (paramObject) param() {}
+
+func (paramList) ParamTypeName() string   { return "parameter list" }
+func (paramSingle) ParamTypeName() string { return "simple type" }
+func (paramObject) ParamTypeName() string { return "parameter object" }
+
+// newParamList builds a paramList from the provided constructor type.
+//
+// Variadic arguments of a constructor are ignored and not included as
+// dependencies.
+func newParamList(ctype reflect.Type) (paramList, error) {
+	numArgs := ctype.NumIn()
+	if ctype.IsVariadic() {
+		// NOTE: If the function is variadic, we skip the last argument
+		// because we're not filling variadic arguments yet. See #120.
+		numArgs--
+	}
+
+	pl := paramList{
+		ctype:  ctype,
+		Params: make([]param, 0, numArgs),
+	}
+
+	for i := 0; i < numArgs; i++ {
+		p, err := newParam(ctype.In(i))
+		if err != nil {
+			return pl, errWrapf(err, "bad argument %d", i+1)
+		}
+		pl.Params = append(pl.Params, p)
+	}
+	return pl, nil
+}
+
+// newParam builds a param from the given type. If the provided type is a
+// dig.In struct, an paramObject will be returned.
+func newParam(t reflect.Type) (param, error) {
+	if IsIn(t) {
+		return newParamObject(t)
+	}
+	return paramSingle{Type: t}, nil
+}
+
+// newParamObject builds an paramObject from the provided type. The type MUST
+// be a dig.In struct.
+func newParamObject(t reflect.Type) (paramObject, error) {
+	op := paramObject{Type: t}
+
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Type == _inType {
+			// Skip over the dig.In embed.
+			continue
+		}
+
+		if f.PkgPath != "" {
+			return op, fmt.Errorf(
+				"private fields not allowed in dig.In, did you mean to export %q (%v) from %v?",
+				f.Name, f.Type, t)
+		}
+
+		p, err := newParam(f.Type)
+		if err != nil {
+			return op, errWrapf(err, "bad field %q of %v", f.Name, t)
+		}
+
+		name := f.Tag.Get(_nameTag)
+		optional, err := isFieldOptional(t, f)
+		if err != nil {
+			return op, err
+		}
+
+		if name != "" || optional {
+			// If special tags were used, the field must be a simple type.
+			sp, ok := p.(paramSingle)
+			if !ok {
+				return op, fmt.Errorf(
+					"fields which use the `name` or `optional` tags must be simple types: "+
+						"field %q of %v is a %q", f.Name, t, p.ParamTypeName())
+			}
+
+			sp.Name = name
+			sp.Optional = optional
+			p = sp
+		}
+
+		op.Fields = append(op.Fields, paramObjectField{
+			Name:  f.Name,
+			Index: i,
+			Param: p,
+		})
+		op.deps = append(op.deps, p.Dependencies()...)
+	}
+	return op, nil
+}
+
+func (pl paramList) Dependencies() []edge {
+	var deps []edge
+	for _, p := range pl.Params {
+		deps = append(deps, p.Dependencies()...)
+	}
+	return deps
+}
+
+func (p paramSingle) Dependencies() []edge {
+	return []edge{
+		{key: key{t: p.Type, name: p.Name}, optional: p.Optional},
+	}
+}
+
+func (op paramObject) Dependencies() []edge { return op.deps }

--- a/param.go
+++ b/param.go
@@ -73,7 +73,10 @@ type (
 
 	// paramObjectField is a single field of a dig.In struct.
 	paramObjectField struct {
-		// Name of the field specified via a name:".." tag.
+		// Name of the field in the struct.
+		//
+		// To clarify, this is the name of the *struct field*, not the name of
+		// the dig value requested by this field.
 		Name string
 
 		// Index of this field in the target struct.

--- a/param.go
+++ b/param.go
@@ -149,7 +149,7 @@ func newParamObject(t reflect.Type) (paramObject, error) {
 
 		if f.PkgPath != "" {
 			return po, fmt.Errorf(
-				"private fields not allowed in dig.In, did you mean to export %q (%v) from %v?",
+				"unexported fields not allowed in dig.In, did you mean to export %q (%v) from %v?",
 				f.Name, f.Type, t)
 		}
 

--- a/param_test.go
+++ b/param_test.go
@@ -54,7 +54,7 @@ func TestParamObjectSuccess(t *testing.T) {
 	require.Len(t, po.Fields, 4)
 
 	t.Run("no tags", func(t *testing.T) {
-		require.Equal(t, "T1", po.Fields[0].Name)
+		require.Equal(t, "T1", po.Fields[0].FieldName)
 		t1, ok := po.Fields[0].Param.(paramSingle)
 		require.True(t, ok, "T1 must be a paramSingle")
 		assert.Empty(t, t1.Name)
@@ -63,7 +63,7 @@ func TestParamObjectSuccess(t *testing.T) {
 	})
 
 	t.Run("optional field", func(t *testing.T) {
-		require.Equal(t, "T2", po.Fields[1].Name)
+		require.Equal(t, "T2", po.Fields[1].FieldName)
 
 		t2, ok := po.Fields[1].Param.(paramSingle)
 		require.True(t, ok, "T2 must be a paramSingle")
@@ -73,7 +73,7 @@ func TestParamObjectSuccess(t *testing.T) {
 	})
 
 	t.Run("named value", func(t *testing.T) {
-		require.Equal(t, "T3", po.Fields[2].Name)
+		require.Equal(t, "T3", po.Fields[2].FieldName)
 		t3, ok := po.Fields[2].Param.(paramSingle)
 		require.True(t, ok, "T3 must be a paramSingle")
 		assert.Equal(t, "foo", t3.Name)
@@ -81,7 +81,7 @@ func TestParamObjectSuccess(t *testing.T) {
 	})
 
 	t.Run("tags don't apply to nested dig.In", func(t *testing.T) {
-		require.Equal(t, "Nested", po.Fields[3].Name)
+		require.Equal(t, "Nested", po.Fields[3].FieldName)
 		nested, ok := po.Fields[3].Param.(paramObject)
 		require.True(t, ok, "Nested must be a paramObject")
 

--- a/param_test.go
+++ b/param_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParamObjectSuccess(t *testing.T) {
+	type type1 struct{}
+	type type2 struct{}
+	type type3 struct{}
+
+	type in struct {
+		In
+
+		T1 type1
+		T2 type2 `optional:"true"`
+		T3 type3 `name:"foo"`
+
+		Nested struct {
+			In
+
+			A string
+			B int32
+		} `name:"bar"`
+	}
+
+	po, err := newParamObject(reflect.TypeOf(in{}))
+	require.NoError(t, err)
+
+	require.Len(t, po.Fields, 4)
+
+	t.Run("no tags", func(t *testing.T) {
+		require.Equal(t, "T1", po.Fields[0].Name)
+		t1, ok := po.Fields[0].Param.(paramSingle)
+		require.True(t, ok, "T1 must be a paramSingle")
+		assert.Empty(t, t1.Name)
+		assert.False(t, t1.Optional)
+
+	})
+
+	t.Run("optional field", func(t *testing.T) {
+		require.Equal(t, "T2", po.Fields[1].Name)
+
+		t2, ok := po.Fields[1].Param.(paramSingle)
+		require.True(t, ok, "T2 must be a paramSingle")
+		assert.Empty(t, t2.Name)
+		assert.True(t, t2.Optional)
+
+	})
+
+	t.Run("named value", func(t *testing.T) {
+		require.Equal(t, "T3", po.Fields[2].Name)
+		t3, ok := po.Fields[2].Param.(paramSingle)
+		require.True(t, ok, "T3 must be a paramSingle")
+		assert.Equal(t, "foo", t3.Name)
+		assert.False(t, t3.Optional)
+	})
+
+	t.Run("tags don't apply to nested dig.In", func(t *testing.T) {
+		require.Equal(t, "Nested", po.Fields[3].Name)
+		nested, ok := po.Fields[3].Param.(paramObject)
+		require.True(t, ok, "Nested must be a paramObject")
+
+		assert.Len(t, nested.Fields, 2)
+		a, ok := nested.Fields[0].Param.(paramSingle)
+		require.True(t, ok, "Nested.A must be a paramSingle")
+		assert.Empty(t, a.Name, "Nested.A must not have a name")
+	})
+}
+
+func TestParamObjectFailure(t *testing.T) {
+	t.Run("private field gets an error", func(t *testing.T) {
+		type A struct{}
+		type in struct {
+			In
+
+			A1 A
+			a2 A
+		}
+
+		_, err := newParamObject(reflect.TypeOf(in{}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(),
+			`private fields not allowed in dig.In, did you mean to export "a2" (dig.A) from dig.in?`)
+	})
+}

--- a/param_test.go
+++ b/param_test.go
@@ -93,7 +93,7 @@ func TestParamObjectSuccess(t *testing.T) {
 }
 
 func TestParamObjectFailure(t *testing.T) {
-	t.Run("private field gets an error", func(t *testing.T) {
+	t.Run("unexported field gets an error", func(t *testing.T) {
 		type A struct{}
 		type in struct {
 			In
@@ -105,6 +105,6 @@ func TestParamObjectFailure(t *testing.T) {
 		_, err := newParamObject(reflect.TypeOf(in{}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(),
-			`private fields not allowed in dig.In, did you mean to export "a2" (dig.A) from dig.in?`)
+			`unexported fields not allowed in dig.In, did you mean to export "a2" (dig.A) from dig.in?`)
 	})
 }

--- a/stringer.go
+++ b/stringer.go
@@ -44,8 +44,9 @@ func (c *Container) String() string {
 }
 
 func (n *node) String() string {
-	deps := make([]string, len(n.deps))
-	for i, d := range n.deps {
+	paramDeps := n.Params.Dependencies()
+	deps := make([]string, len(paramDeps))
+	for i, d := range paramDeps {
 		if d.optional {
 			// ~tally.Scope means optional
 			// ~tally.Scope:foo means named optional


### PR DESCRIPTION
As a first-step to DRYing up the graph resolution logic in dig, this
changes Provide to inspect constructors in more detail upfront.

Their dependencies, whether they are dig.In objects, etc. is now
known on the Provide path rather than Invoke.

This information is stored with the help of a `param` interface which
unionizes the following parameter types:

- paramList: List of parameters of a constructor
- paramSingle: Basic argument type. Nothing special about this
- paramObject: `dig.In` object whose fields are other `param`s

This opens room for more `param` types.

Note: The `Dependencies()` method will be removed in a future change. It
exists only to minimize the impact of this specific change.

Also note that no new errors are being surfaced to the user. All errors
returned here are copies of existing errors returned by the library. Of
note is the logic in `newParamObject` which returns an error when
private fields are encountered. In dig currently, that logic exists in
two places:

- https://github.com/uber-go/dig/blob/809ed57c66b4c4b74e882be9da77d997ec439cde/dig.go#L363-L367
- https://github.com/uber-go/dig/blob/809ed57c66b4c4b74e882be9da77d997ec439cde/dig.go#L532-L534

If you look at the implementations, one of them skips private fields
while the other returns an error. The one that errors out does so at
`Invoke` time rather than `Provide`. With this change, the error will be
returned at `Provide` time instead, which is preferable anyway. This is
not actually a breaking change because we're failing fast rather than
waiting for an Invoke.