### PR TITLE
Provide: Add Name option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   information.
 
 ### Changed
-- `name:"..."` tags on nested Result Objects are no longer ignored.
+- `name:"..."` tags on nested Result Objects will now cause errors instead of
+  being ignored.
 
 ## [1.3.0] - 2017-12-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Added `Name` option for `Provide` to add named values to the container
+  without rewriting constructors. See package documentation for more
+  information.
+
+### Changed
+- `name:"..."` tags on nested Result Objects are no longer ignored.
 
 ## [1.3.0] - 2017-12-04
 ### Changed

--- a/dig.go
+++ b/dig.go
@@ -85,26 +85,19 @@ func (f provideOptionFunc) applyProvideOption(opts *provideOptions) { f(opts) }
 // constructor should have the given name. See also the package documentation
 // about Named Values.
 //
-// The name also applies to the fields of a dig.Out struct returned by the
-// constructor if those fields did not have their own name:"..." tag.
-//
 // Given,
 //
-//   type ConnectionResult struct {
-//     dig.Out
-//
-//     Conn    *sql.DB
-//     ROConn  *sql.DB `name:"ro"`
-//   }
-//
-//   func NewConnection(...) (ConnectionResult, error)
+//   func NewReadOnlyConnection(...) (*Connection, error)
+//   func NewReadWriteConnection(...) (*Connection, error)
 //
 // The following will provide two connections to the container: one under the
 // name "ro" and the other under the name "rw".
 //
-//   c.Provide(NewConnection, dig.Name("rw"))
+//   c.Provide(NewReadOnlyConnection, dig.Name("ro"))
+//   c.Provide(NewReadWriteConnection, dig.Name("rw"))
 //
-// This option has no effect on Value Groups.
+// This option cannot be provided for constructors which produce result
+// objects.
 func Name(name string) ProvideOption {
 	return provideOptionFunc(func(opts *provideOptions) {
 		opts.Name = name

--- a/doc.go
+++ b/doc.go
@@ -221,10 +221,25 @@
 // Named Values
 //
 // Some use cases call for multiple values of the same type. Dig allows adding
-// multiple values of the same type to the container with the use of
-// `name:".."` tags on fields of dig.In and dig.Out structs.
+// multiple values of the same type to the container with the use of Named
+// Values.
 //
-// A constructor that produces a dig.Out struct can tag any field with
+// Named Values can be produced by passing the dig.Name option when a
+// constructor is provided. All values produced by that constructor will have
+// the given name.
+//
+// Given the following constructors,
+//
+//   func NewReadOnlyConnection(...) (*sql.DB, error)
+//   func NewReadWriteConnection(...) (*sql.DB, error)
+//
+// You can provide *sql.DB into a Container under different names by passing
+// the dig.Name option.
+//
+//   c.Provide(NewReadOnlyConnection, dig.Name("ro"))
+//   c.Provide(NewReadWriteConnection, dig.Name("rw"))
+//
+// Alternatively, you can produce a dig.Out struct and tag its fields with
 // `name:".."` to have the corresponding value added to the graph under the
 // specified name.
 //
@@ -240,8 +255,9 @@
 //     return ConnectionResult{ReadWrite: rw, ReadOnly:  ro}, nil
 //   }
 //
-// Another constructor can consume these values by adding fields to a dig.In
-// struct with the same name AND type.
+// Regardless of how a Named Value was produced, it can be consumed by another
+// constructor by accepting a dig.In struct which has exported fields with the
+// same name AND type that you provided.
 //
 //   type GatewayParams struct {
 //     dig.In

--- a/result.go
+++ b/result.go
@@ -235,6 +235,10 @@ type resultObject struct {
 
 func newResultObject(t reflect.Type, opts resultOptions) (resultObject, error) {
 	ro := resultObject{Type: t}
+	if len(opts.Name) > 0 {
+		return ro, fmt.Errorf(
+			"cannot specify a name for result objects: %v embeds dig.Out", t)
+	}
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)


### PR DESCRIPTION
This adds a `Name(string)` option to `Provide()` so that the following,

    c.Provide(NewThing, Name("foo"))

Is the same as the following,

    type result struct {
        dig.Out

        Thing *Thing `name:"foo"`
    }

    c.Provide(func(...) result {
        return result{Thing: NewThing(..)}
    })

The name applies to *all* values produced by the constructor--even if it
produces multiple values. Passing this option is not allowed if the
constructor produces a Result object.

This change was motivated by an offline discussion with @bayesianmind.
We agreed that Fx needs to support some way to specify the name for a
value produced by a constructor without rewriting the constructor to
produce an fx.Out. An API similar to the following was suggested.

    fx.Provide(fx.Named("foo", NewThing))

Regardless of the user-facing API, such functionality would need to rely
on reflection pretty heavily. It would need to generate a function using
`reflect.MakeFunc` equivalent to the following,

    func(...) (out struct {
        fx.Out

        Result *Thing `name:"foo"`
    }) {
        out.Result = NewThing(...)
        return
    }

See yarpc/yarpc-go#1200 for an example of the initial attempt made by
@bayesianmind.

I don't think that this functionality should rely this heavily on some
fairly fragile reflection logic. The way to build anonymous structs with
embedded fields is not the same between Go 1.8 and 1.9 (see
https://github.com/uber-go/dig/blob/a84ae412585ef6c4b8fc2f7577ff80f701317314/dig_test.go#L628-L635).

Supporting this in Dig natively is much more straightforward and safer,
and it requires no reflection.

This change defers the decision of how we should treat names on Result Objects
by throwing an error in that case.