### PR TITLE
result: Find results with resultVisitor

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -156,7 +156,7 @@ func (c *Container) provide(ctor interface{}, ctype reflect.Type) error {
 		return err
 	}
 
-	keys, err := c.findConnections(n)
+	keys, err := c.findAndValidateResults(n)
 	if err != nil {
 		return err
 	}
@@ -176,14 +176,15 @@ func (c *Container) provide(ctor interface{}, ctype reflect.Type) error {
 	return nil
 }
 
-func (c *Container) findConnections(n *node) (map[key]struct{}, error) {
+// Builds a collection of all result types produced by this node.
+func (c *Container) findAndValidateResults(n *node) (map[key]struct{}, error) {
 	var err error
 	keyPaths := make(map[key]string)
 	walkResult(n.Results, connectionVisitor{
-		c:    c,
-		n:    n,
-		err:  &err,
-		keys: keyPaths,
+		c:        c,
+		n:        n,
+		err:      &err,
+		keyPaths: keyPaths,
 	})
 
 	if err != nil {

--- a/dig.go
+++ b/dig.go
@@ -232,12 +232,12 @@ type connectionVisitor struct {
 	currentResultPath []string
 }
 
-func (cv connectionVisitor) VisitField(f resultObjectField) resultVisitor {
+func (cv connectionVisitor) AnnotateWithField(f resultObjectField) resultVisitor {
 	cv.currentResultPath = append(cv.currentResultPath, f.FieldName)
 	return cv
 }
 
-func (cv connectionVisitor) VisitPosition(i int) resultVisitor {
+func (cv connectionVisitor) AnnotateWithPosition(i int) resultVisitor {
 	cv.currentResultPath = append(cv.currentResultPath, fmt.Sprintf("[%d]", i))
 	return cv
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -1129,7 +1129,9 @@ func TestProvideFailures(t *testing.T) {
 			}
 		})
 		require.Error(t, err, "provide must return error")
-		require.Contains(t, err.Error(), "returns multiple dig.A")
+		require.Contains(t, err.Error(),
+			"cannot provide dig.A from [0].A2 in constructor func() dig.ret: "+
+				"already provided by [0].A1")
 	})
 
 	t.Run("provide multiple instances with the same name", func(t *testing.T) {
@@ -1150,7 +1152,9 @@ func TestProvideFailures(t *testing.T) {
 			return ret2{A: &A{}}
 		})
 		require.Error(t, err, "expected error on the second provide")
-		assert.Contains(t, err.Error(), "provides *dig.A:foo, which is already in the container")
+		assert.Contains(t, err.Error(),
+			"cannot provide *dig.A:foo from [0].A in constructor func() dig.ret2: "+
+				"already in the container")
 	})
 
 	t.Run("out with unexported field should error", func(t *testing.T) {

--- a/param.go
+++ b/param.go
@@ -78,8 +78,8 @@ type paramVisitor interface {
 	// the child params of this param.
 	Visit(param) paramVisitor
 
-	// We can implement VisitField and VisitPosition like resultVisitor if we
-	// need to track that information in the future.
+	// We can implement AnnotateWithField and AnnotateWithPosition like
+	// resultVisitor if we need to track that information in the future.
 }
 
 // paramVisitorFunc is a paramVisitor that visits param in a tree with the

--- a/param.go
+++ b/param.go
@@ -77,6 +77,9 @@ type paramVisitor interface {
 	// If Visit returns a non-nil paramVisitor, that paramVisitor visits all
 	// the child params of this param.
 	Visit(param) paramVisitor
+
+	// We can implement VisitField and VisitPosition like resultVisitor if we
+	// need to track that information in the future.
 }
 
 // paramVisitorFunc is a paramVisitor that visits param in a tree with the

--- a/result.go
+++ b/result.go
@@ -79,25 +79,25 @@ type resultVisitor interface {
 	// the child results of this result.
 	Visit(result) resultVisitor
 
-	// VisitField is called on each field of a resultObject after visiting it
-	// but before walking its descendants.
+	// AnnotateWithField is called on each field of a resultObject after
+	// visiting it but before walking its descendants.
 	//
 	// The same resultVisitor is used for all fields: the one returned upon
 	// visiting the resultObject.
 	//
-	// For each visited field, if VisitField returns a non-nil resultVisitor,
-	// it will be used to walk the result of that field.
-	VisitField(resultObjectField) resultVisitor
+	// For each visited field, if AnnotateWithField returns a non-nil
+	// resultVisitor, it will be used to walk the result of that field.
+	AnnotateWithField(resultObjectField) resultVisitor
 
-	// VisitPosition is called with the index of each result of a resultList
-	// after vising it but before walking its descendants.
+	// AnnotateWithPosition is called with the index of each result of a
+	// resultList after vising it but before walking its descendants.
 	//
 	// The same resultVisitor is used for all results: the one returned upon
 	// visiting the resultList.
 	//
-	// For each position, if VisitPosition returns a non-nil resultVisitor, it
-	// will be used to walk the result at that index.
-	VisitPosition(idx int) resultVisitor
+	// For each position, if AnnotateWithPosition returns a non-nil
+	// resultVisitor, it will be used to walk the result at that index.
+	AnnotateWithPosition(idx int) resultVisitor
 }
 
 // walkResult walks the result tree for the given result with the provided
@@ -105,9 +105,9 @@ type resultVisitor interface {
 //
 // resultVisitor.Visit will be called on the provided result and if a non-nil
 // resultVisitor is received, it will be used to walk its descendants. If a
-// resultObject or resultList was visited, VisitField and VisitPosition
-// respectively will be called before visiting the descendants of that
-// resultObject/resultList.
+// resultObject or resultList was visited, AnnotateWithField and
+// AnnotateWithPosition respectively will be called before visiting the
+// descendants of that resultObject/resultList.
 //
 // This is very similar to how go/ast.Walk works.
 func walkResult(r result, v resultVisitor) {
@@ -122,14 +122,14 @@ func walkResult(r result, v resultVisitor) {
 	case resultObject:
 		w := v
 		for _, f := range res.Fields {
-			if v := w.VisitField(f); v != nil {
+			if v := w.AnnotateWithField(f); v != nil {
 				walkResult(f.Result, v)
 			}
 		}
 	case resultList:
 		w := v
 		for i, r := range res.Results {
-			if v := w.VisitPosition(i); v != nil {
+			if v := w.AnnotateWithPosition(i); v != nil {
 				walkResult(r, v)
 			}
 		}

--- a/result.go
+++ b/result.go
@@ -39,8 +39,6 @@ type result interface {
 	//
 	// This MAY panic if the result does not consume a single value.
 	Extract(*Container, reflect.Value) error
-
-	Produces() map[key]struct{}
 }
 
 var (
@@ -72,19 +70,89 @@ func newResult(t reflect.Type) (result, error) {
 	}
 }
 
+// resultVisitor visits every result in a result tree, allowing tracking state
+// at each level.
+type resultVisitor interface {
+	// Visit is called on the result being visited.
+	//
+	// If Visit returns a non-nil resultVisitor, that resultVisitor visits all
+	// the child results of this result.
+	Visit(result) resultVisitor
+
+	// VisitField is called on each field of a resultObject after visiting it
+	// but before walking its descendants.
+	//
+	// The same resultVisitor is used for all fields: the one returned upon
+	// visiting the resultObject.
+	//
+	// For each visited field, if VisitField returns a non-nil resultVisitor,
+	// it will be used to walk the result of that field.
+	VisitField(resultObjectField) resultVisitor
+
+	// VisitPosition is called with the index of each result of a resultList
+	// after vising it but before walking its descendants.
+	//
+	// The same resultVisitor is used for all results: the one returned upon
+	// visiting the resultList.
+	//
+	// For each position, if VisitPosition returns a non-nil resultVisitor, it
+	// will be used to walk the result at that index.
+	VisitPosition(idx int) resultVisitor
+}
+
+// walkResult walks the result tree for the given result with the provided
+// visitor.
+//
+// resultVisitor.Visit will be called on the provided result and if a non-nil
+// resultVisitor is received, it will be used to walk its descendants. If a
+// resultObject or resultList was visited, VisitField and VisitPosition
+// respectively will be called before visiting the descendants of that
+// resultObject/resultList.
+//
+// This is very similar to how go/ast.Walk works.
+func walkResult(r result, v resultVisitor) {
+	v = v.Visit(r)
+	if v == nil {
+		return
+	}
+
+	switch res := r.(type) {
+	case resultSingle, resultError:
+		// No sub-results
+	case resultObject:
+		w := v
+		for _, f := range res.Fields {
+			if v := w.VisitField(f); v != nil {
+				walkResult(f.Result, v)
+			}
+		}
+	case resultList:
+		w := v
+		for i, r := range res.Results {
+			if v := w.VisitPosition(i); v != nil {
+				walkResult(r, v)
+			}
+		}
+	default:
+		panic(fmt.Sprintf(
+			"It looks like you have found a bug in dig. "+
+				"Please file an issue at https://github.com/uber-go/dig/issues/ "+
+				"and provide the following message: "+
+				"received unknown result type %T", res))
+	}
+}
+
 // resultList holds all values returned by the constructor as results.
 type resultList struct {
-	ctype    reflect.Type
-	produces map[key]struct{}
+	ctype reflect.Type
 
 	Results []result
 }
 
 func newResultList(ctype reflect.Type) (resultList, error) {
 	rl := resultList{
-		ctype:    ctype,
-		Results:  make([]result, ctype.NumOut()),
-		produces: make(map[key]struct{}),
+		ctype:   ctype,
+		Results: make([]result, ctype.NumOut()),
 	}
 
 	for i := 0; i < ctype.NumOut(); i++ {
@@ -93,23 +161,10 @@ func newResultList(ctype reflect.Type) (resultList, error) {
 			return rl, errWrapf(err, "bad result %d", i+1)
 		}
 		rl.Results[i] = r
-
-		for k := range r.Produces() {
-			if _, ok := rl.produces[k]; ok {
-				return rl, fmt.Errorf("returns multiple %v", k)
-			}
-			rl.produces[k] = struct{}{}
-		}
-	}
-
-	if len(rl.produces) == 0 {
-		return rl, fmt.Errorf("%v must provide at least one non-error type", ctype)
 	}
 
 	return rl, nil
 }
-
-func (rl resultList) Produces() map[key]struct{} { return rl.produces }
 
 func (resultList) Extract(*Container, reflect.Value) error {
 	panic("It looks like you have found a bug in dig. " +
@@ -130,9 +185,6 @@ func (rl resultList) ExtractList(c *Container, values []reflect.Value) error {
 // resultError is an error returned by a constructor.
 type resultError struct{}
 
-// resultError doesn't produce anything
-func (resultError) Produces() map[key]struct{} { return nil }
-
 func (resultError) Extract(_ *Container, v reflect.Value) error {
 	err, _ := v.Interface().(error)
 	return err
@@ -145,12 +197,6 @@ func (resultError) Extract(_ *Container, v reflect.Value) error {
 type resultSingle struct {
 	Name string
 	Type reflect.Type
-}
-
-func (rs resultSingle) Produces() map[key]struct{} {
-	return map[key]struct{}{
-		{name: rs.Name, t: rs.Type}: {},
-	}
 }
 
 func (rs resultSingle) Extract(c *Container, v reflect.Value) error {
@@ -178,14 +224,12 @@ type resultObjectField struct {
 // This object is not added to the graph. Its fields are interpreted as
 // results and added to the graph if needed.
 type resultObject struct {
-	produces map[key]struct{}
-
 	Type   reflect.Type
 	Fields []resultObjectField
 }
 
 func newResultObject(t reflect.Type) (resultObject, error) {
-	ro := resultObject{Type: t, produces: make(map[key]struct{})}
+	ro := resultObject{Type: t}
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
@@ -219,13 +263,6 @@ func newResultObject(t reflect.Type) (resultObject, error) {
 			r = rs
 		}
 
-		for k := range r.Produces() {
-			if _, ok := ro.produces[k]; ok {
-				return ro, fmt.Errorf("returns multiple %v", k)
-			}
-			ro.produces[k] = struct{}{}
-		}
-
 		ro.Fields = append(ro.Fields, resultObjectField{
 			FieldName:  f.Name,
 			FieldIndex: i,
@@ -234,8 +271,6 @@ func newResultObject(t reflect.Type) (resultObject, error) {
 	}
 	return ro, nil
 }
-
-func (ro resultObject) Produces() map[key]struct{} { return ro.produces }
 
 func (ro resultObject) Extract(c *Container, v reflect.Value) error {
 	for _, f := range ro.Fields {

--- a/result_test.go
+++ b/result_test.go
@@ -37,21 +37,6 @@ func TestNewResultListErrors(t *testing.T) {
 		err  string
 	}{
 		{
-			desc: "no results",
-			give: func() {},
-			err:  "must provide at least one non-error type",
-		},
-		{
-			desc: "only error",
-			give: func() error { panic("invalid") },
-			err:  "must provide at least one non-error type",
-		},
-		{
-			desc: "empty dig.Out",
-			give: func() struct{ Out } { panic("invalid") },
-			err:  "must provide at least one non-error type",
-		},
-		{
 			desc: "returns dig.In",
 			give: func() struct{ In } { panic("invalid") },
 			err:  "bad result 1: cannot provide parameter objects",
@@ -65,23 +50,6 @@ func TestNewResultListErrors(t *testing.T) {
 				panic("invalid")
 			},
 			err: "bad result 1: cannot provide parameter objects",
-		},
-		{
-			desc: "type conflict",
-			give: func() (io.Reader, io.Writer, io.Reader) { panic("invalid") },
-			err:  "returns multiple io.Reader",
-		},
-		{
-			desc: "name conflict",
-			give: func() struct {
-				Out
-
-				NamedWriter   io.Writer `name:"what"`
-				AnotherWriter io.Writer `name:"what"`
-			} {
-				panic("invalid")
-			},
-			err: "returns multiple io.Writer:what",
 		},
 	}
 
@@ -168,34 +136,6 @@ func TestNewResultObjectErrors(t *testing.T) {
 				Error error
 			}{},
 			err: `cannot return errors from dig.Out, return it from the constructor instead: field "Error" (error)`,
-		},
-		{
-			desc: "type conflict",
-			give: struct {
-				Out
-
-				Reader io.Reader
-				Writer io.Writer
-
-				Nested struct {
-					Out
-
-					AnotherReader io.Reader
-					AnotherWriter io.Writer `name:"conflict-free-writer"`
-				}
-			}{},
-			err: "returns multiple io.Reader",
-		},
-		{
-			desc: "name conflict",
-			give: struct {
-				Out
-
-				Reader        io.Reader
-				NamedWriter   io.Writer `name:"what"`
-				AnotherWriter io.Writer `name:"what"`
-			}{},
-			err: "returns multiple io.Writer:what",
 		},
 		{
 			desc: "nested dig.In",

--- a/result_test.go
+++ b/result_test.go
@@ -159,8 +159,8 @@ func TestNewResultObjectErrors(t *testing.T) {
 
 type fakeResultVisit struct {
 	Visit         result
-	VisitField    *resultObjectField
-	VisitPosition int
+	AnnotateWithField    *resultObjectField
+	AnnotateWithPosition int
 	Return        fakeResultVisits
 }
 
@@ -168,10 +168,10 @@ func (fv fakeResultVisit) String() string {
 	switch {
 	case fv.Visit != nil:
 		return fmt.Sprintf("Visit(%#v) -> %v", fv.Visit, fv.Return)
-	case fv.VisitField != nil:
-		return fmt.Sprintf("VisitField(%#v) -> %v", *fv.VisitField, fv.Return)
+	case fv.AnnotateWithField != nil:
+		return fmt.Sprintf("AnnotateWithField(%#v) -> %v", *fv.AnnotateWithField, fv.Return)
 	default:
-		return fmt.Sprintf("VisitPosition(%v) -> %v", fv.VisitPosition, fv.Return)
+		return fmt.Sprintf("AnnotateWithPosition(%v) -> %v", fv.AnnotateWithPosition, fv.Return)
 	}
 }
 
@@ -204,18 +204,18 @@ func (fv *fakeResultVisitor) Visit(r result) resultVisitor {
 	return &fakeResultVisitor{t: fv.t, visits: v.Return}
 }
 
-func (fv *fakeResultVisitor) VisitField(f resultObjectField) resultVisitor {
-	v := fv.popNext(fmt.Sprintf("VisitField(%#v)", f))
-	if v.VisitField == nil || !reflect.DeepEqual(f, *v.VisitField) {
-		fv.t.Fatalf("received unexpected call VisitField(%#v)\nexpected %v", f, v)
+func (fv *fakeResultVisitor) AnnotateWithField(f resultObjectField) resultVisitor {
+	v := fv.popNext(fmt.Sprintf("AnnotateWithField(%#v)", f))
+	if v.AnnotateWithField == nil || !reflect.DeepEqual(f, *v.AnnotateWithField) {
+		fv.t.Fatalf("received unexpected call AnnotateWithField(%#v)\nexpected %v", f, v)
 	}
 	return &fakeResultVisitor{t: fv.t, visits: v.Return}
 }
 
-func (fv *fakeResultVisitor) VisitPosition(i int) resultVisitor {
-	v := fv.popNext(fmt.Sprintf("VisitPosition(%v)", i))
-	if i != v.VisitPosition {
-		fv.t.Fatalf("received unexpected call VisitPosition(%v)\nexpected %v", i, v)
+func (fv *fakeResultVisitor) AnnotateWithPosition(i int) resultVisitor {
+	v := fv.popNext(fmt.Sprintf("AnnotateWithPosition(%v)", i))
+	if i != v.AnnotateWithPosition {
+		fv.t.Fatalf("received unexpected call AnnotateWithPosition(%v)\nexpected %v", i, v)
 	}
 	return &fakeResultVisitor{t: fv.t, visits: v.Return}
 }
@@ -260,31 +260,31 @@ func TestWalkResult(t *testing.T) {
 				Visit: ro,
 				Return: fakeResultVisits{
 					{
-						VisitField: &ro.Fields[0],
+						AnnotateWithField: &ro.Fields[0],
 						Return: fakeResultVisits{
 							{Visit: ro.Fields[0].Result},
 						},
 					},
 					{
-						VisitField: &ro.Fields[1],
+						AnnotateWithField: &ro.Fields[1],
 						Return: fakeResultVisits{
 							{Visit: ro.Fields[1].Result},
 						},
 					},
 					{
-						VisitField: &ro.Fields[2],
+						AnnotateWithField: &ro.Fields[2],
 						Return: fakeResultVisits{
 							{
 								Visit: ro.Fields[2].Result,
 								Return: fakeResultVisits{
 									{
-										VisitField: &ro.Fields[2].Result.(resultObject).Fields[0],
+										AnnotateWithField: &ro.Fields[2].Result.(resultObject).Fields[0],
 										Return: fakeResultVisits{
 											{Visit: ro.Fields[2].Result.(resultObject).Fields[0].Result},
 										},
 									},
 									{
-										VisitField: &ro.Fields[2].Result.(resultObject).Fields[1],
+										AnnotateWithField: &ro.Fields[2].Result.(resultObject).Fields[1],
 										Return: fakeResultVisits{
 											{Visit: ro.Fields[2].Result.(resultObject).Fields[1].Result},
 										},


### PR DESCRIPTION
Similar to paramVisitor, this adds resultVisitor and walkResult. In
addition to visiting results, resultVisitor also knows which result
position or result object field it is visiting, allowing for more
detailed error messages.

For example, this lets us provide a lot more information in the case
when the constructor is providing the same type multiple times. Given,

    type out struct {
        dig.Out

        Foo struct {
            dig.Out

            Writer io.Writer
        }

        Bar struct {
            dig.Out

            Writer io.Writer
        }
    }

Instead of,

   returns multiple io.Writer

We will now get,

    cannot provide io.Writer from [0].Bar.Writer in constructor func() out:
        already provided by [0].Foo.Writer