### PR TITLE
graph: Support multiple providers

### DIFF
--- a/param.go
+++ b/param.go
@@ -203,7 +203,7 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		return v, nil
 	}
 
-	nodes := c.producers[k]
+	nodes := c.providers[k]
 	if len(nodes) == 0 {
 		// Unlike in the fallback case below, if a user makes an error
 		// requesting an optional value, a good error message ("did you mean
@@ -223,7 +223,7 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		}
 
 		tk := key{t: typo, name: ps.Name}
-		if _, ok := c.producers[tk]; ok {
+		if _, ok := c.providers[tk]; ok {
 			return _noValue, fmt.Errorf(
 				"type %v is not in the container, did you mean to use %v?", k, tk)
 		}

--- a/param.go
+++ b/param.go
@@ -199,12 +199,12 @@ type paramSingle struct {
 
 func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 	k := key{name: ps.Name, t: ps.Type}
-	if v, ok := c.cache[k]; ok {
+	if v, ok := c.values[k]; ok {
 		return v, nil
 	}
 
-	n, ok := c.nodes[k]
-	if !ok {
+	nodes := c.producers[k]
+	if len(nodes) == 0 {
 		// Unlike in the fallback case below, if a user makes an error
 		// requesting an optional value, a good error message ("did you mean
 		// X?") will not be used and we'll return a zero value instead.
@@ -223,7 +223,7 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		}
 
 		tk := key{t: typo, name: ps.Name}
-		if _, ok := c.nodes[tk]; ok {
+		if _, ok := c.producers[tk]; ok {
 			return _noValue, fmt.Errorf(
 				"type %v is not in the container, did you mean to use %v?", k, tk)
 		}
@@ -231,18 +231,20 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 		return _noValue, fmt.Errorf("type %v isn't in the container", k)
 	}
 
-	if err := shallowCheckDependencies(c, n.Params); err != nil {
-		if ps.Optional {
-			return reflect.Zero(ps.Type), nil
+	for _, n := range nodes {
+		if err := shallowCheckDependencies(c, n.Params); err != nil {
+			if ps.Optional {
+				return reflect.Zero(ps.Type), nil
+			}
+			return _noValue, errWrapf(err, "missing dependencies for %v", k)
 		}
-		return _noValue, errWrapf(err, "missing dependencies for %v", k)
+
+		if err := n.Call(c); err != nil {
+			return _noValue, errWrapf(err, "failed to build %v", k)
+		}
 	}
 
-	if err := n.Call(c); err != nil {
-		return _noValue, errWrapf(err, "failed to build %v", k)
-	}
-
-	return c.cache[k], nil
+	return c.values[k], nil
 }
 
 // paramObjectField is a single field of a dig.In struct.

--- a/result.go
+++ b/result.go
@@ -200,7 +200,7 @@ type resultSingle struct {
 }
 
 func (rs resultSingle) Extract(c *Container, v reflect.Value) error {
-	c.cache[key{name: rs.Name, t: rs.Type}] = v
+	c.values[key{name: rs.Name, t: rs.Type}] = v
 	return nil
 }
 

--- a/stringer.go
+++ b/stringer.go
@@ -30,7 +30,7 @@ import (
 func (c *Container) String() string {
 	b := &bytes.Buffer{}
 	fmt.Fprintln(b, "nodes: {")
-	for k, vs := range c.producers {
+	for k, vs := range c.providers {
 		for _, v := range vs {
 			fmt.Fprintln(b, "\t", k, "->", v)
 		}

--- a/stringer.go
+++ b/stringer.go
@@ -30,13 +30,15 @@ import (
 func (c *Container) String() string {
 	b := &bytes.Buffer{}
 	fmt.Fprintln(b, "nodes: {")
-	for k, v := range c.nodes {
-		fmt.Fprintln(b, "\t", k, "->", v)
+	for k, vs := range c.producers {
+		for _, v := range vs {
+			fmt.Fprintln(b, "\t", k, "->", v)
+		}
 	}
 	fmt.Fprintln(b, "}")
 
 	fmt.Fprintln(b, "cache: {")
-	for k, v := range c.cache {
+	for k, v := range c.values {
 		fmt.Fprintln(b, "\t", k, "=>", v)
 	}
 	fmt.Fprintln(b, "}")


### PR DESCRIPTION
This changes how the graph is represented internally from storing a
`map[key]*node` to `map[key][]*node`. This essentially allows a key to
have a dependency on multiple nodes (constructors).

As part of this change, I also renamed this dependency map to
`providers` and the store for values from `cache` to `values`, which I
think is clearer.