### PR TITLE
Feed results into container using `result`s

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,4 +16,4 @@ coverage:
     patch:
       default:
         enabled: yes
-        target: 95
+        target: 70

--- a/dig.go
+++ b/dig.go
@@ -204,8 +204,18 @@ func newNode(ctor interface{}, ctype reflect.Type) (*node, error) {
 	}, err
 }
 
-func (n *node) Call(args []reflect.Value) []reflect.Value {
-	return reflect.ValueOf(n.ctor).Call(args)
+func (n *node) Call(c *Container) error {
+	args, err := n.Params.BuildList(c)
+	if err != nil {
+		return errWrapf(err, "couldn't get arguments for constructor %v", n.ctype)
+	}
+
+	results := reflect.ValueOf(n.ctor).Call(args)
+	if err := n.Results.ExtractResults(c, results); err != nil {
+		return errWrapf(err, "constructor %v failed", n.ctype)
+	}
+
+	return nil
 }
 
 type errCycleDetected struct {

--- a/dig.go
+++ b/dig.go
@@ -211,7 +211,7 @@ func (n *node) Call(c *Container) error {
 	}
 
 	results := reflect.ValueOf(n.ctor).Call(args)
-	if err := n.Results.ExtractResults(c, results); err != nil {
+	if err := n.Results.ExtractList(c, results); err != nil {
 		return errWrapf(err, "constructor %v failed", n.ctype)
 	}
 

--- a/param.go
+++ b/param.go
@@ -201,13 +201,8 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		return _noValue, errWrapf(err, "missing dependencies for %v", k)
 	}
 
-	args, err := n.Params.BuildList(c)
-	if err != nil {
-		return _noValue, errWrapf(err, "couldn't get arguments for constructor %v", n.ctype)
-	}
-
-	if err := n.Results.ExtractResults(c, n.Call(args)); err != nil {
-		return _noValue, errWrapf(err, "constructor %v for type %v failed", n.ctype, ps.Type)
+	if err := n.Call(c); err != nil {
+		return _noValue, errWrapf(err, "failed to build %v", k)
 	}
 
 	return c.cache[k], nil

--- a/result.go
+++ b/result.go
@@ -36,6 +36,8 @@ import (
 type result interface {
 	// Extracts the values for this result from the provided value and
 	// stores them in the container.
+	//
+	// This MAY panic if the result does not consume a single value.
 	Extract(*Container, reflect.Value) error
 
 	Produces() map[key]struct{}
@@ -110,7 +112,10 @@ func newResultList(ctype reflect.Type) (resultList, error) {
 func (rl resultList) Produces() map[key]struct{} { return rl.produces }
 
 func (resultList) Extract(*Container, reflect.Value) error {
-	panic("resultList.Extract() must never be called")
+	panic("It looks like you have found a bug in dig. " +
+		"Please file an issue at https://github.com/uber-go/dig/issues/ " +
+		"and provide the following message: " +
+		"resultList.Extract() must never be called")
 }
 
 func (rl resultList) ExtractResults(c *Container, values []reflect.Value) error {

--- a/result.go
+++ b/result.go
@@ -118,7 +118,7 @@ func (resultList) Extract(*Container, reflect.Value) error {
 		"resultList.Extract() must never be called")
 }
 
-func (rl resultList) ExtractResults(c *Container, values []reflect.Value) error {
+func (rl resultList) ExtractList(c *Container, values []reflect.Value) error {
 	for i, r := range rl.Results {
 		if err := r.Extract(c, values[i]); err != nil {
 			return err

--- a/result.go
+++ b/result.go
@@ -242,7 +242,11 @@ func (ro resultObject) Extract(c *Container, v reflect.Value) error {
 		if err := f.Result.Extract(c, v.Field(f.FieldIndex)); err != nil {
 			// In reality, this will never fail because none of the fields of
 			// a resultObject can be resultError.
-			return err
+			panic(fmt.Sprintf(
+				"It looks like you have found a bug in dig. "+
+					"Please file an issue at https://github.com/uber-go/dig/issues/ "+
+					"and provide the following message: "+
+					"result.Extract() encountered an error: %v", err))
 		}
 	}
 	return nil

--- a/result_test.go
+++ b/result_test.go
@@ -94,6 +94,16 @@ func TestNewResultListErrors(t *testing.T) {
 	}
 }
 
+func TestResultListExtractFails(t *testing.T) {
+	rl, err := newResultList(reflect.TypeOf(func() (io.Writer, error) {
+		panic("function should not be called")
+	}))
+	require.NoError(t, err)
+	assert.Panics(t, func() {
+		rl.Extract(New(), reflect.ValueOf("irrelevant"))
+	})
+}
+
 func TestNewResultErrors(t *testing.T) {
 	type outPtr struct{ *Out }
 	type out struct{ Out }


### PR DESCRIPTION
This changes how values are fed into the container to rely on individual
`result` implementations.

Instead of a single place where we handle the different return values of
a constructor, each `result` type now extracts information it cares
about.

- resultList feeds individual values into the underlying results
- resultSingle stores the value into the container cache
- resultError retrieves and returns the error as-is
- resultObject extracts corresponding dig.Out fields and delegates to
  the underlying results

With this change, both the input and output paths have been refactored
to use this approach.