### PR TITLE
[do not review] Subscribe constructors to grouped params

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -198,7 +198,7 @@ func New(opts ...Option) *Container {
 		values:    make(map[key]reflect.Value),
 		groups:    make(map[key][]reflect.Value),
 		rand:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		dg:        new(dot.Graph),
+		dg:        dot.NewGraph(),
 	}
 
 	for _, opt := range opts {
@@ -222,7 +222,7 @@ func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
 		subgraph cluster_{{$index}} {
 			{{printf "%q" .Name}} [shape=plaintext];
 			{{range $res := .Results}}
-				{{printf "%q" .String}} [label=<{{.Type}}{{.Attributes}}>];
+				{{printf "%q" .String}} [label=<{{.Type.String}}{{.Attributes}}>];
 			{{end}}
 		}
 		{{range $par := .Params}}
@@ -382,6 +382,7 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -410,7 +411,7 @@ func (c *Container) provide(ctor interface{}, opts provideOptions) error {
 		}
 	}
 
-	c.dg.Ctors = append(c.dg.Ctors, newDotCtor(n))
+	c.dg.AddDotCtor(newDotCtor(n))
 
 	return nil
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -2474,7 +2474,15 @@ func TestDotGraph(t *testing.T) {
 	type t3 struct{}
 	type t4 struct{}
 
-	n1, n2, n3, n4 := &dot.Node{Type: "dig.t1"}, &dot.Node{Type: "dig.t2"}, &dot.Node{Type: "dig.t3"}, &dot.Node{Type: "dig.t4"}
+	type1 := reflect.TypeOf(t1{})
+	type2 := reflect.TypeOf(t2{})
+	type3 := reflect.TypeOf(t3{})
+	type4 := reflect.TypeOf(t4{})
+
+	n1 := &dot.Node{Type: type1}
+	n2 := &dot.Node{Type: type2}
+	n3 := &dot.Node{Type: type3}
+	n4 := &dot.Node{Type: type4}
 
 	t.Parallel()
 
@@ -2627,17 +2635,17 @@ func TestDotGraph(t *testing.T) {
 			C t1 `group:"foo"`
 		}
 
+		p1 := &dot.Node{Type: type1, Group: "foo", GroupIndex: 0}
+		p2 := &dot.Node{Type: type1, Group: "foo", GroupIndex: 1}
+		p3 := &dot.Node{Type: type1, Group: "foo", GroupIndex: 2}
+
 		expected := []*dot.Ctor{
 			{
-				Params: []*dot.Node{n2},
-				Results: []*dot.Node{
-					{Type: "dig.t1", Group: "foo"},
-					{Type: "dig.t1", Group: "foo"},
-					{Type: "dig.t1", Group: "foo"},
-				},
+				Params:  []*dot.Node{n2},
+				Results: []*dot.Node{p1, p2, p3},
 			},
 			{
-				Params:  []*dot.Node{{Type: "[]dig.t1", Group: "foo"}},
+				Params:  []*dot.Node{p1, p2, p3},
 				Results: []*dot.Node{n3},
 			},
 		}
@@ -2663,8 +2671,8 @@ func TestDotGraph(t *testing.T) {
 
 		expected := []*dot.Ctor{
 			{
-				Params:  []*dot.Node{{Type: "dig.t1", Name: "A"}},
-				Results: []*dot.Node{{Type: "dig.t2", Name: "B"}},
+				Params:  []*dot.Node{{Type: type1, Name: "A"}},
+				Results: []*dot.Node{{Type: type2, Name: "B"}},
 			},
 		}
 
@@ -2685,9 +2693,9 @@ func TestDotGraph(t *testing.T) {
 		expected := []*dot.Ctor{
 			{
 				Params: []*dot.Node{
-					{Type: "dig.t1", Name: "A", Optional: true},
-					{Type: "dig.t2", Name: "B"},
-					{Type: "dig.t3", Optional: true},
+					{Type: type1, Name: "A", Optional: true},
+					{Type: type2, Name: "B"},
+					{Type: type3, Optional: true},
 				},
 				Results: []*dot.Node{n4},
 			},
@@ -2702,6 +2710,8 @@ func TestDotGraph(t *testing.T) {
 func TestNewDotCtor(t *testing.T) {
 	type t1 struct{}
 	type t2 struct{}
+
+	type1, type2 := reflect.TypeOf(t1{}), reflect.TypeOf(t2{})
 
 	n, err := newNode(func(A t1) t2 { return t2{} }, nodeOptions{})
 	require.NoError(t, err)
@@ -2718,12 +2728,20 @@ func TestNewDotCtor(t *testing.T) {
 	assert.Equal(t, "pkg1", ctor.Package)
 	assert.Equal(t, "file1", ctor.File)
 	assert.Equal(t, 24534, ctor.Line)
-	assert.Equal(t, []*dot.Node{{Type: "dig.t1"}}, ctor.Params)
-	assert.Equal(t, []*dot.Node{{Type: "dig.t2"}}, ctor.Results)
+	assert.Equal(t, []*dot.Node{{Type: type1}}, ctor.Params)
+	assert.Equal(t, []*dot.Node{{Type: type2}}, ctor.Results)
 }
 
 func TestVisualize(t *testing.T) {
-	n1, n2, n3, n4 := &dot.Node{Type: "t1"}, &dot.Node{Type: "t2"}, &dot.Node{Type: "t3"}, &dot.Node{Type: "t4"}
+	type1 := reflect.TypeOf(72)
+	type2 := reflect.TypeOf("72")
+	type3 := reflect.TypeOf(true)
+	type4 := reflect.TypeOf(72.0)
+
+	n1 := &dot.Node{Type: type1}
+	n2 := &dot.Node{Type: type2}
+	n3 := &dot.Node{Type: type3}
+	n4 := &dot.Node{Type: type4}
 
 	t.Parallel()
 
@@ -2753,8 +2771,8 @@ func TestVisualize(t *testing.T) {
 			Name:   "constructor1",
 			Params: []*dot.Node{n3},
 			Results: []*dot.Node{
-				{Type: "t1", Name: "foo"},
-				{Type: "t2", Group: "bar"},
+				{Type: type1, Name: "foo"},
+				{Type: type2, Group: "bar"},
 			},
 		}}
 
@@ -2766,8 +2784,8 @@ func TestVisualize(t *testing.T) {
 		c.dg.Ctors = []*dot.Ctor{{
 			Name: "constructor1",
 			Params: []*dot.Node{
-				{Type: "t1", Name: "foo", Optional: true},
-				{Type: "t2", Optional: true},
+				{Type: type1, Name: "foo", Optional: true},
+				{Type: type2, Optional: true},
 			},
 			Results: []*dot.Node{n3},
 		}}

--- a/internal/dot/graph.go
+++ b/internal/dot/graph.go
@@ -20,7 +20,10 @@
 
 package dot
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 // Ctor encodes a constructor provided to the container for the DOT graph.
 type Ctor struct {
@@ -34,15 +37,42 @@ type Ctor struct {
 
 // Graph is the DOT-format graph in a Container.
 type Graph struct {
-	Ctors []*Ctor
+	Ctors       []*Ctor
+	ctorMap     map[key][]*Ctor
+	nodes       map[key][]*Node
+	subscribers map[key][]*Ctor
 }
 
 // Node is a single node in a graph.
 type Node struct {
-	Type     string
-	Name     string
-	Optional bool
-	Group    string
+	Type       reflect.Type
+	Name       string
+	Optional   bool
+	Group      string
+	GroupIndex int
+}
+
+type key struct {
+	t     reflect.Type
+	name  string
+	group string
+}
+
+// NewGraph creates a new empty graph.
+func NewGraph() *Graph {
+	return &Graph{
+		ctorMap:     make(map[key][]*Ctor),
+		nodes:       make(map[key][]*Node),
+		subscribers: make(map[key][]*Ctor),
+	}
+}
+
+// AddDotCtor adds a constructor to the graph, changing the params and results
+// of the constructor to point at the nodes they refer to, and subscribing it
+// to any grouped params.
+func (dg *Graph) AddDotCtor(c *Ctor) {
+	c.findParams(dg, c.Params)
+	dg.addResults(c)
 }
 
 // String returns the string representation of a node so the different
@@ -51,12 +81,12 @@ type Node struct {
 // for another.
 func (n *Node) String() string {
 	if n.Name != "" {
-		return fmt.Sprintf("%v[name=%v]", n.Type, n.Name)
+		return fmt.Sprintf("%v[name=%v]", n.Type.String(), n.Name)
 	} else if n.Group != "" {
-		return fmt.Sprintf("%v[group=%v]", n.Type, n.Group)
+		return fmt.Sprintf("%v[group=%v]%v", n.Type.String(), n.Group, n.GroupIndex)
 	}
 
-	return n.Type
+	return n.Type.String()
 }
 
 // Attributes composes and returns a string to style the sublabels when
@@ -70,4 +100,64 @@ func (n *Node) Attributes() string {
 	default:
 		return ""
 	}
+}
+
+func (dg *Graph) subscribe(k key, c *Ctor) {
+	if dg.subscribers[k] == nil {
+		dg.subscribers[k] = []*Ctor{c}
+	} else {
+		dg.subscribers[k] = append(dg.subscribers[k], c)
+	}
+}
+
+func (dg *Graph) addResults(c *Ctor) {
+	for i, node := range c.Results {
+		k := key{t: node.Type, name: node.Name, group: node.Group}
+
+		switch {
+		case node.Group != "":
+			if dg.nodes[k] == nil {
+				dg.nodes[k] = []*Node{}
+			}
+
+			node.GroupIndex = len(dg.nodes[k])
+			dg.nodes[k] = append(dg.nodes[k], node)
+
+			if dg.subscribers[k] != nil {
+				for _, ctor := range dg.subscribers[k] {
+					ctor.Params = append(ctor.Params, node)
+				}
+			}
+		case dg.nodes[k] == nil:
+			dg.nodes[k] = []*Node{node}
+		default:
+			c.Results[i] = dg.nodes[k][0]
+		}
+
+		if dg.ctorMap[k] == nil {
+			dg.ctorMap[k] = []*Ctor{c}
+		} else {
+			dg.ctorMap[k] = append(dg.ctorMap[k], c)
+		}
+	}
+	dg.Ctors = append(dg.Ctors, c)
+}
+
+func (c *Ctor) findParams(dg *Graph, nodes []*Node) {
+	ptrs := []*Node{}
+	for _, node := range c.Params {
+		var k key
+		k = key{t: node.Type, name: node.Name, group: node.Group}
+
+		if node.Group != "" {
+			dg.subscribe(k, c)
+		} else {
+			if dg.nodes[k] == nil {
+				dg.nodes[k] = []*Node{node}
+			}
+		}
+
+		ptrs = append(ptrs, dg.nodes[k]...)
+	}
+	c.Params = ptrs
 }

--- a/internal/dot/graph_test.go
+++ b/internal/dot/graph_test.go
@@ -21,25 +21,35 @@
 package dot
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNodeString(t *testing.T) {
-	n1 := &Node{Type: "t1"}
-	n2 := &Node{Type: "t2", Name: "bar"}
-	n3 := &Node{Type: "t3", Group: "foo"}
+func TestNewGraph(t *testing.T) {
+	dg := NewGraph()
 
-	assert.Equal(t, "t1", n1.String())
-	assert.Equal(t, "t2[name=bar]", n2.String())
-	assert.Equal(t, "t3[group=foo]", n3.String())
+	assert.Equal(t, "*dot.Graph", reflect.TypeOf(dg).String())
+	assert.Equal(t, make(map[key][]*Ctor), dg.ctorMap)
+	assert.Equal(t, make(map[key][]*Node), dg.nodes)
+	assert.Equal(t, make(map[key][]*Ctor), dg.subscribers)
+}
+
+func TestNodeString(t *testing.T) {
+	n1 := &Node{Type: reflect.TypeOf("123")}
+	n2 := &Node{Type: reflect.TypeOf(123), Name: "bar"}
+	n3 := &Node{Type: reflect.TypeOf(123.0), Group: "foo"}
+
+	assert.Equal(t, "string", n1.String())
+	assert.Equal(t, "int[name=bar]", n2.String())
+	assert.Equal(t, "float64[group=foo]0", n3.String())
 }
 
 func TestAttributes(t *testing.T) {
-	n1 := &Node{Type: "t1"}
-	n2 := &Node{Type: "t2", Name: "bar"}
-	n3 := &Node{Type: "t3", Group: "foo"}
+	n1 := &Node{Type: reflect.TypeOf(123)}
+	n2 := &Node{Type: reflect.TypeOf(123), Name: "bar"}
+	n3 := &Node{Type: reflect.TypeOf(123), Group: "foo", GroupIndex: 2}
 
 	assert.Equal(t, "", n1.Attributes())
 	assert.Equal(t, `<BR /><FONT POINT-SIZE="10">Name: bar</FONT>`, n2.Attributes())

--- a/param.go
+++ b/param.go
@@ -218,7 +218,7 @@ type paramSingle struct {
 
 func (ps paramSingle) DotNodes() []*dot.Node {
 	return []*dot.Node{{
-		Type:     ps.Type.String(),
+		Type:     ps.Type,
 		Name:     ps.Name,
 		Optional: ps.Optional,
 	}}
@@ -392,7 +392,7 @@ type paramGroupedSlice struct {
 
 func (pt paramGroupedSlice) DotNodes() []*dot.Node {
 	return []*dot.Node{{
-		Type:  pt.Type.String(),
+		Type:  pt.Type.Elem(),
 		Group: pt.Group,
 	}}
 }

--- a/result.go
+++ b/result.go
@@ -237,7 +237,7 @@ type resultSingle struct {
 
 func (rs resultSingle) DotNodes() []*dot.Node {
 	return []*dot.Node{{
-		Type: rs.Type.String(),
+		Type: rs.Type,
 		Name: rs.Name,
 	}}
 }
@@ -363,7 +363,7 @@ type resultGrouped struct {
 
 func (rt resultGrouped) DotNodes() []*dot.Node {
 	return []*dot.Node{{
-		Type:  rt.Type.String(),
+		Type:  rt.Type,
 		Group: rt.Group,
 	}}
 }

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -4,13 +4,13 @@ digraph {
 		subgraph cluster_0 {
 			"constructor1" [shape=plaintext];
 			
-				"t3" [label=<t3>];
+				"bool" [label=<bool>];
 			
 		}
 		
-			"constructor1" -> "t1[name=foo]" [ltail=cluster_0 style=dashed];
+			"constructor1" -> "int[name=foo]" [ltail=cluster_0 style=dashed];
 		
-			"constructor1" -> "t2" [ltail=cluster_0 style=dashed];
+			"constructor1" -> "string" [ltail=cluster_0 style=dashed];
 		
 	
 }

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -4,21 +4,21 @@ digraph {
 		subgraph cluster_0 {
 			"constructor1" [shape=plaintext];
 			
-				"t3" [label=<t3>];
+				"bool" [label=<bool>];
 			
 		}
 		
-			"constructor1" -> "t1" [ltail=cluster_0];
+			"constructor1" -> "int" [ltail=cluster_0];
 		
 	
 		subgraph cluster_1 {
 			"constructor2" [shape=plaintext];
 			
-				"t4" [label=<t4>];
+				"float64" [label=<float64>];
 			
 		}
 		
-			"constructor2" -> "t2" [ltail=cluster_1];
+			"constructor2" -> "string" [ltail=cluster_1];
 		
 	
 }

--- a/testdata/sublabel.dot
+++ b/testdata/sublabel.dot
@@ -4,13 +4,13 @@ digraph {
 		subgraph cluster_0 {
 			"constructor1" [shape=plaintext];
 			
-				"t1[name=foo]" [label=<t1<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
+				"int[name=foo]" [label=<int<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
 			
-				"t2[group=bar]" [label=<t2<BR /><FONT POINT-SIZE="10">Group: bar</FONT>>];
+				"string[group=bar]0" [label=<string<BR /><FONT POINT-SIZE="10">Group: bar</FONT>>];
 			
 		}
 		
-			"constructor1" -> "t3" [ltail=cluster_0];
+			"constructor1" -> "bool" [ltail=cluster_0];
 		
 	
 }


### PR DESCRIPTION
* Added a `subscribers` map to to the `Graph` struct to keep track of constructors that have grouped parameters. Whenever a new type within the same group is created, the constructor will be updated to include the new type in its `Params`.
* Added a `ctorMap` to keep track of all the constructors that provide a type.
* Added a `nodes` map to track all nodes so the constructors point to the same `Node` if they refer to the same type.