### PR TITLE
doc: Value groups: Mention version

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -270,6 +270,8 @@
 //
 // Value Groups
 //
+//   Added in Dig 1.2
+//
 // Dig provides value groups to allow producing and consuming many values of
 // the same type. Value groups allow constructors to send values to a named,
 // unordered collection in the container. Other constructors can request all


### PR DESCRIPTION
This includes a little note in the docs that informs users that dig 1.2
or newer is needed to use value groups.