### PR TITLE
doc: Dedent "Added in [..]"

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -270,7 +270,7 @@
 //
 // Value Groups
 //
-//   Added in Dig 1.2
+// Added in Dig 1.2.
 //
 // Dig provides value groups to allow producing and consuming many values of
 // the same type. Value groups allow constructors to send values to a named,


### PR DESCRIPTION
We rendered "Added in Dig 1.2" as a code block intentionally but it
looks like godoc renders the "Value Groups" header as a paragraph
because of that. See https://godoc.org/go.uber.org/dig.

I'm dedenting this statement to have it rendered correctly.