### PR TITLE
Shallow dependency check for `param` types

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -544,7 +544,7 @@ func isFieldOptional(parent reflect.Type, f reflect.StructField) (bool, error) {
 // the container. Returns an error if not.
 func shallowCheckDependencies(c *Container, p param) error {
 	var missing []key
-	forEachSimpleParam(p, func(p paramSingle) {
+	forEachParamSingle(p, func(p paramSingle) {
 		k := key{name: p.Name, t: p.Type}
 		if _, ok := c.nodes[k]; !ok && !p.Optional {
 			missing = append(missing, k)

--- a/dig.go
+++ b/dig.go
@@ -316,7 +316,7 @@ func (c *Container) get(e edge) (reflect.Value, error) {
 		return _noValue, fmt.Errorf("type %v isn't in the container", e.key)
 	}
 
-	if err := c.contains(n.Params.Dependencies()); err != nil {
+	if err := shallowCheckDependencies(c, n.Params); err != nil {
 		if e.optional {
 			return reflect.Zero(e.t), nil
 		}
@@ -399,19 +399,6 @@ func (c *Container) set(k key, v reflect.Value) {
 		fk := key{t: f.Type, name: f.Tag.Get(_nameTag)}
 		c.set(fk, v.Field(i))
 	}
-}
-
-func (c *Container) contains(deps []edge) error {
-	var missing []key
-	for _, d := range deps {
-		if _, ok := c.nodes[d.key]; !ok && !d.optional {
-			missing = append(missing, d.key)
-		}
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("container is missing: %v", missing)
-	}
-	return nil
 }
 
 func (c *Container) remove(nodes []*node) {
@@ -551,4 +538,20 @@ func isFieldOptional(parent reflect.Type, f reflect.StructField) (bool, error) {
 	}
 
 	return optional, err
+}
+
+// Checks that all direct dependencies of the provided param are present in
+// the container. Returns an error if not.
+func shallowCheckDependencies(c *Container, p param) error {
+	var missing []key
+	forEachSimpleParam(p, func(p paramSingle) {
+		k := key{name: p.Name, t: p.Type}
+		if _, ok := c.nodes[k]; !ok && !p.Optional {
+			missing = append(missing, k)
+		}
+	})
+	if len(missing) > 0 {
+		return fmt.Errorf("container is missing: %v", missing)
+	}
+	return nil
 }

--- a/param.go
+++ b/param.go
@@ -45,6 +45,24 @@ var (
 	_ param = paramList{}
 )
 
+// Calls the provided function on all paramSingles in the given param tree.
+func forEachSimpleParam(param param, f func(paramSingle)) {
+	switch p := param.(type) {
+	case paramList:
+		for _, arg := range p.Params {
+			forEachSimpleParam(arg, f)
+		}
+	case paramSingle:
+		f(p)
+	case paramObject:
+		for _, field := range p.Fields {
+			forEachSimpleParam(field.Param, f)
+		}
+	default:
+		panic(fmt.Sprintf("unknown param type %T", param))
+	}
+}
+
 // newParam builds a param from the given type. If the provided type is a
 // dig.In struct, an paramObject will be returned.
 func newParam(t reflect.Type) (param, error) {

--- a/param.go
+++ b/param.go
@@ -46,17 +46,17 @@ var (
 )
 
 // Calls the provided function on all paramSingles in the given param tree.
-func forEachSimpleParam(param param, f func(paramSingle)) {
+func forEachParamSingle(param param, f func(paramSingle)) {
 	switch p := param.(type) {
 	case paramList:
 		for _, arg := range p.Params {
-			forEachSimpleParam(arg, f)
+			forEachParamSingle(arg, f)
 		}
 	case paramSingle:
 		f(p)
 	case paramObject:
 		for _, field := range p.Fields {
-			forEachSimpleParam(field.Param, f)
+			forEachParamSingle(field.Param, f)
 		}
 	default:
 		panic(fmt.Sprintf("unknown param type %T", param))

--- a/param.go
+++ b/param.go
@@ -59,7 +59,11 @@ func forEachParamSingle(param param, f func(paramSingle)) {
 			forEachParamSingle(field.Param, f)
 		}
 	default:
-		panic(fmt.Sprintf("unknown param type %T", param))
+		panic(fmt.Sprintf(
+			"It looks like you have found a bug in dig. "+
+				"Please file an issue at https://github.com/uber-go/dig/issues/ "+
+				"and provide the following message: "+
+				"received unknown param type %T", param))
 	}
 }
 

--- a/param_test.go
+++ b/param_test.go
@@ -109,7 +109,7 @@ func TestParamObjectFailure(t *testing.T) {
 	})
 }
 
-func TestForEachSimpleParam(t *testing.T) {
+func TestForEachParamSingle(t *testing.T) {
 	type type1 struct{}
 	type type2 struct{}
 	type type3 struct{}
@@ -138,7 +138,7 @@ func TestForEachSimpleParam(t *testing.T) {
 	require.NoError(t, err)
 
 	var pos int
-	forEachSimpleParam(pl, func(p paramSingle) {
+	forEachParamSingle(pl, func(p paramSingle) {
 		switch pos {
 		case 0:
 			require.Equal(t, reflect.TypeOf(type1{}), p.Type)
@@ -155,15 +155,15 @@ func TestForEachSimpleParam(t *testing.T) {
 		case 6:
 			require.Equal(t, reflect.TypeOf(int64(0)), p.Type)
 		default:
-			t.Fatalf("forEachSimpleParam: unexpected call with %#v", p)
+			t.Fatalf("forEachParamSingle: unexpected call with %#v", p)
 		}
 		pos++
 	})
 }
 
-func TestForEachSimpleParamPanic(t *testing.T) {
+func TestForEachParamSinglePanic(t *testing.T) {
 	type badParam struct{ param }
 	assert.Panics(t, func() {
-		forEachSimpleParam(badParam{}, func(paramSingle) {})
+		forEachParamSingle(badParam{}, func(paramSingle) {})
 	})
 }


### PR DESCRIPTION
This implements a shallow check (previously implemented by
`Container.contains`) in terms of `param`. This check just verifies that
constructors for all dependencies of the provided param are present in
the container.

Note that this is the last usage of `Dependencies()` and we should be
able to delete it now.