### PR TITLE
Visualize: Parse graph into DOT format

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -213,10 +213,7 @@ type VisualizeOption interface {
 	unimplemented()
 }
 
-// Visualize parses the graph in Container c into DOT format and writes it to
-// io.Writer w.
-func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
-	graphTmpl := template.Must(template.New("DotGraph").Parse(`digraph {
+var _graphTmpl = template.Must(template.New("DotGraph").Parse(`digraph {
 	graph [compound=true];
 	{{range $index, $ctor := .Ctors}}
 		subgraph cluster_{{$index}} {
@@ -231,7 +228,10 @@ func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
 	{{end}}
 }`))
 
-	if err := graphTmpl.Execute(w, c.dg); err != nil {
+// Visualize parses the graph in Container c into DOT format and writes it to
+// io.Writer w.
+func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
+	if err := _graphTmpl.Execute(w, c.dg); err != nil {
 		return fmt.Errorf("error executing template: %v", err)
 	}
 	return nil

--- a/dig.go
+++ b/dig.go
@@ -23,11 +23,13 @@ package dig
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"go.uber.org/dig/internal/digreflect"
@@ -203,6 +205,45 @@ func New(opts ...Option) *Container {
 		opt.applyOption(c)
 	}
 	return c
+}
+
+// A VisualizeOption modifies the default behavior of Visualize. It's included for
+// future functionality; currently, there are no concrete implementations.
+type VisualizeOption interface {
+	unimplemented()
+}
+
+// Visualize parses the graph in Container c into DOT format and writes it to
+// io.Writer w. The nodes(types) are clustered by constructors. Clusters and
+// nodes are connected by directed edges in the graph to indicate dependency.
+//
+// For example, if constructor c1 has params p1 and p2, c1 -> t1 and c1 -> t2.
+//
+// Different type attributes are represented differently on the graph -
+//   The names and groups of types are indicated in sublabels.
+//   An optional dependency is indicated by dotted edges to the params.
+func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
+	tmpl := `digraph {
+	graph [compound=true];
+{{range $index, $ctor := .Ctors}}
+	subgraph cluster_{{$index}} {
+		"{{.Name}}" [shape=plaintext];
+{{range $res := .Results}}
+		"{{.String}}" [label=<{{.Type}}{{.Attributes}}>];{{end}}
+	}
+{{range $par := .Params}}
+	"{{$ctor.Name}}" -> "{{.String}}" [ltail=cluster_{{$index}}{{if .Optional}} style=dashed{{end}}];{{end}}
+{{end}}}`
+
+	t := template.New("DOT graph")
+	t, err := t.Parse(tmpl)
+	if err != nil {
+		return fmt.Errorf("error parsing DOT graph template: got %v", err)
+	}
+	if err := t.Execute(w, c.dg); err != nil {
+		return fmt.Errorf("error executing DOT graph template: got %v", err)
+	}
+	return nil
 }
 
 // Changes the source of randomness for the container.

--- a/dig.go
+++ b/dig.go
@@ -207,8 +207,8 @@ func New(opts ...Option) *Container {
 	return c
 }
 
-// A VisualizeOption modifies the default behavior of Visualize. It's included for
-// future functionality; currently, there are no concrete implementations.
+// A VisualizeOption modifies the default behavior of Visualize. It's included
+// for future functionality; currently, there are no concrete implementations.
 type VisualizeOption interface {
 	unimplemented()
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -2474,7 +2474,10 @@ func TestDotGraph(t *testing.T) {
 	type t3 struct{}
 	type t4 struct{}
 
-	n1, n2, n3, n4 := &dot.Node{Type: "dig.t1"}, &dot.Node{Type: "dig.t2"}, &dot.Node{Type: "dig.t3"}, &dot.Node{Type: "dig.t4"}
+	n1 := &dot.Node{Type: "t1"}
+	n2 := &dot.Node{Type: "t2"}
+	n3 := &dot.Node{Type: "t3"}
+	n4 := &dot.Node{Type: "t4"}
 
 	t.Parallel()
 
@@ -2723,7 +2726,10 @@ func TestNewDotCtor(t *testing.T) {
 }
 
 func TestVisualize(t *testing.T) {
-	n1, n2, n3, n4 := &dot.Node{Type: "t1"}, &dot.Node{Type: "t2"}, &dot.Node{Type: "t3"}, &dot.Node{Type: "t4"}
+	n1 := &dot.Node{Type: "t1"}
+	n2 := &dot.Node{Type: "t2"}
+	n3 := &dot.Node{Type: "t3"}
+	n4 := &dot.Node{Type: "t4"}
 
 	t.Parallel()
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -2721,3 +2721,57 @@ func TestNewDotCtor(t *testing.T) {
 	assert.Equal(t, []*dot.Node{{Type: "dig.t1"}}, ctor.Params)
 	assert.Equal(t, []*dot.Node{{Type: "dig.t2"}}, ctor.Results)
 }
+
+func TestVisualize(t *testing.T) {
+	n1, n2, n3, n4 := &dot.Node{Type: "t1"}, &dot.Node{Type: "t2"}, &dot.Node{Type: "t3"}, &dot.Node{Type: "t4"}
+
+	t.Parallel()
+
+	t.Run("empty graph in container", func(t *testing.T) {
+		c := New()
+		VerifyVisualization(t, "empty", c)
+	})
+
+	t.Run("simple graph", func(t *testing.T) {
+		c := New()
+		c.dg.Ctors = []*dot.Ctor{{
+			Name:    "constructor1",
+			Params:  []*dot.Node{n1},
+			Results: []*dot.Node{n3},
+		}, {
+			Name:    "constructor2",
+			Params:  []*dot.Node{n2},
+			Results: []*dot.Node{n4},
+		}}
+
+		VerifyVisualization(t, "simple", c)
+	})
+
+	t.Run("named and grouped types", func(t *testing.T) {
+		c := New()
+		c.dg.Ctors = []*dot.Ctor{{
+			Name:   "constructor1",
+			Params: []*dot.Node{n3},
+			Results: []*dot.Node{
+				{Type: "t1", Name: "foo"},
+				{Type: "t2", Group: "bar"},
+			},
+		}}
+
+		VerifyVisualization(t, "sublabel", c)
+	})
+
+	t.Run("optional params", func(t *testing.T) {
+		c := New()
+		c.dg.Ctors = []*dot.Ctor{{
+			Name: "constructor1",
+			Params: []*dot.Node{
+				{Type: "t1", Name: "foo", Optional: true},
+				{Type: "t2", Optional: true},
+			},
+			Results: []*dot.Node{n3},
+		}}
+
+		VerifyVisualization(t, "optional", c)
+	})
+}

--- a/dig_test.go
+++ b/dig_test.go
@@ -2474,10 +2474,10 @@ func TestDotGraph(t *testing.T) {
 	type t3 struct{}
 	type t4 struct{}
 
-	n1 := &dot.Node{Type: "t1"}
-	n2 := &dot.Node{Type: "t2"}
-	n3 := &dot.Node{Type: "t3"}
-	n4 := &dot.Node{Type: "t4"}
+	n1 := &dot.Node{Type: "dig.t1"}
+	n2 := &dot.Node{Type: "dig.t2"}
+	n3 := &dot.Node{Type: "dig.t3"}
+	n4 := &dot.Node{Type: "dig.t4"}
 
 	t.Parallel()
 

--- a/internal/dot/graph.go
+++ b/internal/dot/graph.go
@@ -45,9 +45,10 @@ type Node struct {
 	Group    string
 }
 
-// String returns the string representation of a node so the different constructors can refer to
-// the same node. We omit information on the optional field since the same type can be optional to
-// one constructor and required for another.
+// String returns the string representation of a node so the different
+// constructors can refer to the same node. We omit information on the optional
+// field since the same type can be optional to one constructor and required
+// for another.
 func (n *Node) String() string {
 	if n.Name != "" {
 		return fmt.Sprintf("%v[name=%v]", n.Type, n.Name)
@@ -58,7 +59,8 @@ func (n *Node) String() string {
 	return n.Type
 }
 
-// Attributes composes and returns a string to style the sublabels when visualizing graph.
+// Attributes composes and returns a string to style the sublabels when
+// visualizing graph.
 func (n *Node) Attributes() string {
 	if n.Name != "" {
 		return fmt.Sprintf("<BR /><FONT POINT-SIZE=\"10\">Name: %v</FONT>", n.Name)

--- a/internal/dot/graph.go
+++ b/internal/dot/graph.go
@@ -45,18 +45,17 @@ type Node struct {
 	Group    string
 }
 
-// String returns the string representation of a node so the different
-// constructors can refer to the same node. We omit information on the optional
-// field since the same type can be optional to one constructor and required
-// for another.
+// String implements fmt.Stringer for Node. We omit the optional field since a
+// type can be optional to one constructor and required for another.
 func (n *Node) String() string {
-	if n.Name != "" {
+	switch {
+	case n.Name != "":
 		return fmt.Sprintf("%v[name=%v]", n.Type, n.Name)
-	} else if n.Group != "" {
+	case n.Group != "":
 		return fmt.Sprintf("%v[group=%v]", n.Type, n.Group)
+	default:
+		return n.Type
 	}
-
-	return n.Type
 }
 
 // Attributes composes and returns a string to style the sublabels when

--- a/internal/dot/graph.go
+++ b/internal/dot/graph.go
@@ -20,6 +20,8 @@
 
 package dot
 
+import "fmt"
+
 // Ctor encodes a constructor provided to the container for the DOT graph.
 type Ctor struct {
 	Name    string
@@ -41,4 +43,28 @@ type Node struct {
 	Name     string
 	Optional bool
 	Group    string
+}
+
+// String returns the string representation of a node so the different constructors can refer to
+// the same node. We omit information on the optional field since the same type can be optional to
+// one constructor and required for another.
+func (n *Node) String() string {
+	if n.Name != "" {
+		return fmt.Sprintf("%v[name=%v]", n.Type, n.Name)
+	} else if n.Group != "" {
+		return fmt.Sprintf("%v[group=%v]", n.Type, n.Group)
+	}
+
+	return n.Type
+}
+
+// Attributes composes and returns a string to style the sublabels when visualizing graph.
+func (n *Node) Attributes() string {
+	if n.Name != "" {
+		return fmt.Sprintf("<BR /><FONT POINT-SIZE=\"10\">Name: %v</FONT>", n.Name)
+	} else if n.Group != "" {
+		return fmt.Sprintf("<BR /><FONT POINT-SIZE=\"10\">Group: %v</FONT>", n.Group)
+	} else {
+		return ""
+	}
 }

--- a/internal/dot/graph.go
+++ b/internal/dot/graph.go
@@ -62,11 +62,12 @@ func (n *Node) String() string {
 // Attributes composes and returns a string to style the sublabels when
 // visualizing graph.
 func (n *Node) Attributes() string {
-	if n.Name != "" {
-		return fmt.Sprintf("<BR /><FONT POINT-SIZE=\"10\">Name: %v</FONT>", n.Name)
-	} else if n.Group != "" {
-		return fmt.Sprintf("<BR /><FONT POINT-SIZE=\"10\">Group: %v</FONT>", n.Group)
-	} else {
+	switch {
+	case n.Name != "":
+		return fmt.Sprintf(`<BR /><FONT POINT-SIZE="10">Name: %v</FONT>`, n.Name)
+	case n.Group != "":
+		return fmt.Sprintf(`<BR /><FONT POINT-SIZE="10">Group: %v</FONT>`, n.Group)
+	default:
 		return ""
 	}
 }

--- a/internal/dot/graph_test.go
+++ b/internal/dot/graph_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package dot
 
 import (

--- a/internal/dot/graph_test.go
+++ b/internal/dot/graph_test.go
@@ -1,0 +1,27 @@
+package dot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeString(t *testing.T) {
+	n1 := &Node{Type: "t1"}
+	n2 := &Node{Type: "t2", Name: "bar"}
+	n3 := &Node{Type: "t3", Group: "foo"}
+
+	assert.Equal(t, "t1", n1.String())
+	assert.Equal(t, "t2[name=bar]", n2.String())
+	assert.Equal(t, "t3[group=foo]", n3.String())
+}
+
+func TestAttributes(t *testing.T) {
+	n1 := &Node{Type: "t1"}
+	n2 := &Node{Type: "t2", Name: "bar"}
+	n3 := &Node{Type: "t3", Group: "foo"}
+
+	assert.Equal(t, "", n1.Attributes())
+	assert.Equal(t, `<BR /><FONT POINT-SIZE="10">Name: bar</FONT>`, n2.Attributes())
+	assert.Equal(t, `<BR /><FONT POINT-SIZE="10">Group: foo</FONT>`, n3.Attributes())
+}

--- a/testdata/empty.dot
+++ b/testdata/empty.dot
@@ -1,3 +1,4 @@
 digraph {
 	graph [compound=true];
+	
 }

--- a/testdata/empty.dot
+++ b/testdata/empty.dot
@@ -1,0 +1,3 @@
+digraph {
+	graph [compound=true];
+}

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -1,0 +1,12 @@
+digraph {
+	graph [compound=true];
+
+	subgraph cluster_0 {
+		"constructor1" [shape=plaintext];
+
+		"t3" [label=<t3>];
+	}
+
+	"constructor1" -> "t1[name=foo]" [ltail=cluster_0 style=dashed];
+	"constructor1" -> "t2" [ltail=cluster_0 style=dashed];
+}

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -1,12 +1,16 @@
 digraph {
 	graph [compound=true];
-
-	subgraph cluster_0 {
-		"constructor1" [shape=plaintext];
-
-		"t3" [label=<t3>];
-	}
-
-	"constructor1" -> "t1[name=foo]" [ltail=cluster_0 style=dashed];
-	"constructor1" -> "t2" [ltail=cluster_0 style=dashed];
+	
+		subgraph cluster_0 {
+			"constructor1" [shape=plaintext];
+			
+				"t3" [label=<t3>];
+			
+		}
+		
+			"constructor1" -> "t1[name=foo]" [ltail=cluster_0 style=dashed];
+		
+			"constructor1" -> "t2" [ltail=cluster_0 style=dashed];
+		
+	
 }

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -1,0 +1,19 @@
+digraph {
+	graph [compound=true];
+
+	subgraph cluster_0 {
+		"constructor1" [shape=plaintext];
+
+		"t3" [label=<t3>];
+	}
+
+	"constructor1" -> "t1" [ltail=cluster_0];
+
+	subgraph cluster_1 {
+		"constructor2" [shape=plaintext];
+
+		"t4" [label=<t4>];
+	}
+
+	"constructor2" -> "t2" [ltail=cluster_1];
+}

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -1,19 +1,24 @@
 digraph {
 	graph [compound=true];
-
-	subgraph cluster_0 {
-		"constructor1" [shape=plaintext];
-
-		"t3" [label=<t3>];
-	}
-
-	"constructor1" -> "t1" [ltail=cluster_0];
-
-	subgraph cluster_1 {
-		"constructor2" [shape=plaintext];
-
-		"t4" [label=<t4>];
-	}
-
-	"constructor2" -> "t2" [ltail=cluster_1];
+	
+		subgraph cluster_0 {
+			"constructor1" [shape=plaintext];
+			
+				"t3" [label=<t3>];
+			
+		}
+		
+			"constructor1" -> "t1" [ltail=cluster_0];
+		
+	
+		subgraph cluster_1 {
+			"constructor2" [shape=plaintext];
+			
+				"t4" [label=<t4>];
+			
+		}
+		
+			"constructor2" -> "t2" [ltail=cluster_1];
+		
+	
 }

--- a/testdata/sublabel.dot
+++ b/testdata/sublabel.dot
@@ -1,0 +1,12 @@
+digraph {
+	graph [compound=true];
+
+	subgraph cluster_0 {
+		"constructor1" [shape=plaintext];
+
+		"t1[name=foo]" [label=<t1<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
+		"t2[group=bar]" [label=<t2<BR /><FONT POINT-SIZE="10">Group: bar</FONT>>];
+	}
+
+	"constructor1" -> "t3" [ltail=cluster_0];
+}

--- a/testdata/sublabel.dot
+++ b/testdata/sublabel.dot
@@ -1,12 +1,16 @@
 digraph {
 	graph [compound=true];
-
-	subgraph cluster_0 {
-		"constructor1" [shape=plaintext];
-
-		"t1[name=foo]" [label=<t1<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
-		"t2[group=bar]" [label=<t2<BR /><FONT POINT-SIZE="10">Group: bar</FONT>>];
-	}
-
-	"constructor1" -> "t3" [ltail=cluster_0];
+	
+		subgraph cluster_0 {
+			"constructor1" [shape=plaintext];
+			
+				"t1[name=foo]" [label=<t1<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
+			
+				"t2[group=bar]" [label=<t2<BR /><FONT POINT-SIZE="10">Group: bar</FONT>>];
+			
+		}
+		
+			"constructor1" -> "t3" [ltail=cluster_0];
+		
+	
 }

--- a/visualize_golden_test.go
+++ b/visualize_golden_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package dig
 
 import (

--- a/visualize_golden_test.go
+++ b/visualize_golden_test.go
@@ -1,0 +1,34 @@
+package dig
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var generate = flag.Bool("generate", false, "generates output to testdata/ if set")
+
+func VerifyVisualization(t *testing.T, testname string, c *Container) {
+	flag.Parse()
+
+	var b bytes.Buffer
+	require.NoError(t, Visualize(c, &b))
+
+	if *generate {
+		err := ioutil.WriteFile("testdata/"+testname+".dot", b.Bytes(), 0644)
+		require.NoError(t, err)
+		return
+	}
+
+	wantBytes, err := ioutil.ReadFile("testdata/" + testname + ".dot")
+	require.NoError(t, err)
+
+	got := b.String()
+	want := string(wantBytes)
+	assert.Equal(t, want, got,
+		"Output did not match. Make sure you updated the testdata by running 'go test -generate'")
+}

--- a/visualize_golden_test.go
+++ b/visualize_golden_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"flag"
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,18 +34,18 @@ import (
 var generate = flag.Bool("generate", false, "generates output to testdata/ if set")
 
 func VerifyVisualization(t *testing.T, testname string, c *Container) {
-	flag.Parse()
-
 	var b bytes.Buffer
 	require.NoError(t, Visualize(c, &b))
 
+	dotFile := filepath.Join("testdata", testname+".dot")
+
 	if *generate {
-		err := ioutil.WriteFile("testdata/"+testname+".dot", b.Bytes(), 0644)
+		err := ioutil.WriteFile(dotFile, b.Bytes(), 0644)
 		require.NoError(t, err)
 		return
 	}
 
-	wantBytes, err := ioutil.ReadFile("testdata/" + testname + ".dot")
+	wantBytes, err := ioutil.ReadFile(dotFile)
 	require.NoError(t, err)
 
 	got := b.String()


### PR DESCRIPTION
Added `Visualize` method that takes in a `Container` object, parses its dependency graph into DOT format, and writes to an `io.Writer`.