### PR TITLE
node: Track if already called

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -279,9 +279,13 @@ func (c *Container) isAcyclic(p param, k key) error {
 	return detectCycles(p, c.nodes, []key{k})
 }
 
+// node represents a single constructor in the graph.
 type node struct {
 	ctor  interface{}
 	ctype reflect.Type
+
+	// Whether this constructor was already run.
+	called bool
 
 	// Type information about constructor parameters.
 	Params paramList
@@ -310,6 +314,10 @@ func newNode(ctor interface{}, ctype reflect.Type) (*node, error) {
 }
 
 func (n *node) Call(c *Container) error {
+	if n.called {
+		return nil
+	}
+
 	args, err := n.Params.BuildList(c)
 	if err != nil {
 		return errWrapf(err, "couldn't get arguments for constructor %v", n.ctype)
@@ -320,6 +328,7 @@ func (n *node) Call(c *Container) error {
 		return errWrapf(err, "constructor %v failed", n.ctype)
 	}
 
+	n.called = true
 	return nil
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1674,3 +1674,17 @@ func TestInvokeFailures(t *testing.T) {
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
 	})
 }
+
+func TestNodeAlreadyCalled(t *testing.T) {
+	type type1 struct{}
+	f := func() type1 { return type1{} }
+
+	n, err := newNode(f, reflect.TypeOf(f))
+	require.NoError(t, err, "failed to build node")
+	require.False(t, n.called, "node must not have been called")
+
+	c := New()
+	require.NoError(t, n.Call(c), "invoke failed")
+	require.True(t, n.called, "node must be called")
+	require.NoError(t, n.Call(c), "calling again should be okay")
+}


### PR DESCRIPTION
Now that nodes represent individual constructors in the graph rather
than the types they provide, we can track on the node whether it was
already called.

This has no value right now but we will need this once we introduce
value groups to ensure that constructors don't get called multiple
times.