### PR TITLE
Add support for value groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v1.2.0 (unreleased)
 
-- No changes yet.
+- `dig.In` and `dig.Out` now support value groups, making it possible to
+  produce many values of the same type from different constructors. See package
+  documentation for more information.
 
 ## v1.1.0 (2017-09-15)
 

--- a/dig.go
+++ b/dig.go
@@ -429,7 +429,7 @@ func detectCycles(par param, graph map[key][]*node, path []key) error {
 }
 
 // Checks if a field of an In struct is optional.
-func isFieldOptional(parent reflect.Type, f reflect.StructField) (bool, error) {
+func isFieldOptional(f reflect.StructField) (bool, error) {
 	tag := f.Tag.Get(_optionalTag)
 	if tag == "" {
 		return false, nil
@@ -438,8 +438,8 @@ func isFieldOptional(parent reflect.Type, f reflect.StructField) (bool, error) {
 	optional, err := strconv.ParseBool(tag)
 	if err != nil {
 		err = errWrapf(err,
-			"invalid value %q for %q tag on field %v of %v",
-			tag, _optionalTag, f.Name, parent)
+			"invalid value %q for %q tag on field %v",
+			tag, _optionalTag, f.Name)
 	}
 
 	return optional, err

--- a/dig.go
+++ b/dig.go
@@ -288,10 +288,15 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 			return nil
 		}
 
-		if _, ok := cv.c.providers[k]; ok {
+		if ps := cv.c.providers[k]; len(ps) > 0 {
+			csigs := make([]string, len(ps))
+			for i, p := range ps {
+				csigs[i] = fmt.Sprint(p.ctype)
+			}
+
 			*cv.err = fmt.Errorf(
-				"cannot provide %v from %v in constructor %v: already in the container",
-				k, path, cv.n.ctype)
+				"cannot provide %v from %v in constructor %v: already provided by %v",
+				k, path, cv.n.ctype, csigs)
 			return nil
 		}
 

--- a/dig.go
+++ b/dig.go
@@ -21,7 +21,6 @@
 package dig
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -382,12 +381,12 @@ type errCycleDetected struct {
 }
 
 func (e errCycleDetected) Error() string {
-	b := new(bytes.Buffer)
-	for _, k := range e.Path {
-		fmt.Fprintf(b, "%v ->", k.t)
+	items := make([]string, len(e.Path)+1)
+	for i, k := range e.Path {
+		items[i] = fmt.Sprint(k)
 	}
-	fmt.Fprintf(b, "%v", e.Key.t)
-	return b.String()
+	items[len(items)-1] = fmt.Sprint(e.Key)
+	return strings.Join(items, " -> ")
 }
 
 func detectCycles(par param, graph map[key][]*node, path []key) error {

--- a/dig.go
+++ b/dig.go
@@ -39,7 +39,9 @@ const (
 
 // Unique identification of an object in the graph.
 type key struct {
-	t     reflect.Type
+	t reflect.Type
+
+	// Only one of name or group will be set.
 	name  string
 	group string
 }

--- a/dig.go
+++ b/dig.go
@@ -385,7 +385,7 @@ func (e errCycleDetected) Error() string {
 	for i, k := range e.Path {
 		items[i] = fmt.Sprint(k)
 	}
-	items[len(items)-1] = fmt.Sprint(e.Key)
+	items[len(e.Path)] = fmt.Sprint(e.Key)
 	return strings.Join(items, " -> ")
 }
 

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -60,7 +60,7 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 		err := c.Provide(func() B { return B{} })
 		require.Error(t, err, "B should fail to provide")
 		assert.Contains(t, err.Error(), `can't provide func() dig.A`)
-		assert.Contains(t, err.Error(), `already in the container`)
+		assert.Contains(t, err.Error(), `already provided by [func() dig.A]`)
 	})
 
 	t.Run("named instances", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1054,7 +1054,7 @@ func TestGroups(t *testing.T) {
 			require.FailNow(t, "this function must not be called")
 		})
 		require.Error(t, err, "expected failure")
-		assert.Contains(t, err.Error(), "failed to build string:[]x: ")
+		assert.Contains(t, err.Error(), "failed to build [string]:x")
 		assert.Equal(t, gaveErr, RootCause(err))
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -1492,7 +1492,7 @@ func TestProvideFailures(t *testing.T) {
 		require.Error(t, err, "expected error on the second provide")
 		assert.Contains(t, err.Error(),
 			"cannot provide *dig.A:foo from [0].A in constructor func() dig.ret2: "+
-				"already in the container")
+				"already provided by [func() dig.ret1]")
 	})
 
 	t.Run("out with unexported field should error", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1539,7 +1539,8 @@ func TestInvokeFailures(t *testing.T) {
 		}
 		err := c.Invoke(func(p param) { assert.Fail(t, "should never get here") })
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), `did you mean to export "string" (string) from dig.param?`)
+		assert.Contains(t, err.Error(),
+			`bad argument 1: bad field "string" of dig.param: unexported fields not allowed in dig.In, did you mean to export "string" (string)`)
 	})
 
 	t.Run("pointer in dependency is not supported", func(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -293,7 +293,7 @@
 //   }
 //
 // Any number of constructors may provide values to this named collection.
-// Other contsructors can request all values for this collection by requesting
+// Other constructors can request all values for this collection by requesting
 // a slice tagged with `group:".."`. This will execute all constructors that
 // provide a value to that group in an unspecified order.
 //

--- a/doc.go
+++ b/doc.go
@@ -288,7 +288,7 @@
 //     ..
 //   }
 //
-//   func NewEchoHanlder() HandlerResult {
+//   func NewEchoHandler() HandlerResult {
 //     ..
 //   }
 //

--- a/doc.go
+++ b/doc.go
@@ -267,4 +267,50 @@
 //     }
 //     // ...
 //   }
+//
+// Value Groups
+//
+// Dig provides value groups to allow producing and consuming many values of
+// the same type. Value groups allow constructors to send values to a named,
+// unordered collection in the container. Other constructors can request all
+// values in this collection as a slice.
+//
+// Constructors can send values into value groups by returning a dig.Out
+// struct tagged with `group:".."`.
+//
+//   type HandlerResult struct {
+//     dig.Out
+//
+//     Handler Handler `group:"server"`
+//   }
+//
+//   func NewHelloHandler() HandlerResult {
+//     ..
+//   }
+//
+//   func NewEchoHanlder() HandlerResult {
+//     ..
+//   }
+//
+// Any number of constructors may provide values to this named collection.
+// Other contsructors can request all values for this collection by requesting
+// a slice tagged with `group:".."`. This will execute all constructors that
+// provide a value to that group in an unspecified order.
+//
+//   type ServerParams struct {
+//     dig.In
+//
+//     Handlers []Handler `group:"server"`
+//   }
+//
+//   func NewServer(p ServerParams) *Server {
+//     server := newServer()
+//     for _, h := range p.Handlers {
+//       server.Register(h)
+//     }
+//     return server
+//   }
+//
+// Note that values in a value group are unordered. Dig makes no guarantees
+// about the order in which these values will be produced.
 package dig

--- a/param.go
+++ b/param.go
@@ -381,7 +381,7 @@ func newParamGroupedSlice(f reflect.StructField) (paramGroupedSlice, error) {
 			"field %q (%v) is not a slice", f.Name, f.Type)
 	case name != "":
 		return pg, fmt.Errorf(
-			"cannot use named values with value groups: name:%q provided with group:%q", name, pg.Group)
+			"cannot use named values with value groups: name:%q requested with group:%q", name, pg.Group)
 
 	case optional:
 		return pg, errors.New("value groups cannot be optional")

--- a/param.go
+++ b/param.go
@@ -34,8 +34,9 @@ import (
 //  paramObject   dig.In struct where each field in the struct can be another
 //                param.
 //  paramGroupedSlice
-//                A slice consuming a value group. This will receive alle the
-//                values grouped under that name.
+//                A slice consuming a value group. This will receive all
+//                values produced with a `group:".."` tag with the same name
+//                as a slice.
 type param interface {
 	fmt.Stringer
 
@@ -374,7 +375,7 @@ func (pt paramGroupedSlice) Build(c *Container) (reflect.Value, error) {
 	items := c.groups[k]
 
 	// shuffle the list so users don't rely on the ordering of grouped values
-	items = shuffledCopy(items)
+	items = shuffledCopy(c.rand, items)
 
 	result := reflect.MakeSlice(pt.Type, len(items), len(items))
 	for i, v := range items {
@@ -383,9 +384,8 @@ func (pt paramGroupedSlice) Build(c *Container) (reflect.Value, error) {
 	return result, nil
 }
 
-func shuffledCopy(items []reflect.Value) []reflect.Value {
+func shuffledCopy(rand *rand.Rand, items []reflect.Value) []reflect.Value {
 	newItems := make([]reflect.Value, len(items))
-	// TODO(abg): Inject rand to get some determinism during tests.
 	for i, j := range rand.Perm(len(items)) {
 		newItems[i] = items[j]
 	}

--- a/param.go
+++ b/param.go
@@ -378,7 +378,7 @@ func newParamGroupedSlice(f reflect.StructField) (paramGroupedSlice, error) {
 	switch {
 	case f.Type.Kind() != reflect.Slice:
 		return pg, fmt.Errorf("value groups may be consumed as slices only: "+
-			"field %q (%T) is not a slice", f.Name, f.Type)
+			"field %q (%v) is not a slice", f.Name, f.Type)
 	case name != "":
 		return pg, fmt.Errorf(
 			"cannot use named values with value groups: name:%q provided with group:%q", name, pg.Group)

--- a/param_test.go
+++ b/param_test.go
@@ -114,6 +114,6 @@ func TestParamObjectFailure(t *testing.T) {
 		_, err := newParamObject(reflect.TypeOf(in{}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(),
-			`unexported fields not allowed in dig.In, did you mean to export "a2" (dig.A) from dig.in?`)
+			`bad field "a2" of dig.in: unexported fields not allowed in dig.In, did you mean to export "a2" (dig.A)`)
 	})
 }

--- a/param_test.go
+++ b/param_test.go
@@ -117,3 +117,49 @@ func TestParamObjectFailure(t *testing.T) {
 			`bad field "a2" of dig.in: unexported fields not allowed in dig.In, did you mean to export "a2" (dig.A)`)
 	})
 }
+
+func TestParamGroupSliceErrors(t *testing.T) {
+	tests := []struct {
+		desc    string
+		shape   interface{}
+		wantErr string
+	}{
+		{
+			desc: "non-slice type are disallowed",
+			shape: struct {
+				In
+
+				Foo string `group:"foo"`
+			}{},
+			wantErr: "value groups may be consumed as slices only: " +
+				`field "Foo" (string) is not a slice`,
+		},
+		{
+			desc: "cannot provide name for a group",
+			shape: struct {
+				In
+
+				Foo []string `group:"foo" name:"bar"`
+			}{},
+			wantErr: "cannot use named values with value groups: " +
+				`name:"bar" provided with group:"foo"`,
+		},
+		{
+			desc: "cannot be optional",
+			shape: struct {
+				In
+
+				Foo []string `group:"foo" optional:"true"`
+			}{},
+			wantErr: "value groups cannot be optional",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := newParamObject(reflect.TypeOf(tt.shape))
+			require.Error(t, err, "expected failure")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/param_test.go
+++ b/param_test.go
@@ -142,7 +142,7 @@ func TestParamGroupSliceErrors(t *testing.T) {
 				Foo []string `group:"foo" name:"bar"`
 			}{},
 			wantErr: "cannot use named values with value groups: " +
-				`name:"bar" provided with group:"foo"`,
+				`name:"bar" requested with group:"foo"`,
 		},
 		{
 			desc: "cannot be optional",

--- a/result.go
+++ b/result.go
@@ -29,10 +29,12 @@ import (
 //
 // The following implementations exist:
 //   resultList    All values returned by the constructor.
-//   resultSingle  An explicitly requested type.
+//   resultSingle  A single value produced by a constructor.
 //   resultError   An error returned by the constructor.
 //   resultObject  dig.Out struct where each field in the struct can be
 //                 another result.
+//   resultGrouped A value produced by a constructor that is part of a value
+//                 group.
 type result interface {
 	// Extracts the values for this result from the provided value and
 	// stores them into the provided resultReceiver.
@@ -55,6 +57,7 @@ var (
 	_ result = resultError{}
 	_ result = resultObject{}
 	_ result = resultList{}
+	_ result = resultGrouped{}
 )
 
 // newResult builds a result from the given type.
@@ -126,7 +129,7 @@ func walkResult(r result, v resultVisitor) {
 	}
 
 	switch res := r.(type) {
-	case resultSingle, resultError:
+	case resultSingle, resultError, resultGrouped:
 		// No sub-results
 	case resultObject:
 		w := v
@@ -257,16 +260,23 @@ func newResultObject(t reflect.Type) (resultObject, error) {
 				f.Name, f.Type, t)
 		}
 
-		r, err := newResult(f.Type)
-		if err != nil {
-			return ro, errWrapf(err, "bad field %q of %v", f.Name, t)
-		}
+		var r result
+		if group := f.Tag.Get(_groupTag); group != "" {
+			// TODO(abg): Verify that a name or optional was not specified.
+			r = newResultGrouped(group, f.Type)
+		} else {
+			var err error
+			r, err = newResult(f.Type)
+			if err != nil {
+				return ro, errWrapf(err, "bad field %q of %v", f.Name, t)
+			}
 
-		name := f.Tag.Get(_nameTag)
-		if rs, ok := r.(resultSingle); ok {
-			// field tags apply only if the result is "simple"
-			rs.Name = name
-			r = rs
+			name := f.Tag.Get(_nameTag)
+			if rs, ok := r.(resultSingle); ok {
+				// field tags apply only if the result is "simple"
+				rs.Name = name
+				r = rs
+			}
 		}
 
 		ro.Fields = append(ro.Fields, resultObjectField{
@@ -282,4 +292,30 @@ func (ro resultObject) Extract(rr resultReceiver, v reflect.Value) {
 	for _, f := range ro.Fields {
 		f.Result.Extract(rr, v.Field(f.FieldIndex))
 	}
+}
+
+// resultGrouped is a value produced by a constructor that is part of a result
+// group.
+//
+// These will be produced as fields of a dig.Out struct.
+type resultGrouped struct {
+	// Name of the group as specified in the `group:".."` tag.
+	Group string
+
+	// Type of value produced.
+	Type reflect.Type
+}
+
+// newResultGrouped builds a new resultGrouped with the provided name and
+// type.
+//
+// The type MUST be a slice type.
+func newResultGrouped(group string, t reflect.Type) resultGrouped {
+	return resultGrouped{Group: group, Type: t}
+}
+
+func (rt resultGrouped) Extract(c *Container, v reflect.Value) error {
+	k := key{group: rt.Group, t: rt.Type}
+	c.groups[k] = append(c.groups[k], v)
+	return nil
 }

--- a/result.go
+++ b/result.go
@@ -51,6 +51,9 @@ type resultReceiver interface {
 
 	// Submits a new value to the receiver.
 	SubmitValue(name string, t reflect.Type, v reflect.Value)
+
+	// Submits a new value to a value group.
+	SubmitGroupValue(group string, t reflect.Type, v reflect.Value)
 }
 
 var (
@@ -338,8 +341,6 @@ func newResultGrouped(f reflect.StructField) (resultGrouped, error) {
 	return rg, nil
 }
 
-func (rt resultGrouped) Extract(c *Container, v reflect.Value) error {
-	k := key{group: rt.Group, t: rt.Type}
-	c.groups[k] = append(c.groups[k], v)
-	return nil
+func (rt resultGrouped) Extract(rr resultReceiver, v reflect.Value) {
+	rr.SubmitGroupValue(rt.Group, rt.Type, v)
 }

--- a/result.go
+++ b/result.go
@@ -332,7 +332,7 @@ func newResultGrouped(f reflect.StructField) (resultGrouped, error) {
 		return rg, fmt.Errorf(
 			"cannot use named values with value groups: name:%q provided with group:%q", name, rg.Group)
 	case optional:
-		return rg, errors.New("cannot mark value groups as optional")
+		return rg, errors.New("value groups cannot be optional")
 	}
 
 	return rg, nil

--- a/result_test.go
+++ b/result_test.go
@@ -146,6 +146,25 @@ func TestNewResultObjectErrors(t *testing.T) {
 			}{},
 			err: `bad field "Nested"`,
 		},
+		{
+			desc: "group with name should fail",
+			give: struct {
+				Out
+
+				Foo string `group:"foo" name:"bar"`
+			}{},
+			err: "cannot use named values with value groups: " +
+				`name:"bar" provided with group:"foo"`,
+		},
+		{
+			desc: "group marked as optional",
+			give: struct {
+				Out
+
+				Foo string `group:"foo" optional:"true"`
+			}{},
+			err: "value groups cannot be optional",
+		},
 	}
 
 	for _, tt := range tests {

--- a/stringer.go
+++ b/stringer.go
@@ -41,6 +41,11 @@ func (c *Container) String() string {
 	for k, v := range c.values {
 		fmt.Fprintln(b, "\t", k, "=>", v)
 	}
+	for k, vs := range c.groups {
+		for _, v := range vs {
+			fmt.Fprintln(b, "\t", k, "=>", v)
+		}
+	}
 	fmt.Fprintln(b, "}")
 
 	return b.String()
@@ -53,6 +58,9 @@ func (n *node) String() string {
 func (k key) String() string {
 	if k.name != "" {
 		return fmt.Sprintf("%v:%s", k.t, k.name)
+	}
+	if k.group != "" {
+		return fmt.Sprintf("%v:[]%s", k.t, k.group)
 	}
 	return k.t.String()
 }
@@ -86,4 +94,8 @@ func (op paramObject) String() string {
 		fields[i] = f.Param.String()
 	}
 	return strings.Join(fields, " ")
+}
+
+func (pt paramGroupedSlice) String() string {
+	return fmt.Sprintf("%v:[]%v", pt.Type.Elem(), pt.Group)
 }

--- a/stringer.go
+++ b/stringer.go
@@ -56,11 +56,15 @@ func (n *node) String() string {
 }
 
 func (k key) String() string {
+	// ~tally.Scope means optional
+	// ~tally.Scope:foo means named optional
+	// [io.Reader]:foo refers to a group of io.Readers called 'foo'
+
 	if k.name != "" {
 		return fmt.Sprintf("%v:%s", k.t, k.name)
 	}
 	if k.group != "" {
-		return fmt.Sprintf("%v:[]%s", k.t, k.group)
+		return fmt.Sprintf("[%v]:%s", k.t, k.group)
 	}
 	return k.t.String()
 }
@@ -97,5 +101,7 @@ func (op paramObject) String() string {
 }
 
 func (pt paramGroupedSlice) String() string {
-	return fmt.Sprintf("%v:[]%v", pt.Type.Elem(), pt.Group)
+	// [io.Reader]:foo refers to a group of io.Readers called 'foo'
+
+	return fmt.Sprintf("[%v]:%v", pt.Type.Elem(), pt.Group)
 }

--- a/stringer.go
+++ b/stringer.go
@@ -37,7 +37,7 @@ func (c *Container) String() string {
 	}
 	fmt.Fprintln(b, "}")
 
-	fmt.Fprintln(b, "cache: {")
+	fmt.Fprintln(b, "values: {")
 	for k, v := range c.values {
 		fmt.Fprintln(b, "\t", k, "=>", v)
 	}


### PR DESCRIPTION
This adds support for value groups to dig. In addition to supporting
named values with `dig.In/Out`, we now supported unordered groups of
named values.

To produce a named value, a constructor will tag a `dig.Out` field with
`group:".."`. Constructors which rely on value groups can consume these
values by declaring a slice tagged with `group:".."`.

For example, consider the YARPC TransportSpec use case. The constructor
that produces the TransportSpec will do,

    type TransportSpecResult struct {
        dig.Out

        TransportSpec config.TransportSpec `group:"yarpc.transports"`
    }

    func NewTransportSpec() TransportSpecResult

The constructor that consumes the TransportSpecs will do,

    type Param struct {
        dig.In

        TransportSpecs []config.TransportSpec `group:"yarpc.transports"`
    }

    func NewThing(Param) *Thing

Resolves #127 