### PR TITLE
Add canonical import path

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -331,4 +331,4 @@
 //
 // Note that values in a value group are unordered. Dig makes no guarantees
 // about the order in which these values will be produced.
-package dig
+package dig // import "go.uber.org/dig"


### PR DESCRIPTION
This adds the canonical import path directive so that people don't
try to import this as github.com/uber-go/dig and see cryptic error
messages.