### PR TITLE
Implement String() using `param`s

### DIFF
--- a/param.go
+++ b/param.go
@@ -33,7 +33,7 @@ import (
 //  paramObject   dig.In struct where each field in the struct can be another
 //                param.
 type param interface {
-	String() string
+	fmt.Stringer
 
 	// Comprehensive list of dependencies this parameter represents.
 	Dependencies() []edge

--- a/param.go
+++ b/param.go
@@ -33,6 +33,8 @@ import (
 //  paramObject   dig.In struct where each field in the struct can be another
 //                param.
 type param interface {
+	String() string
+
 	// Comprehensive list of dependencies this parameter represents.
 	Dependencies() []edge
 }

--- a/stringer.go
+++ b/stringer.go
@@ -23,6 +23,7 @@ package dig
 import (
 	"bytes"
 	"fmt"
+	"strings"
 )
 
 // String representation of the entire Container
@@ -44,20 +45,7 @@ func (c *Container) String() string {
 }
 
 func (n *node) String() string {
-	paramDeps := n.Params.Dependencies()
-	deps := make([]string, len(paramDeps))
-	for i, d := range paramDeps {
-		if d.optional {
-			// ~tally.Scope means optional
-			// ~tally.Scope:foo means named optional
-			deps[i] = fmt.Sprintf("~%v", d.key)
-			continue
-		}
-		deps[i] = d.key.String()
-	}
-	return fmt.Sprintf(
-		"deps: %v, ctor: %v", deps, n.ctype,
-	)
+	return fmt.Sprintf("deps: %v, ctor: %v", n.Params, n.ctype)
 }
 
 func (k key) String() string {
@@ -65,4 +53,35 @@ func (k key) String() string {
 		return fmt.Sprintf("%v:%s", k.t, k.name)
 	}
 	return k.t.String()
+}
+
+func (pl paramList) String() string {
+	args := make([]string, len(pl.Params))
+	for i, p := range pl.Params {
+		args[i] = p.String()
+	}
+	return fmt.Sprint(args)
+}
+
+func (sp paramSingle) String() string {
+	// ~tally.Scope means optional
+	// ~tally.Scope:foo means named optional
+
+	var prefix, suffix string
+	if sp.Optional {
+		prefix = "~"
+	}
+	if sp.Name != "" {
+		suffix = ":" + sp.Name
+	}
+
+	return fmt.Sprintf("%s%v%s", prefix, sp.Type, suffix)
+}
+
+func (op paramObject) String() string {
+	fields := make([]string, len(op.Fields))
+	for i, f := range op.Fields {
+		fields[i] = f.Param.String()
+	}
+	return strings.Join(fields, " ")
 }

--- a/stringer_test.go
+++ b/stringer_test.go
@@ -39,7 +39,7 @@ func TestStringer(t *testing.T) {
 	type D struct{}
 	type param struct {
 		In
-		*D `named:"foo" optional:"true"`
+		*D `name:"foo" optional:"true"`
 	}
 	require.NoError(t, c.Provide(func(p param) (*A, *B) { return &A{}, &B{} }))
 	require.NoError(t, c.Provide(func(*B) *C { return &C{} }))
@@ -50,8 +50,8 @@ func TestStringer(t *testing.T) {
 	s := b.String()
 
 	// all nodes are in the graph
-	assert.Contains(t, s, "*dig.A -> deps: [~*dig.D]")
-	assert.Contains(t, s, "*dig.B -> deps: [~*dig.D]")
+	assert.Contains(t, s, "*dig.A -> deps: [~*dig.D:foo]")
+	assert.Contains(t, s, "*dig.B -> deps: [~*dig.D:foo]")
 	assert.Contains(t, s, "*dig.C -> deps: [*dig.B]")
 
 	// constructors


### PR DESCRIPTION
This adds String implementations for the different `param` types and
uses those in `node.String`.