### PR TITLE
Constructor error should not cause bad state

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -1688,3 +1688,20 @@ func TestNodeAlreadyCalled(t *testing.T) {
 	require.True(t, n.called, "node must be called")
 	require.NoError(t, n.Call(c), "calling again should be okay")
 }
+
+func TestFailingFunctionDoesNotCreateInvalidState(t *testing.T) {
+	type type1 struct{}
+
+	c := New()
+	require.NoError(t, c.Provide(func() (type1, error) {
+		return type1{}, errors.New("great sadness")
+	}), "provide failed")
+
+	require.Error(t, c.Invoke(func(type1) {
+		require.FailNow(t, "first invoke must not call the function")
+	}), "first invoke must fail")
+
+	require.Error(t, c.Invoke(func(type1) {
+		require.FailNow(t, "second invoke must not call the function")
+	}), "second invoke must fail")
+}

--- a/result_test.go
+++ b/result_test.go
@@ -68,7 +68,7 @@ func TestResultListExtractFails(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	assert.Panics(t, func() {
-		rl.Extract(New(), reflect.ValueOf("irrelevant"))
+		rl.Extract(newStagingReceiver(), reflect.ValueOf("irrelevant"))
 	})
 }
 
@@ -158,10 +158,10 @@ func TestNewResultObjectErrors(t *testing.T) {
 }
 
 type fakeResultVisit struct {
-	Visit         result
+	Visit                result
 	AnnotateWithField    *resultObjectField
 	AnnotateWithPosition int
-	Return        fakeResultVisits
+	Return               fakeResultVisits
 }
 
 func (fv fakeResultVisit) String() string {


### PR DESCRIPTION
This fixes a regression introduced by refactoring that left the
container in a bad state if a constructor failed.

The issue is that in the following,

    c.Invoke(func(myDepedency) { ... })
    c.Invoke(func(myDepedency) { ... })

If the constructor for myDepedency always fails, the function will still
be called on the second invoke because we will have recorded the output
of the myDepedency constructor from the first call.

This happens because `result.Extract` feeds its results directly into
the container. To fix this issue, I changed result.Extract to operate on
a resultReceiver interface instead of operating directly on the
container. An implementation of resultReceiver stages the pending
changes from a call and commits them to the container only if no errors
were encountered.

This also lets us change result.Extract to no longer return an error
because the error is sent directly to the resultReceiver.