### PR TITLE
make/license: ignore vendor/ only and other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ dependencies:
 	glide --version || go get -u -f github.com/Masterminds/glide
 	glide install
 	@echo "Installing uber-license tool..."
-	update-license -h || go get -u -f go.uber.org/tools/update-license
+	command -v update-license >/dev/null || go get -u -f go.uber.org/tools/update-license
 	@echo "Installing golint..."
-	golint -h || go get -u -f github.com/golang/lint/golint
+	command -v golint >/dev/null || go get -u -f github.com/golang/lint/golint
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ dependencies:
 	@echo "Installing golint..."
 	command -v golint >/dev/null || go get -u -f github.com/golang/lint/golint
 
+.PHONY: license
+license: dependencies
+	./check_license.sh | tee -a lint.log
+
 .PHONY: lint
 lint:
 	@rm -rf lint.log

--- a/check_license.sh
+++ b/check_license.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 run_update_license() {
   # doing this because of SC2046 warning
-  for file in $(find . -name '*.go' | grep -v \.\/vendor); do
+  for file in $(git ls-files | grep '\.go$'); do
     update-license $@ "${file}"
   done
 }

--- a/internal/digreflect/tests/myrepository.git/vendor.go
+++ b/internal/digreflect/tests/myrepository.git/vendor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/digreflect/tests/myrepository.git/vendor/mydependency/panic.go
+++ b/internal/digreflect/tests/myrepository.git/vendor/mydependency/panic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR includes a couple fixes to our `make lint` handling. See individual
commits for details.