### PR TITLE
IDEA: Rules Prototype

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -204,6 +204,15 @@ func newNode(ctor interface{}, ctype reflect.Type) (*node, error) {
 	}, err
 }
 
+func instancedNode(name string, n *node) *node {
+	return &node{
+		ctor:    n.ctor,
+		ctype:   n.ctype,
+		Params:  instancedParamList(name, n.Params),
+		Results: instancedResultList(name, n.Results),
+	}
+}
+
 func (n *node) Call(c *Container) error {
 	args, err := n.Params.BuildList(c)
 	if err != nil {

--- a/dig.go
+++ b/dig.go
@@ -113,6 +113,10 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 }
 
 // ProvideRule XXX probably options for #reasons
+//
+// XXX but maybe, this should just be some ProvideOption rather than a separate
+// toplevel api? How about `c.Provide(func(S) T, dig.ProvideRule)` (where
+// ProvideRule would be some ProvideOption sentinel?)
 func (c *Container) ProvideRule(constructor interface{}) error {
 	ctype := reflect.TypeOf(constructor)
 	if ctype == nil {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1671,8 +1671,11 @@ func TestInvokeFailures(t *testing.T) {
 	})
 }
 
-func TestProvideRuleXXX(t *testing.T) {
-	// XXX rename and/or subsume into other suites above
+func TestProvideRule_PoC(t *testing.T) {
+	// XXX this test is just a proof on concept, I haven't yet grokked the
+	// layout of the pre-existing test suite, but it seems like if this feature
+	// sticks, it should be tested in situ within the above suite, rather than
+	// being standalone.
 
 	c := New()
 
@@ -1688,6 +1691,8 @@ func TestProvideRuleXXX(t *testing.T) {
 	// - static provide, rather than wrap it in a nil-adic func
 	// - named provide, rather than need to create a struct, just to name some
 	//   piece of static data
+	// - further, how about some sort of collection support, like providing
+	//   some []S and a func(S) T should provide a []T.
 	type rawStuff struct {
 		Out
 		A []byte `name:"a"`

--- a/param.go
+++ b/param.go
@@ -213,28 +213,11 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		return ps.buildNode(k, c, n)
 	}
 
-	if r, ok := c.rules[key{t: ps.Type}]; ok {
+	if r, ok := c.rules[ps.Type]; ok {
 		if k.name != "" {
-			ri := node{
-				ctor:  r.ctor,
-				ctype: r.ctype,
-				Params: paramList{
-					ctype: r.Params.ctype,
-				},
-				Results: resultList{
-					ctype: r.Results.ctype,
-				},
-			}
-
-			// XXX which ones to rename? how?
-			ri.Params.Params = append([]param(nil), r.Params.Params...)
-			ri.Results.produces = make(map[key]struct{})
-			ri.Results.Results = append([]param(nil), r.Results.Results...)
-
-			// TODO: named params -> results
+			return ps.buildNode(k, c, instancedNode(k.name, r))
 		}
-
-		return ps.buildNode(c, r)
+		// XXX probably not useful?  return ps.buildNode(c, r)
 	}
 
 	// Unlike in the fallback case below, if a user makes an error

--- a/param.go
+++ b/param.go
@@ -195,6 +195,8 @@ func (pl paramList) BuildList(c *Container) ([]reflect.Value, error) {
 //
 // This object must be present in the graph as-is unless it's specified as
 // optional.
+//
+// XXX rules
 type paramSingle struct {
 	Name     string
 	Optional bool
@@ -209,6 +211,30 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 
 	if n, ok := c.nodes[k]; ok {
 		return ps.buildNode(k, c, n)
+	}
+
+	if r, ok := c.rules[key{t: ps.Type}]; ok {
+		if k.name != "" {
+			ri := node{
+				ctor:  r.ctor,
+				ctype: r.ctype,
+				Params: paramList{
+					ctype: r.Params.ctype,
+				},
+				Results: resultList{
+					ctype: r.Results.ctype,
+				},
+			}
+
+			// XXX which ones to rename? how?
+			ri.Params.Params = append([]param(nil), r.Params.Params...)
+			ri.Results.produces = make(map[key]struct{})
+			ri.Results.Results = append([]param(nil), r.Results.Results...)
+
+			// TODO: named params -> results
+		}
+
+		return ps.buildNode(c, r)
 	}
 
 	// Unlike in the fallback case below, if a user makes an error

--- a/result.go
+++ b/result.go
@@ -93,12 +93,8 @@ func newResultList(ctype reflect.Type) (resultList, error) {
 			return rl, errWrapf(err, "bad result %d", i+1)
 		}
 		rl.Results[i] = r
-
-		for k := range r.Produces() {
-			if _, ok := rl.produces[k]; ok {
-				return rl, fmt.Errorf("returns multiple %v", k)
-			}
-			rl.produces[k] = struct{}{}
+		if err := rl.addProduces(r); err != nil {
+			return rl, err
 		}
 	}
 
@@ -107,6 +103,16 @@ func newResultList(ctype reflect.Type) (resultList, error) {
 	}
 
 	return rl, nil
+}
+
+func (rl resultList) addProduces(r result) error {
+	for k := range r.Produces() {
+		if _, ok := rl.produces[k]; ok {
+			return fmt.Errorf("returns multiple %v", k)
+		}
+		rl.produces[k] = struct{}{}
+	}
+	return nil
 }
 
 func (rl resultList) Produces() map[key]struct{} { return rl.produces }

--- a/stringer.go
+++ b/stringer.go
@@ -41,6 +41,12 @@ func (c *Container) String() string {
 	}
 	fmt.Fprintln(b, "}")
 
+	fmt.Fprintln(b, "rules: {")
+	for k, v := range c.rules {
+		fmt.Fprintln(b, "\t", k, "->", v)
+	}
+	fmt.Fprintln(b, "}")
+
 	return b.String()
 }
 


### PR DESCRIPTION
This PR is a proof of concept for how rules could work:
- a rule is a constructor function, say `func(S) T`
- that is then used to convert one or more `s S`s into one or more corresponding `t T`s
- the plurality currently only expands over dep nodes (in particular named ones)...
- ...but you could easily imagine extending it over other pluralities like providing `[]T` from a `[]S`

Most notes, TODOs, and the like are inline, but as an overview:
- container now sports a rules mapping from possible type to constructor
- there's a toplevel `ProvideRule` api (which in retrospect could've been a `ProvideOption`)
- param building then will try to instantiate a rule, if it fails to find a normal node
  - instantiation literally works by filling in the name of the rule node, and all of its constituent params and results (only happens if they had no name set, manual names stick)
  - there's an "obvious" gap here, actually not noted in the code, where-in you might want a way top opt some param(s)/result(s) out of this instantiation (e.g. there is only one logger, and it shouldn't have to be named)

Anyhow, I got it working through a PoC test, but you could imagine many use cases. For example my original was "I have 2 separate configs for 2 separate database connections, ideally I'd provide a single database connector/constructor function".