### PR TITLE
Build dependencies using `param`s

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -132,7 +132,7 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 		return err
 	}
 
-	args, err := pl.BuildParams(c)
+	args, err := pl.BuildList(c)
 	if err != nil {
 		return errWrapf(err, "failed to get arguments for %v (type %v)", function, ftype)
 	}

--- a/dig_test.go
+++ b/dig_test.go
@@ -1207,8 +1207,8 @@ func TestInvokeFailures(t *testing.T) {
 			t.Fatal("function should not be called")
 		})
 		require.Error(t, err, "invoke should fail")
-		assert.Contains(t, err.Error(), "edge *bytes.Buffer:foo")
-		assert.Contains(t, err.Error(), "*bytes.Buffer:foo isn't in the container")
+		assert.Contains(t, err.Error(), "could not get field Buffer of dig.param")
+		assert.Contains(t, err.Error(), "type *bytes.Buffer:foo isn't in the container")
 	})
 
 	t.Run("unmet constructor dependency", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1491,8 +1491,8 @@ func TestInvokeFailures(t *testing.T) {
 		}
 		err := c.Invoke(func(i *in) { assert.Fail(t, "should never get here") })
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "*dig.in is a pointer")
-		assert.Contains(t, err.Error(), "use value type instead")
+		assert.Contains(t, err.Error(), "cannot depend on a pointer to a parameter object, use a value instead")
+		assert.Contains(t, err.Error(), "*dig.in is a pointer to a struct that embeds dig.In")
 	})
 
 	t.Run("embedding in pointer is not supported", func(t *testing.T) {
@@ -1505,8 +1505,8 @@ func TestInvokeFailures(t *testing.T) {
 		}
 		err := c.Invoke(func(i in) { assert.Fail(t, "should never get here") })
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot build a parameter object by embedding *dig.In")
 		assert.Contains(t, err.Error(), "dig.in embeds *dig.In")
-		assert.Contains(t, err.Error(), "embed dig.In value instead")
 	})
 
 	t.Run("requesting a value or pointer when other is present", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1495,6 +1495,23 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Contains(t, err.Error(), "*dig.in is a pointer to a struct that embeds dig.In")
 	})
 
+	t.Run("embedding dig.In and dig.Out is not supported", func(t *testing.T) {
+		c := New()
+		type in struct {
+			In
+			Out
+
+			String string
+		}
+
+		err := c.Invoke(func(in) {
+			assert.Fail(t, "should never get here")
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot depend on result objects")
+		assert.Contains(t, err.Error(), "dig.in embeds a dig.Out")
+	})
+
 	t.Run("embedding in pointer is not supported", func(t *testing.T) {
 		c := New()
 		type in struct {

--- a/param.go
+++ b/param.go
@@ -168,9 +168,9 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 
 	n, ok := c.nodes[k]
 	if !ok {
-		// Unlike in the fallback case below, if a user makes an error requesting
-		// a mixed type for an optional parameter, a good error message "did you mean X?"
-		// will not be used and dig will return zero value.
+		// Unlike in the fallback case below, if a user makes an error
+		// requesting an optional value, a good error message ("did you mean
+		// X?") will not be used and we'll return a zero value instead.
 		if ps.Optional {
 			return reflect.Zero(ps.Type), nil
 		}
@@ -220,7 +220,7 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		// Set the resolved object into the cache.
 		// This might look confusing at first like we're ignoring named types,
 		// but `con` in this case will be the dig.Out object, which will
-		// cause a recursion into the .set for each of it's memebers.
+		// cause a recursion into the .set for each of it's members.
 		c.set(key{t: con.Type()}, con)
 	}
 	return c.cache[k], nil

--- a/param.go
+++ b/param.go
@@ -128,7 +128,10 @@ func newParamList(ctype reflect.Type) (paramList, error) {
 }
 
 func (pl paramList) Build(*Container) (reflect.Value, error) {
-	panic("paramList.Build() must never be called")
+	panic("It looks like you have found a bug in dig. " +
+		"Please file an issue at https://github.com/uber-go/dig/issues/ " +
+		"and provide the following message: " +
+		"paramList.Build() must never be called")
 }
 
 // BuildParams returns an ordered list of values which may be passed directly

--- a/param.go
+++ b/param.go
@@ -52,6 +52,8 @@ var (
 // dig.In struct, an paramObject will be returned.
 func newParam(t reflect.Type) (param, error) {
 	switch {
+	case IsOut(t) || (t.Kind() == reflect.Ptr && IsOut(t.Elem())) || embedsType(t, _outPtrType):
+		return nil, fmt.Errorf("cannot depend on result objects: %v embeds a dig.Out", t)
 	case IsIn(t):
 		return newParamObject(t)
 	case embedsType(t, _inPtrType):
@@ -62,8 +64,6 @@ func newParam(t reflect.Type) (param, error) {
 		return nil, fmt.Errorf(
 			"cannot depend on a pointer to a parameter object, use a value instead: "+
 				"%v is a pointer to a struct that embeds dig.In", t)
-	case IsOut(t) || (t.Kind() == reflect.Ptr && IsOut(t.Elem())) || embedsType(t, _outPtrType):
-		return nil, fmt.Errorf("cannot depend on result objects: %v embeds a dig.Out", t)
 	default:
 		return paramSingle{Type: t}, nil
 	}

--- a/param.go
+++ b/param.go
@@ -93,7 +93,7 @@ func forEachParamSingle(param param, f func(paramSingle)) {
 
 // paramList holds all arguments of the constructor as params.
 //
-// NOTE: Build() MUST NOT be called on paramList. Instead, BuildParams
+// NOTE: Build() MUST NOT be called on paramList. Instead, BuildList
 // must be called.
 type paramList struct {
 	ctype reflect.Type // type of the constructor
@@ -136,9 +136,9 @@ func (pl paramList) Build(*Container) (reflect.Value, error) {
 		"paramList.Build() must never be called")
 }
 
-// BuildParams returns an ordered list of values which may be passed directly
+// BuildList returns an ordered list of values which may be passed directly
 // to the underlying constructor.
-func (pl paramList) BuildParams(c *Container) ([]reflect.Value, error) {
+func (pl paramList) BuildList(c *Container) ([]reflect.Value, error) {
 	args := make([]reflect.Value, len(pl.Params))
 	for i, p := range pl.Params {
 		var err error
@@ -201,7 +201,7 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		return _noValue, errWrapf(err, "missing dependencies for %v", k)
 	}
 
-	args, err := n.Params.BuildParams(c)
+	args, err := n.Params.BuildList(c)
 	if err != nil {
 		return _noValue, errWrapf(err, "couldn't get arguments for constructor %v", n.ctype)
 	}

--- a/param.go
+++ b/param.go
@@ -35,7 +35,8 @@ import (
 type param interface {
 	fmt.Stringer
 
-	// Builds this dependency and any of its from the provided Container.
+	// Builds this dependency and any of its dependencies from the provided
+	// Container.
 	//
 	// This MAY panic if the param does not produce a single value.
 	Build(*Container) (reflect.Value, error)

--- a/param.go
+++ b/param.go
@@ -56,10 +56,12 @@ func newParam(t reflect.Type) (param, error) {
 		return newParamObject(t)
 	case embedsType(t, _inPtrType):
 		return nil, fmt.Errorf(
-			"%v embeds *dig.In which is not supported, embed dig.In value instead", t)
+			"cannot build a parameter object by embedding *dig.In, embed dig.In instead: "+
+				"%v embeds *dig.In", t)
 	case t.Kind() == reflect.Ptr && IsIn(t.Elem()):
 		return nil, fmt.Errorf(
-			"dependency %v is a pointer to dig.In, use value type instead", t)
+			"cannot depend on a pointer to a parameter object, use a value instead: "+
+				"%v is a pointer to a struct that embeds dig.In", t)
 	case IsOut(t) || (t.Kind() == reflect.Ptr && IsOut(t.Elem())) || embedsType(t, _outPtrType):
 		return nil, fmt.Errorf("cannot depend on result objects: %v embeds a dig.Out", t)
 	default:

--- a/param.go
+++ b/param.go
@@ -59,6 +59,8 @@ func newParam(t reflect.Type) (param, error) {
 	case t.Kind() == reflect.Ptr && IsIn(t.Elem()):
 		return nil, fmt.Errorf(
 			"dependency %v is a pointer to dig.In, use value type instead", t)
+	case IsOut(t) || (t.Kind() == reflect.Ptr && IsOut(t.Elem())) || embedsType(t, _outPtrType):
+		return nil, fmt.Errorf("cannot depend on result objects: %v embeds a dig.Out", t)
 	default:
 		return paramSingle{Type: t}, nil
 	}

--- a/param_test.go
+++ b/param_test.go
@@ -21,12 +21,21 @@
 package dig
 
 import (
+	"io"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParamListBuild(t *testing.T) {
+	p, err := newParamList(reflect.TypeOf(func() io.Writer { return nil }))
+	require.NoError(t, err)
+	assert.Panics(t, func() {
+		p.Build(New())
+	})
+}
 
 func TestParamObjectSuccess(t *testing.T) {
 	type type1 struct{}


### PR DESCRIPTION
This moves the logic to build a `reflect.Value` given a `*Container`
from `Container.get` into individual `param` types.

- `paramList` builds a `[]reflect.Value` by calling its underlying
  `param`s.
- `paramSingle` builds a `reflect.Value` by fetching its cached value
  from the container or retrieving and calling its constructor.
- `paramObject` builds the corresponding `dig.In` struct and fills it
  with `reflect.Value`s retrieved from the underlying `param`s.

Besides breaking up the massive function into consumable chunks, this
lets us delete a number of things that were duplicating some of the
reflection logic.