### PR TITLE
Reduce access of internals between abstractions

### DIFF
--- a/result_test.go
+++ b/result_test.go
@@ -217,7 +217,7 @@ func TestNewResultObjectErrors(t *testing.T) {
 
 				Error error
 			}{},
-			err: `cannot return errors from dig.Out, return it from the constructor instead: field "Error" (error)`,
+			err: `bad field "Error" of struct { dig.Out; Error error }: cannot return an error here, return it from the constructor instead`,
 		},
 		{
 			desc: "nested dig.In",

--- a/result_test.go
+++ b/result_test.go
@@ -68,7 +68,7 @@ func TestResultListExtractFails(t *testing.T) {
 	}), resultOptions{})
 	require.NoError(t, err)
 	assert.Panics(t, func() {
-		rl.Extract(newStagingReceiver(), reflect.ValueOf("irrelevant"))
+		rl.Extract(newStagingContainerWriter(), reflect.ValueOf("irrelevant"))
 	})
 }
 

--- a/stringer.go
+++ b/stringer.go
@@ -52,7 +52,7 @@ func (c *Container) String() string {
 }
 
 func (n *node) String() string {
-	return fmt.Sprintf("deps: %v, ctor: %v", n.Params, n.ctype)
+	return fmt.Sprintf("deps: %v, ctor: %v", n.paramList, n.ctype)
 }
 
 func (k key) String() string {


### PR DESCRIPTION
(Each commit should be reviewed individually.)

This pull request changes some of the internals to stop relying on internal
details of each other.

Previously, everything was accessing and modifying the internals of
`*Container` and `*node`. This pull request puts a bunch of interfaces and
unexported methods in place instead.

These changes are needed so that we can move some of the code from the
top-level package into internal packages, which will allow us to re-use that
functionality from a Dig introspection package.