### PR TITLE
Improved error messages

### DIFF
--- a/cycle.go
+++ b/cycle.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.uber.org/dig/internal/digreflect"
+)
+
+type cycleEntry struct {
+	Key  key
+	Func *digreflect.Func
+}
+
+type errCycleDetected struct {
+	Path []cycleEntry
+}
+
+func (e errCycleDetected) Error() string {
+	// We get something like,
+	//
+	//   foo provided by "path/to/package".NewFoo (path/to/file.go:42)
+	//   	depends on bar provided by "another/package".NewBar (somefile.go:1)
+	//   	depends on baz provided by "somepackage".NewBar (anotherfile.go:2)
+	//   	depends on foo provided by "path/to/package".NewFoo (path/to/file.go:42)
+	//
+	b := new(bytes.Buffer)
+
+	for i, entry := range e.Path {
+		if i > 0 {
+			b.WriteString("\n\tdepends on ")
+		}
+		fmt.Fprintf(b, "%v provided by %v", entry.Key, entry.Func)
+	}
+	return b.String()
+}
+
+func verifyAcyclic(c *Container, n *node, k key) error {
+	err := detectCycles(n, c.providers, []cycleEntry{
+		{Key: k, Func: n.Func},
+	})
+	if err != nil {
+		err = errWrapf(err, "this function introduces a cycle")
+	}
+	return err
+}
+
+func detectCycles(n *node, graph map[key][]*node, path []cycleEntry) error {
+	var err error
+	walkParam(n.Params, paramVisitorFunc(func(param param) bool {
+		if err != nil {
+			return false
+		}
+
+		var k key
+		switch p := param.(type) {
+		case paramSingle:
+			k = key{name: p.Name, t: p.Type}
+		case paramGroupedSlice:
+			// NOTE: The key uses the element type, not the slice type.
+			k = key{group: p.Group, t: p.Type.Elem()}
+		default:
+			// Recurse for non-edge params.
+			return true
+		}
+
+		entry := cycleEntry{Func: n.Func, Key: k}
+
+		for _, p := range path {
+			if p.Key == k {
+				err = errCycleDetected{Path: append(path, entry)}
+				return false
+			}
+		}
+
+		for _, n := range graph[k] {
+			if e := detectCycles(n, graph, append(path, entry)); e != nil {
+				err = e
+				return false
+			}
+		}
+
+		return true
+	}))
+
+	return err
+}

--- a/dig.go
+++ b/dig.go
@@ -409,7 +409,7 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 // Checks that all direct dependencies of the provided param are present in
 // the container. Returns an error if not.
 func shallowCheckDependencies(c *Container, p param) error {
-	var missing []key
+	var missing errMissingManyTypes
 	walkParam(p, paramVisitorFunc(func(p param) bool {
 		ps, ok := p.(paramSingle)
 		if !ok {
@@ -418,14 +418,14 @@ func shallowCheckDependencies(c *Container, p param) error {
 
 		k := key{name: ps.Name, t: ps.Type}
 		if ns := c.providers[k]; len(ns) == 0 && !ps.Optional {
-			missing = append(missing, k)
+			missing = append(missing, newErrMissingType(c, k))
 		}
 
 		return true
 	}))
 
 	if len(missing) > 0 {
-		return fmt.Errorf("container is missing: %v", missing)
+		return missing
 	}
 	return nil
 }

--- a/dig.go
+++ b/dig.go
@@ -164,6 +164,10 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 		return err
 	}
 
+	if err := shallowCheckDependencies(c, pl); err != nil {
+		return errWrapf(err, "missing dependencies for function %v", digreflect.InspectFunc(function))
+	}
+
 	args, err := pl.BuildList(c)
 	if err != nil {
 		return errArgumentsFailed{

--- a/dig.go
+++ b/dig.go
@@ -165,7 +165,7 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 	}
 
 	if err := shallowCheckDependencies(c, pl); err != nil {
-		return errWrapf(err, "missing dependencies for function %v", digreflect.InspectFunc(function))
+		return errMissingDependencies{Func: digreflect.InspectFunc(function), Reason: err}
 	}
 
 	args, err := pl.BuildList(c)
@@ -374,6 +374,10 @@ func newNode(ctor interface{}) (*node, error) {
 func (n *node) Call(c *Container) error {
 	if n.called {
 		return nil
+	}
+
+	if err := shallowCheckDependencies(c, n.Params); err != nil {
+		return errMissingDependencies{Func: n.Func, Reason: err}
 	}
 
 	args, err := n.Params.BuildList(c)

--- a/dig.go
+++ b/dig.go
@@ -383,7 +383,7 @@ func (n *node) Call(c *Container) error {
 	n.Results.ExtractList(receiver, results)
 
 	if err := receiver.Commit(c); err != nil {
-		return errWrapf(err, "constructor %v failed", n.ctype)
+		return errConstructorFailed{Func: n.Func, Reason: err}
 	}
 
 	n.called = true

--- a/dig.go
+++ b/dig.go
@@ -134,7 +134,10 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 		return fmt.Errorf("must provide constructor function, got %v (type %v)", constructor, ctype)
 	}
 	if err := c.provide(constructor); err != nil {
-		return errWrapf(err, "can't provide %v", ctype)
+		return errProvide{
+			Func:   digreflect.InspectFunc(constructor),
+			Reason: err,
+		}
 	}
 	return nil
 }

--- a/dig.go
+++ b/dig.go
@@ -296,20 +296,20 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 
 		if conflict, ok := cv.keyPaths[k]; ok {
 			*cv.err = fmt.Errorf(
-				"cannot provide %v from %v in constructor %v: already provided by %v",
-				k, path, cv.n.ctype, conflict)
+				"cannot provide %v from %v: already provided by %v",
+				k, path, conflict)
 			return nil
 		}
 
 		if ps := cv.c.providers[k]; len(ps) > 0 {
-			csigs := make([]string, len(ps))
+			cons := make([]string, len(ps))
 			for i, p := range ps {
-				csigs[i] = fmt.Sprint(p.ctype)
+				cons[i] = fmt.Sprint(p.Func)
 			}
 
 			*cv.err = fmt.Errorf(
-				"cannot provide %v from %v in constructor %v: already provided by %v",
-				k, path, cv.n.ctype, csigs)
+				"cannot provide %v from %v: already provided by %v",
+				k, path, strings.Join(cons, "; "))
 			return nil
 		}
 

--- a/dig.go
+++ b/dig.go
@@ -166,7 +166,10 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 
 	args, err := pl.BuildList(c)
 	if err != nil {
-		return errWrapf(err, "failed to get arguments for %v (type %v)", function, ftype)
+		return errArgumentsFailed{
+			Func:   digreflect.InspectFunc(function),
+			Reason: err,
+		}
 	}
 
 	returned := reflect.ValueOf(function).Call(args)
@@ -375,7 +378,7 @@ func (n *node) Call(c *Container) error {
 
 	args, err := n.Params.BuildList(c)
 	if err != nil {
-		return errWrapf(err, "couldn't get arguments for constructor %v", n.ctype)
+		return errArgumentsFailed{Func: n.Func, Reason: err}
 	}
 
 	receiver := newStagingReceiver()

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -59,8 +59,11 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 
 		err := c.Provide(func() B { return B{} })
 		require.Error(t, err, "B should fail to provide")
-		assert.Contains(t, err.Error(), `function "go.uber.org/dig".TestEndToEndSuccessWithAliases`)
-		assert.Contains(t, err.Error(), `cannot be provided: cannot provide dig.A`)
+		assertErrorMatches(t, err,
+			`function "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide dig.A from \[0\]:`,
+			`already provided by "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+`,
+		)
 	})
 
 	t.Run("named instances", func(t *testing.T) {

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -59,8 +59,8 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 
 		err := c.Provide(func() B { return B{} })
 		require.Error(t, err, "B should fail to provide")
-		assert.Contains(t, err.Error(), `can't provide func() dig.A`)
-		assert.Contains(t, err.Error(), `already provided by [func() dig.A]`)
+		assert.Contains(t, err.Error(), `function "go.uber.org/dig".TestEndToEndSuccessWithAliases`)
+		assert.Contains(t, err.Error(), `cannot be provided: cannot provide dig.A`)
 	})
 
 	t.Run("named instances", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1470,9 +1470,7 @@ func TestProvideFailures(t *testing.T) {
 			}
 		})
 		require.Error(t, err, "provide must return error")
-		require.Contains(t, err.Error(),
-			"cannot provide dig.A from [0].A2 in constructor func() dig.ret: "+
-				"already provided by [0].A1")
+		assert.Contains(t, err.Error(), `cannot provide dig.A from [0].A2: already provided by [0].A1`)
 	})
 
 	t.Run("provide multiple instances with the same name", func(t *testing.T) {
@@ -1493,9 +1491,8 @@ func TestProvideFailures(t *testing.T) {
 			return ret2{A: &A{}}
 		})
 		require.Error(t, err, "expected error on the second provide")
-		assert.Contains(t, err.Error(),
-			`cannot provide *dig.A[name="foo"] from [0].A in constructor func() dig.ret2: `+
-				"already provided by [func() dig.ret1]")
+		assert.Contains(t, err.Error(), `cannot provide *dig.A[name="foo"] from [0].A: `+
+			`already provided by "go.uber.org/dig".TestProvideFailures`)
 	})
 
 	t.Run("out with unexported field should error", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -1564,7 +1564,11 @@ func TestInvokeFailures(t *testing.T) {
 
 	t.Run("unmet dependency", func(t *testing.T) {
 		c := New()
-		assert.Error(t, c.Invoke(func(*bytes.Buffer) {}))
+
+		err := c.Invoke(func(*bytes.Buffer) {})
+		require.Error(t, err, "expected failure")
+		assert.Contains(t, err.Error(), `missing dependencies for function "go.uber.org/dig".TestInvokeFailures`)
+		assert.Contains(t, err.Error(), "type *bytes.Buffer is not in the container, did you mean to Provide it?")
 	})
 
 	t.Run("unmet required dependency", func(t *testing.T) {
@@ -1584,7 +1588,8 @@ func TestInvokeFailures(t *testing.T) {
 		})
 
 		require.Error(t, err, "expected invoke error")
-		require.Contains(t, err.Error(), "type *dig.type2 is not in the container, did you mean to Provide it?")
+		assert.Contains(t, err.Error(), `missing dependencies for function "go.uber.org/dig".TestInvokeFailures`)
+		assert.Contains(t, err.Error(), "type *dig.type2 is not in the container, did you mean to Provide it?")
 	})
 
 	t.Run("unmet named dependency", func(t *testing.T) {
@@ -1598,6 +1603,7 @@ func TestInvokeFailures(t *testing.T) {
 			t.Fatal("function should not be called")
 		})
 		require.Error(t, err, "invoke should fail")
+		assert.Contains(t, err.Error(), `missing dependencies for function "go.uber.org/dig".TestInvokeFailures`)
 		assert.Contains(t, err.Error(), `type *bytes.Buffer[name="foo"] is not in the container`)
 	})
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1727,7 +1727,8 @@ func TestInvokeFailures(t *testing.T) {
 			panic("shouldn't execute invoked function")
 		})
 		require.Error(t, err, "expected invoke error")
-		assert.Contains(t, err.Error(), "couldn't get arguments for constructor", "unexpected error text")
+		assert.Contains(t, err.Error(),
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func`)
 		assert.Contains(t, err.Error(), `returned a non-nil error: failed`)
 		assert.Equal(t, errFailed, RootCause(err), "root cause must match")
 	})

--- a/dig_test.go
+++ b/dig_test.go
@@ -1626,8 +1626,10 @@ func TestInvokeFailures(t *testing.T) {
 			t.Fatal("function must not be called")
 		})
 		require.Error(t, err, "invoke must fail")
-		require.Contains(t, err.Error(), "missing dependencies for *dig.type3")
-		require.Contains(t, err.Error(), "*dig.type1 is not in the container")
+		assert.Contains(t, err.Error(), `could not build arguments for function "go.uber.org/dig".TestInvokeFailures`)
+		assert.Contains(t, err.Error(), "failed to build *dig.type3:")
+		assert.Contains(t, err.Error(), `missing dependencies for function "go.uber.org/dig".TestInvokeFailures`)
+		require.Contains(t, err.Error(), "type *dig.type1 is not in the container")
 		// We don't expect type2 to be mentioned in the list because it's
 		// optional
 	})
@@ -1652,9 +1654,10 @@ func TestInvokeFailures(t *testing.T) {
 		})
 
 		require.Error(t, err, "invoke must fail")
-		assert.Contains(t, err.Error(), "missing dependencies for dig.type3: "+
-			"the following types are not in the container: "+
-			"dig.type1; *dig.type2 (did you mean dig.type2?)")
+		assert.Contains(t, err.Error(), `could not build arguments for function "go.uber.org/dig".TestInvokeFailures`)
+		assert.Contains(t, err.Error(), "failed to build dig.type3:")
+		assert.Contains(t, err.Error(), `missing dependencies for function "go.uber.org/dig".TestInvokeFailures`)
+		assert.Contains(t, err.Error(), "the following types are not in the container: dig.type1; *dig.type2 (did you mean dig.type2?)")
 	})
 
 	t.Run("invalid optional tag", func(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -780,7 +780,7 @@ func TestEndToEndSuccess(t *testing.T) {
 
 		err := c.Invoke(func(B) {})
 		require.Error(t, err, "invoking with B param should error out")
-		assert.Contains(t, err.Error(), "B isn't in the container")
+		assert.Contains(t, err.Error(), "B is not in the container")
 	})
 }
 
@@ -1584,7 +1584,7 @@ func TestInvokeFailures(t *testing.T) {
 		})
 
 		require.Error(t, err, "expected invoke error")
-		require.Contains(t, err.Error(), "dig.type2 isn't in the container")
+		require.Contains(t, err.Error(), "type *dig.type2 is not in the container, did you mean to Provide it?")
 	})
 
 	t.Run("unmet named dependency", func(t *testing.T) {
@@ -1598,7 +1598,7 @@ func TestInvokeFailures(t *testing.T) {
 			t.Fatal("function should not be called")
 		})
 		require.Error(t, err, "invoke should fail")
-		assert.Contains(t, err.Error(), `type *bytes.Buffer[name="foo"] isn't in the container`)
+		assert.Contains(t, err.Error(), `type *bytes.Buffer[name="foo"] is not in the container`)
 	})
 
 	t.Run("unmet constructor dependency", func(t *testing.T) {
@@ -1765,7 +1765,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.NoError(t, c.Invoke(func(param1) {}))
 		err := c.Invoke(func(param2) {})
 		require.Error(t, err, "provide should return error since cases don't match")
-		assert.Contains(t, err.Error(), `dig.A[name="camelcase"] isn't in the container`)
+		assert.Contains(t, err.Error(), `dig.A[name="camelcase"] is not in the container`)
 	})
 
 	t.Run("in unexported member gets an error", func(t *testing.T) {
@@ -2042,8 +2042,9 @@ func TestInvokeFailures(t *testing.T) {
 			require.FailNow(t, "must not be called")
 		})
 		require.Error(t, err, "expected failure")
-		assert.Contains(t, err.Error(), "type dig.A isn't in the container")
 		assert.Contains(t, err.Error(), `could not build value group dig.B[group="b"]`)
+		assert.Contains(t, err.Error(),
+			"type dig.A is not in the container, did you mean to Provide it")
 	})
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -2049,7 +2049,7 @@ func TestNodeAlreadyCalled(t *testing.T) {
 	type type1 struct{}
 	f := func() type1 { return type1{} }
 
-	n, err := newNode(f, reflect.TypeOf(f))
+	n, err := newNode(f)
 	require.NoError(t, err, "failed to build node")
 	require.False(t, n.called, "node must not have been called")
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1054,7 +1054,7 @@ func TestGroups(t *testing.T) {
 			require.FailNow(t, "this function must not be called")
 		})
 		require.Error(t, err, "expected failure")
-		assert.Contains(t, err.Error(), `failed to build string[group="x"]`)
+		assert.Contains(t, err.Error(), `could not build value group string[group="x"]`)
 		assert.Equal(t, gaveErr, RootCause(err))
 	})
 }
@@ -1581,7 +1581,6 @@ func TestInvokeFailures(t *testing.T) {
 		})
 
 		require.Error(t, err, "expected invoke error")
-		require.Contains(t, err.Error(), "could not get field T2")
 		require.Contains(t, err.Error(), "dig.type2 isn't in the container")
 	})
 
@@ -1596,7 +1595,6 @@ func TestInvokeFailures(t *testing.T) {
 			t.Fatal("function should not be called")
 		})
 		require.Error(t, err, "invoke should fail")
-		assert.Contains(t, err.Error(), "could not get field Buffer of dig.param")
 		assert.Contains(t, err.Error(), `type *bytes.Buffer[name="foo"] isn't in the container`)
 	})
 
@@ -2041,8 +2039,8 @@ func TestInvokeFailures(t *testing.T) {
 			require.FailNow(t, "must not be called")
 		})
 		require.Error(t, err, "expected failure")
-		assert.Contains(t, err.Error(), `could not get field Bs of dig.in: failed to build dig.B[group="b"]`)
 		assert.Contains(t, err.Error(), "type dig.A isn't in the container")
+		assert.Contains(t, err.Error(), `could not build value group dig.B[group="b"]`)
 	})
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1728,7 +1728,7 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected invoke error")
 		assert.Contains(t, err.Error(), "couldn't get arguments for constructor", "unexpected error text")
-		assert.Contains(t, err.Error(), ": failed", "unexpected error text")
+		assert.Contains(t, err.Error(), `returned a non-nil error: failed`)
 		assert.Equal(t, errFailed, RootCause(err), "root cause must match")
 	})
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1256,7 +1256,11 @@ func TestProvideCycleFails(t *testing.T) {
 		assert.NoError(t, c.Provide(newB))
 		err := c.Provide(newC)
 		require.Error(t, err, "expected error when introducing cycle")
-		require.Contains(t, err.Error(), "cycle")
+		assert.Contains(t, err.Error(), "this function introduces a cycle:")
+		assert.Contains(t, err.Error(), `*dig.C provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on *dig.B provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on *dig.A provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on *dig.C provided by "go.uber.org/dig".TestProvideCycleFails`)
 	})
 
 	t.Run("dig.In based cycle", func(t *testing.T) {
@@ -1294,7 +1298,11 @@ func TestProvideCycleFails(t *testing.T) {
 
 		err := c.Provide(newC)
 		require.Error(t, err, "expected error when introducing cycle")
-		assert.Contains(t, err.Error(), "introduces a cycle")
+		assert.Contains(t, err.Error(), "this function introduces a cycle:")
+		assert.Contains(t, err.Error(), `dig.C provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on dig.B provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on dig.A provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on dig.C provided by "go.uber.org/dig".TestProvideCycleFails`)
 	})
 
 	t.Run("group based cycle", func(t *testing.T) {
@@ -1356,16 +1364,11 @@ func TestProvideCycleFails(t *testing.T) {
 
 		err := c.Provide(newD)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(),
-			`introduces a cycle: *dig.D -> int[group="bar"] -> string[group="foo"] -> *dig.D`)
-	})
-
-	t.Run("detectCycles invalid param", func(t *testing.T) {
-		type badParam struct{ param }
-
-		assert.Panics(t, func() {
-			detectCycles(badParam{}, nil, nil)
-		})
+		assert.Contains(t, err.Error(), "this function introduces a cycle:")
+		assert.Contains(t, err.Error(), `*dig.D provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on int[group="bar"] provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on string[group="foo"] provided by "go.uber.org/dig".TestProvideCycleFails`)
+		assert.Contains(t, err.Error(), `depends on *dig.D provided by "go.uber.org/dig".TestProvideCycleFails`)
 	})
 }
 

--- a/error.go
+++ b/error.go
@@ -105,3 +105,16 @@ func (e errConstructorFailed) cause() error { return e.Reason }
 func (e errConstructorFailed) Error() string {
 	return fmt.Sprintf("function %v returned a non-nil error: %v", e.Func, e.Reason)
 }
+
+// errArgumentsFailed is returned when a function could not be run because one
+// of its dependencies failed to build for any reason.
+type errArgumentsFailed struct {
+	Func   *digreflect.Func
+	Reason error
+}
+
+func (e errArgumentsFailed) cause() error { return e.Reason }
+
+func (e errArgumentsFailed) Error() string {
+	return fmt.Sprintf("could not build arguments for function %v: %v", e.Func, e.Reason)
+}

--- a/error.go
+++ b/error.go
@@ -201,3 +201,27 @@ func (e errMissingType) Error() string {
 
 	return b.String()
 }
+
+// errMissingManyTypes combines multiple errMissingType errors.
+type errMissingManyTypes []errMissingType // length must be non-zero
+
+func (e errMissingManyTypes) Error() string {
+	if len(e) == 1 {
+		return e[0].Error()
+	}
+
+	b := new(bytes.Buffer)
+
+	b.WriteString("the following types are not in the container: ")
+	for i, err := range e {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(b, "%v", err.Key)
+		if err.Typo != nil {
+			fmt.Fprintf(b, " (did you mean %v?)", *err.Typo)
+		}
+	}
+
+	return b.String()
+}

--- a/error.go
+++ b/error.go
@@ -118,3 +118,28 @@ func (e errArgumentsFailed) cause() error { return e.Reason }
 func (e errArgumentsFailed) Error() string {
 	return fmt.Sprintf("could not build arguments for function %v: %v", e.Func, e.Reason)
 }
+
+// errParamSingleFailed is returned when a paramSingle could not be built.
+type errParamSingleFailed struct {
+	Key    key
+	Reason error
+}
+
+func (e errParamSingleFailed) cause() error { return e.Reason }
+
+func (e errParamSingleFailed) Error() string {
+	return fmt.Sprintf("failed to build %v: %v", e.Key, e.Reason)
+}
+
+// errParamGroupFailed is returned when a value group cannot be built because
+// any of the values in the group failed to build.
+type errParamGroupFailed struct {
+	Key    key
+	Reason error
+}
+
+func (e errParamGroupFailed) cause() error { return e.Reason }
+
+func (e errParamGroupFailed) Error() string {
+	return fmt.Sprintf("could not build value group %v: %v", e.Key, e.Reason)
+}

--- a/error.go
+++ b/error.go
@@ -121,6 +121,19 @@ func (e errArgumentsFailed) Error() string {
 	return fmt.Sprintf("could not build arguments for function %v: %v", e.Func, e.Reason)
 }
 
+// errMissingDependencies is returned when the dependencies of a function are
+// not available in the container.
+type errMissingDependencies struct {
+	Func   *digreflect.Func
+	Reason error
+}
+
+func (e errMissingDependencies) cause() error { return e.Reason }
+
+func (e errMissingDependencies) Error() string {
+	return fmt.Sprintf("missing dependencies for function %v: %v", e.Func, e.Reason)
+}
+
 // errParamSingleFailed is returned when a paramSingle could not be built.
 type errParamSingleFailed struct {
 	Key    key

--- a/error.go
+++ b/error.go
@@ -20,7 +20,11 @@
 
 package dig
 
-import "fmt"
+import (
+	"fmt"
+
+	"go.uber.org/dig/internal/digreflect"
+)
 
 // Errors which know their underlying cause should implement this interface to
 // be compatible with RootCause.
@@ -74,4 +78,17 @@ func (e wrappedError) cause() error { return e.err }
 
 func (e wrappedError) Error() string {
 	return fmt.Sprintf("%v: %v", e.msg, e.err)
+}
+
+// errProvide is returned when a constructor could not be Provided into the
+// container.
+type errProvide struct {
+	Func   *digreflect.Func
+	Reason error
+}
+
+func (e errProvide) cause() error { return e.Reason }
+
+func (e errProvide) Error() string {
+	return fmt.Sprintf("function %v cannot be provided: %v", e.Func, e.Reason)
 }

--- a/error.go
+++ b/error.go
@@ -92,3 +92,16 @@ func (e errProvide) cause() error { return e.Reason }
 func (e errProvide) Error() string {
 	return fmt.Sprintf("function %v cannot be provided: %v", e.Func, e.Reason)
 }
+
+// errConstructorFailed is returned when a user-provided constructor failed
+// with a non-nil error.
+type errConstructorFailed struct {
+	Func   *digreflect.Func
+	Reason error
+}
+
+func (e errConstructorFailed) cause() error { return e.Reason }
+
+func (e errConstructorFailed) Error() string {
+	return fmt.Sprintf("function %v returned a non-nil error: %v", e.Func, e.Reason)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -22,6 +22,9 @@ package dig
 
 import (
 	"errors"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,4 +56,92 @@ func TestErrWrapf(t *testing.T) {
 		assert.Equal(t, "something else went wrong: something went wrong: great sadness", werr.Error(),
 			"error message must match")
 	})
+}
+
+// assertErrorMatches matches error messages against the provided list of
+// strings.
+//
+// The error must match each string in-order. That is, the following is valid,
+//
+//   assertErrorMatches(t, errors.New("foo bar baz"), "foo", "baz")
+//
+// But not,
+//
+//   assertErrorMatches(t, errors.New("foo bar baz"), "foo", "baz", "bar")
+//
+// Because "bar" is not after "baz" in the error message.
+//
+// Messages will be treated as regular expressions.
+func assertErrorMatches(t testing.TB, err error, msg string, msgs ...string) {
+	// We have one positional argument in addition to the variadic argument to
+	// ensure that there's at least one string to match against.
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	var finders []consumingFinder
+	for _, m := range append([]string{msg}, msgs...) {
+		if r, err := regexp.Compile(m); err == nil {
+			finders = append(finders, regexpFinder{r})
+		} else {
+			finders = append(finders, stringFinder(m))
+		}
+	}
+
+	original := err.Error()
+	remaining := original
+	for _, f := range finders {
+		if newRemaining, ok := f.Find(remaining); ok {
+			remaining = newRemaining
+			continue
+		}
+
+		// Match not found. Check if the order was wrong.
+		if _, ok := f.Find(original); ok {
+			// We won't use %q for the error message itself because we want it
+			// to be printed to the console as it would actually show.
+			t.Errorf(`"%v" contains %v in the wrong place`, original, f)
+		} else {
+			t.Errorf(`"%v" does not contain %v`, original, f)
+		}
+	}
+}
+
+// consumingFinder matches a string and returns the rest of the string *after*
+// the match.
+type consumingFinder interface {
+	// Attempt to match against the given string and return false if a match
+	// could not be found.
+	//
+	// If a match was found, return the remaining string after the entire
+	// match. So if the finder matches "oo" in "foobar", the returned string
+	// must be just "bar".
+	Find(got string) (rest string, ok bool)
+}
+
+type regexpFinder struct{ r *regexp.Regexp }
+
+func (r regexpFinder) String() string {
+	return "`" + r.r.String() + "`"
+}
+
+func (r regexpFinder) Find(got string) (rest string, ok bool) {
+	loc := r.r.FindStringIndex(got)
+	if len(loc) == 0 {
+		return got, false
+	}
+	return got[loc[1]:], true
+}
+
+type stringFinder string
+
+func (s stringFinder) String() string { return strconv.Quote(string(s)) }
+
+func (s stringFinder) Find(got string) (rest string, ok bool) {
+	i := strings.Index(got, string(s))
+	if i < 0 {
+		return got, false
+	}
+	return got[i+len(s):], true
 }

--- a/internal/digreflect/func.go
+++ b/internal/digreflect/func.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package digreflect
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+// Func contains runtime information about a function.
+type Func struct {
+	// Name of the function.
+	Name string
+
+	// Name of the package in which this function is defined.
+	Package string
+
+	// Path to the file in which this function is defined.
+	File string
+
+	// Line number in the file at which this function is defined.
+	Line int
+}
+
+// String returns a string representation of the function.
+func (f *Func) String() string {
+	// "path/to/package".MyFunction (path/to/file.go:42)
+	return fmt.Sprintf("%q.%v (%v:%v)", f.Package, f.Name, f.File, f.Line)
+}
+
+// InspectFunc inspects and returns runtime information about the given
+// function.
+func InspectFunc(function interface{}) *Func {
+	fptr := reflect.ValueOf(function).Pointer()
+	f := runtime.FuncForPC(fptr)
+	pkgName, funcName := splitFuncName(f.Name())
+	fileName, lineNum := f.FileLine(fptr)
+	return &Func{
+		Name:    funcName,
+		Package: pkgName,
+		File:    fileName,
+		Line:    lineNum,
+	}
+}
+
+const _vendor = "/vendor/"
+
+func splitFuncName(function string) (pname string, fname string) {
+	if len(function) == 0 {
+		return
+	}
+
+	// We have something like "path.to/my/pkg.MyFunction". If the function is
+	// a closure, it is something like, "path.to/my/pkg.MyFunction.func1".
+
+	idx := 0
+
+	// Everything up to the first "." after the last "/" is the package name.
+	// Everything after the "." is the full function name.
+	if i := strings.LastIndex(function, "/"); i >= 0 {
+		idx = i
+	}
+	if i := strings.Index(function[idx:], "."); i >= 0 {
+		idx += i
+	}
+	pname, fname = function[:idx], function[idx+1:]
+
+	// The package may be vendored.
+	if i := strings.Index(pname, _vendor); i > 0 {
+		pname = pname[i+len(_vendor):]
+	}
+
+	// Package names are URL-encoded to avoid ambiguity in the case where the
+	// package name contains ".git". Otherwise, "foo/bar.git.MyFunction" would
+	// mean that "git" is the top-level function and "MyFunction" is embedded
+	// inside it.
+	if unescaped, err := url.QueryUnescape(pname); err == nil {
+		pname = unescaped
+	}
+
+	return
+}

--- a/internal/digreflect/func_test.go
+++ b/internal/digreflect/func_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package digreflect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	myrepository "go.uber.org/dig/internal/digreflect/tests/myrepository.git"
+	mypackage "go.uber.org/dig/internal/digreflect/tests/myrepository.git/mypackage"
+)
+
+func SomeExportedFunction() {}
+
+func unexportedFunction() {}
+
+func nestedFunctions() (nested1, nested2, nested3 func()) {
+	// we call the functions to satisfy the linter.
+	nested1 = func() {}
+	nested2 = func() {
+		nested3 = func() {}
+	}
+	nested2() // set nested3
+	return
+}
+
+func TestInspectFunc(t *testing.T) {
+	nested1, nested2, nested3 := nestedFunctions()
+
+	tests := []struct {
+		desc        string
+		give        interface{}
+		wantName    string
+		wantPackage string
+
+		// We don't match the exact file name because $GOPATH can be anywhere
+		// on someone's system. Instead we'll match the suffix.
+		wantFileSuffix string
+		wantStringLike string
+	}{
+		{
+			desc:           "exported function",
+			give:           SomeExportedFunction,
+			wantName:       "SomeExportedFunction",
+			wantPackage:    "go.uber.org/dig/internal/digreflect",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/func_test.go",
+		},
+		{
+			desc:           "unexported function",
+			give:           unexportedFunction,
+			wantName:       "unexportedFunction",
+			wantPackage:    "go.uber.org/dig/internal/digreflect",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/func_test.go",
+		},
+		{
+			desc:           "nested function",
+			give:           nested1,
+			wantName:       "nestedFunctions.func1",
+			wantPackage:    "go.uber.org/dig/internal/digreflect",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/func_test.go",
+		},
+		{
+			desc:           "second nested function",
+			give:           nested2,
+			wantName:       "nestedFunctions.func2",
+			wantPackage:    "go.uber.org/dig/internal/digreflect",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/func_test.go",
+		},
+		{
+			desc:           "nested inside a nested function",
+			give:           nested3,
+			wantName:       "nestedFunctions.func2.1",
+			wantPackage:    "go.uber.org/dig/internal/digreflect",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/func_test.go",
+		},
+		{
+			desc:           "inside a .git package",
+			give:           myrepository.Hello,
+			wantName:       "Hello",
+			wantPackage:    "go.uber.org/dig/internal/digreflect/tests/myrepository.git",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/tests/myrepository.git/hello.go",
+		},
+		{
+			desc:           "subpackage of a .git package",
+			give:           mypackage.Add,
+			wantName:       "Add",
+			wantPackage:    "go.uber.org/dig/internal/digreflect/tests/myrepository.git/mypackage",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/tests/myrepository.git/mypackage/add.go",
+		},
+		{
+			desc:           "vendored dependency",
+			give:           myrepository.VendoredDependencyFunction(),
+			wantName:       "Panic",
+			wantPackage:    "mydependency",
+			wantFileSuffix: "go.uber.org/dig/internal/digreflect/tests/myrepository.git/vendor/mydependency/panic.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			f := InspectFunc(tt.give)
+			assert.Equal(t, tt.wantName, f.Name, "function name did not match")
+			assert.Equal(t, tt.wantPackage, f.Package, "package name did not match")
+
+			assert.True(t, strings.HasSuffix(f.File, "src/"+tt.wantFileSuffix),
+				"file path %q does not end with src/%v", f.File, tt.wantFileSuffix)
+			assert.Contains(t, f.String(), tt.wantFileSuffix, "file path not in String output")
+		})
+	}
+}
+
+func TestSplitFuncEmptyString(t *testing.T) {
+	pname, fname := splitFuncName("")
+	assert.Empty(t, pname, "package name must be empty")
+	assert.Empty(t, fname, "function name must be empty")
+}

--- a/internal/digreflect/tests/myrepository.git/hello.go
+++ b/internal/digreflect/tests/myrepository.git/hello.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package myrepository
+
+import "fmt"
+
+// Hello says hello.
+func Hello() {
+	fmt.Println("hello")
+}

--- a/internal/digreflect/tests/myrepository.git/mypackage/add.go
+++ b/internal/digreflect/tests/myrepository.git/mypackage/add.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mypackage
+
+import "fmt"
+
+// Add adds numbers.
+func Add(a, b int) {
+	fmt.Println(a + b)
+}

--- a/internal/digreflect/tests/myrepository.git/vendor.go
+++ b/internal/digreflect/tests/myrepository.git/vendor.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package myrepository
+
+import "mydependency"
+
+// VendoredDependencyFunction returns the function for a vendored dependency
+// of this repository.
+//
+// We need this function because we can't import anything from vendor/ from
+// outside this package.
+func VendoredDependencyFunction() func() {
+	return mydependency.Panic
+}

--- a/internal/digreflect/tests/myrepository.git/vendor/mydependency/panic.go
+++ b/internal/digreflect/tests/myrepository.git/vendor/mydependency/panic.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mydependency
+
+// Panic panics.
+func Panic() {
+	panic("There is no need to be alarmed.")
+}

--- a/param.go
+++ b/param.go
@@ -212,30 +212,11 @@ func (ps paramSingle) Build(c *Container) (reflect.Value, error) {
 
 	nodes := c.providers[k]
 	if len(nodes) == 0 {
-		// Unlike in the fallback case below, if a user makes an error
-		// requesting an optional value, a good error message ("did you mean
-		// X?") will not be used and we'll return a zero value instead.
 		if ps.Optional {
 			return reflect.Zero(ps.Type), nil
 		}
 
-		// If the type being asked for is the pointer that is not found,
-		// check if the graph contains the value type element - perhaps the user
-		// accidentally included a splat and vice versa.
-		var typo reflect.Type
-		if ps.Type.Kind() == reflect.Ptr {
-			typo = ps.Type.Elem()
-		} else {
-			typo = reflect.PtrTo(ps.Type)
-		}
-
-		tk := key{t: typo, name: ps.Name}
-		if _, ok := c.providers[tk]; ok {
-			return _noValue, fmt.Errorf(
-				"type %v is not in the container, did you mean to use %v?", k, tk)
-		}
-
-		return _noValue, fmt.Errorf("type %v isn't in the container", k)
+		return _noValue, newErrMissingType(c, k)
 	}
 
 	for _, n := range nodes {

--- a/result_test.go
+++ b/result_test.go
@@ -34,12 +34,10 @@ func TestNewResultListErrors(t *testing.T) {
 	tests := []struct {
 		desc string
 		give interface{}
-		err  string
 	}{
 		{
 			desc: "returns dig.In",
 			give: func() struct{ In } { panic("invalid") },
-			err:  "bad result 1: cannot provide parameter objects",
 		},
 		{
 			desc: "returns dig.Out+dig.In",
@@ -49,7 +47,6 @@ func TestNewResultListErrors(t *testing.T) {
 			} {
 				panic("invalid")
 			},
-			err: "bad result 1: cannot provide parameter objects",
 		},
 	}
 
@@ -57,7 +54,10 @@ func TestNewResultListErrors(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			_, err := newResultList(reflect.TypeOf(tt.give))
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.err)
+			assertErrorMatches(t, err,
+				"bad result 1:",
+				"cannot provide parameter objects:",
+				"embeds a dig.In")
 		})
 	}
 }


### PR DESCRIPTION
This PR attempts to make the error messages returned by dig more
helpful.

One common complaint people have with the error messages is that
the function signature is useless. The following message provides no
avenue for debugging.

    already provided by func() *Foo

One of the primary changes made in this PR is that function locations
are reported where appropriate. So the above becomes,

    already provided by "path/to/package".NewFoo (path/to/file.go:42)

I recommend reviewing each commit individually as these changes
collectively modify most of the files in dig in different places.