### PR TITLE
Provide: Inspect constructor results upfront

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -304,7 +304,8 @@ type node struct {
 	ctype reflect.Type
 
 	// Type information about constructor parameters.
-	Params paramList
+	Params  paramList
+	Results resultList
 }
 
 func newNode(k key, ctor interface{}, ctype reflect.Type) (*node, error) {
@@ -313,11 +314,17 @@ func newNode(k key, ctor interface{}, ctype reflect.Type) (*node, error) {
 		return nil, err
 	}
 
+	results, err := newResultList(ctype)
+	if err != nil {
+		return nil, err
+	}
+
 	return &node{
-		key:    k,
-		ctor:   ctor,
-		ctype:  ctype,
-		Params: params,
+		key:     k,
+		ctor:    ctor,
+		ctype:   ctype,
+		Params:  params,
+		Results: results,
 	}, err
 }
 

--- a/dig.go
+++ b/dig.go
@@ -304,8 +304,7 @@ type node struct {
 	ctype reflect.Type
 
 	// Type information about constructor parameters.
-	Params  paramList
-	Results resultList
+	Params paramList
 }
 
 func newNode(k key, ctor interface{}, ctype reflect.Type) (*node, error) {
@@ -314,17 +313,11 @@ func newNode(k key, ctor interface{}, ctype reflect.Type) (*node, error) {
 		return nil, err
 	}
 
-	results, err := newResultList(ctype)
-	if err != nil {
-		return nil, err
-	}
-
 	return &node{
-		key:     k,
-		ctor:    ctor,
-		ctype:   ctype,
-		Params:  params,
-		Results: results,
+		key:    k,
+		ctor:   ctor,
+		ctype:  ctype,
+		Params: params,
 	}, err
 }
 

--- a/result.go
+++ b/result.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type (
+	result interface {
+		resultType()
+
+		Produces() map[key]struct{}
+	}
+
+	resultList struct {
+		ctype    reflect.Type
+		produces map[key]struct{}
+
+		Results []result
+	}
+
+	resultError struct{}
+
+	resultSingle struct {
+		Name string
+		Type reflect.Type
+	}
+
+	resultObject struct {
+		produces map[key]struct{}
+
+		Type   reflect.Type
+		Fields []resultObjectField
+	}
+
+	resultObjectField struct {
+		Name   string
+		Index  int
+		Result result
+	}
+)
+
+var (
+	_ result = resultSingle{}
+	_ result = resultError{}
+	_ result = resultObject{}
+	_ result = resultList{}
+)
+
+func (resultList) resultType()   {}
+func (resultError) resultType()  {}
+func (resultSingle) resultType() {}
+func (resultObject) resultType() {}
+
+func newResultList(ctype reflect.Type) (resultList, error) {
+	rl := resultList{
+		ctype:    ctype,
+		Results:  make([]result, ctype.NumOut()),
+		produces: make(map[key]struct{}),
+	}
+
+	for i := 0; i < ctype.NumOut(); i++ {
+		r, err := newResult(ctype.Out(i))
+		if err != nil {
+			return rl, errWrapf(err, "bad result %d", i+1)
+		}
+		rl.Results[i] = r
+
+		for k := range r.Produces() {
+			if _, ok := rl.produces[k]; ok {
+				return rl, fmt.Errorf("returns multiple %v", k)
+			}
+			rl.produces[k] = struct{}{}
+		}
+	}
+
+	if len(rl.produces) == 0 {
+		return rl, fmt.Errorf("%v must provide at least one non-error type", ctype)
+	}
+
+	return rl, nil
+}
+
+func (rl resultList) Produces() map[key]struct{} { return rl.produces }
+
+func newResult(t reflect.Type) (result, error) {
+	switch {
+	case isError(t):
+		return resultError{}, nil
+	case IsOut(t):
+		return newResultObject(t)
+	case embedsType(t, _outPtrType):
+		return nil, fmt.Errorf(
+			"%v embeds *dig.Out which is not supported, embed dig.Out value instead", t)
+	case t.Kind() == reflect.Ptr && IsOut(t.Elem()):
+		return nil, fmt.Errorf("%v is a pointer to dig.Out, use value type instead", t)
+		// Make sure we're not producing dig.In's either.
+	case IsIn(t) || (t.Kind() == reflect.Ptr && IsIn(t.Elem())) || embedsType(t, _inPtrType):
+		return nil, fmt.Errorf("cannot provide parameter objects: %v embeds a dig.In", t)
+	default:
+		return resultSingle{Type: t}, nil
+	}
+}
+
+func (rs resultSingle) Produces() map[key]struct{} {
+	return map[key]struct{}{
+		{name: rs.Name, t: rs.Type}: {},
+	}
+}
+
+// resultError doesn't produce anything
+func (resultError) Produces() map[key]struct{} { return nil }
+
+func newResultObject(t reflect.Type) (resultObject, error) {
+	ro := resultObject{Type: t, produces: make(map[key]struct{})}
+
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Type == _outType {
+			// Skip over the dig.Out embed.
+			continue
+		}
+
+		if f.PkgPath != "" {
+			return ro, fmt.Errorf(
+				"private fields not allowed in dig.Out, did you mean to export %q (%v) from %v?",
+				f.Name, f.Type, t)
+		}
+
+		if isError(f.Type) {
+			return ro, fmt.Errorf(
+				"cannot provide errors from dig.Out: field %q (%v) of %v is an error field",
+				f.Name, f.Type, t)
+		}
+
+		r, err := newResult(f.Type)
+		if err != nil {
+			return ro, errWrapf(err, "bad field %q of %v", f.Name, t)
+		}
+
+		name := f.Tag.Get(_nameTag)
+		if rs, ok := r.(resultSingle); ok {
+			// field tags apply only if the result is "simple"
+			rs.Name = name
+			r = rs
+		}
+
+		for k := range r.Produces() {
+			if _, ok := ro.produces[k]; ok {
+				return ro, fmt.Errorf("returns multiple %v", k)
+			}
+			ro.produces[k] = struct{}{}
+		}
+
+		ro.Fields = append(ro.Fields, resultObjectField{
+			Name:   f.Name,
+			Index:  i,
+			Result: r,
+		})
+	}
+	return ro, nil
+}
+
+func (ro resultObject) Produces() map[key]struct{} { return ro.produces }

--- a/result.go
+++ b/result.go
@@ -136,7 +136,7 @@ func newResultObject(t reflect.Type) (resultObject, error) {
 
 		if f.PkgPath != "" {
 			return ro, fmt.Errorf(
-				"private fields not allowed in dig.Out, did you mean to export %q (%v) from %v?",
+				"unexported fields not allowed in dig.Out, did you mean to export %q (%v) from %v?",
 				f.Name, f.Type, t)
 		}
 

--- a/result.go
+++ b/result.go
@@ -129,13 +129,13 @@ func (rs resultSingle) Produces() map[key]struct{} {
 // resultObjectField is a single field inside a dig.Out struct.
 type resultObjectField struct {
 	// Name of the field in the struct.
-	Name string
+	FieldName string
 
 	// Index of the field in the struct.
 	//
 	// We need to track this separately because not all fields of the struct
 	// map to results.
-	Index int
+	FieldIndex int
 
 	// Result produced by this field.
 	Result result
@@ -195,9 +195,9 @@ func newResultObject(t reflect.Type) (resultObject, error) {
 		}
 
 		ro.Fields = append(ro.Fields, resultObjectField{
-			Name:   f.Name,
-			Index:  i,
-			Result: r,
+			FieldName:  f.Name,
+			FieldIndex: i,
+			Result:     r,
 		})
 	}
 	return ro, nil

--- a/result.go
+++ b/result.go
@@ -27,8 +27,6 @@ import (
 
 type (
 	result interface {
-		resultType()
-
 		Produces() map[key]struct{}
 	}
 
@@ -66,11 +64,6 @@ var (
 	_ result = resultObject{}
 	_ result = resultList{}
 )
-
-func (resultList) resultType()   {}
-func (resultError) resultType()  {}
-func (resultSingle) resultType() {}
-func (resultObject) resultType() {}
 
 func newResultList(ctype reflect.Type) (resultList, error) {
 	rl := resultList{

--- a/result.go
+++ b/result.go
@@ -142,7 +142,8 @@ func newResultObject(t reflect.Type) (resultObject, error) {
 
 		if isError(f.Type) {
 			return ro, fmt.Errorf(
-				"cannot provide errors from dig.Out: field %q (%v) of %v is an error field",
+				"cannot return errors from dig.Out, return it from the constructor instead: "+
+					"field %q (%v) of %v is an error field",
 				f.Name, f.Type, t)
 		}
 

--- a/result_test.go
+++ b/result_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewResultListErrors(t *testing.T) {
+	tests := []struct {
+		desc string
+		give interface{}
+		err  string
+	}{
+		{
+			desc: "no results",
+			give: func() {},
+			err:  "must provide at least one non-error type",
+		},
+		{
+			desc: "only error",
+			give: func() error { panic("invalid") },
+			err:  "must provide at least one non-error type",
+		},
+		{
+			desc: "empty dig.Out",
+			give: func() struct{ Out } { panic("invalid") },
+			err:  "must provide at least one non-error type",
+		},
+		{
+			desc: "returns dig.In",
+			give: func() struct{ In } { panic("invalid") },
+			err:  "bad result 1: cannot provide parameter objects",
+		},
+		{
+			desc: "type conflict",
+			give: func() (io.Reader, io.Writer, io.Reader) { panic("invalid") },
+			err:  "returns multiple io.Reader",
+		},
+		{
+			desc: "name conflict",
+			give: func() struct {
+				Out
+
+				NamedWriter   io.Writer `name:"what"`
+				AnotherWriter io.Writer `name:"what"`
+			} {
+				panic("invalid")
+			},
+			err: "returns multiple io.Writer:what",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := newResultList(reflect.TypeOf(tt.give))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.err)
+		})
+	}
+}
+
+func TestNewResultErrors(t *testing.T) {
+	tests := []struct {
+		give interface{}
+		err  string
+	}{
+		{
+			give: struct{ *Out }{},
+			err:  "embeds *dig.Out which is not supported, embed dig.Out value instead",
+		},
+		{
+			give: (*struct{ Out })(nil),
+			err:  "pointer to dig.Out, use value type instead",
+		},
+		{
+			give: struct{ *In }{},
+			err:  "cannot provide parameter objects",
+		},
+		{
+			give: struct{ In }{},
+			err:  "cannot provide parameter objects",
+		},
+	}
+
+	for _, tt := range tests {
+		give := reflect.TypeOf(tt.give)
+		t.Run(fmt.Sprint(give), func(t *testing.T) {
+			_, err := newResult(give)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.err)
+		})
+	}
+}
+
+func TestNewResultObjectErrors(t *testing.T) {
+	tests := []struct {
+		desc string
+		give interface{}
+		err  string
+	}{
+		{
+			desc: "private fields",
+			give: struct {
+				Out
+
+				writer io.Writer
+			}{},
+			err: `private fields not allowed in dig.Out, did you mean to export "writer" (io.Writer)`,
+		},
+		{
+			desc: "error field",
+			give: struct {
+				Out
+
+				Error error
+			}{},
+			err: `cannot provide errors from dig.Out: field "Error" (error)`,
+		},
+		{
+			desc: "type conflict",
+			give: struct {
+				Out
+
+				Reader io.Reader
+				Writer io.Writer
+
+				Nested struct {
+					Out
+
+					AnotherReader io.Reader
+					AnotherWriter io.Writer `name:"conflict-free-writer"`
+				}
+			}{},
+			err: "returns multiple io.Reader",
+		},
+		{
+			desc: "name conflict",
+			give: struct {
+				Out
+
+				Reader        io.Reader
+				NamedWriter   io.Writer `name:"what"`
+				AnotherWriter io.Writer `name:"what"`
+			}{},
+			err: "returns multiple io.Writer:what",
+		},
+		{
+			desc: "nested dig.In",
+			give: struct {
+				Out
+
+				Nested struct{ In }
+			}{},
+			err: `bad field "Nested"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := newResultObject(reflect.TypeOf(tt.give))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.err)
+		})
+	}
+}

--- a/result_test.go
+++ b/result_test.go
@@ -157,7 +157,7 @@ func TestNewResultObjectErrors(t *testing.T) {
 
 				Error error
 			}{},
-			err: `cannot provide errors from dig.Out: field "Error" (error)`,
+			err: `cannot return errors from dig.Out, return it from the constructor instead: field "Error" (error)`,
 		},
 		{
 			desc: "type conflict",

--- a/result_test.go
+++ b/result_test.go
@@ -57,6 +57,16 @@ func TestNewResultListErrors(t *testing.T) {
 			err:  "bad result 1: cannot provide parameter objects",
 		},
 		{
+			desc: "returns dig.Out+dig.In",
+			give: func() struct {
+				Out
+				In
+			} {
+				panic("invalid")
+			},
+			err: "bad result 1: cannot provide parameter objects",
+		},
+		{
 			desc: "type conflict",
 			give: func() (io.Reader, io.Writer, io.Reader) { panic("invalid") },
 			err:  "returns multiple io.Reader",
@@ -85,25 +95,33 @@ func TestNewResultListErrors(t *testing.T) {
 }
 
 func TestNewResultErrors(t *testing.T) {
+	type outPtr struct{ *Out }
+	type out struct{ Out }
+	type in struct{ In }
+	type inOut struct {
+		In
+		Out
+	}
+
 	tests := []struct {
 		give interface{}
 		err  string
 	}{
 		{
-			give: struct{ *Out }{},
-			err:  "embeds *dig.Out which is not supported, embed dig.Out value instead",
+			give: outPtr{},
+			err:  "cannot build a result object by embedding *dig.Out, embed dig.Out instead: dig.outPtr embeds *dig.Out",
 		},
 		{
-			give: (*struct{ Out })(nil),
-			err:  "pointer to dig.Out, use value type instead",
+			give: (*out)(nil),
+			err:  "cannot return a pointer to a result object, use a value instead: *dig.out is a pointer to a struct that embeds dig.Out",
 		},
 		{
-			give: struct{ *In }{},
-			err:  "cannot provide parameter objects",
+			give: in{},
+			err:  "cannot provide parameter objects: dig.in embeds a dig.In",
 		},
 		{
-			give: struct{ In }{},
-			err:  "cannot provide parameter objects",
+			give: inOut{},
+			err:  "cannot provide parameter objects: dig.inOut embeds a dig.In",
 		},
 	}
 

--- a/result_test.go
+++ b/result_test.go
@@ -142,13 +142,13 @@ func TestNewResultObjectErrors(t *testing.T) {
 		err  string
 	}{
 		{
-			desc: "private fields",
+			desc: "unexported fields",
 			give: struct {
 				Out
 
 				writer io.Writer
 			}{},
-			err: `private fields not allowed in dig.Out, did you mean to export "writer" (io.Writer)`,
+			err: `unexported fields not allowed in dig.Out, did you mean to export "writer" (io.Writer)`,
 		},
 		{
 			desc: "error field",


### PR DESCRIPTION
Similar to #149, we now inspect constructor results upfront. These are
represented by the `result` interface which unionizes the following
types,

- resultList: All return values of a constructor
- resultSingle: Basic (optionally named) value
- resultObject: `dig.Out` object whose fields are other `result`s
- resultError: Sentinel type to indicate that an error is returned here.

The `result` interface has a `Produces()` method which returns a
comprehensive set of all values produces by the `result`.