### PR TITLE
 VisualizeError: Move updates to graph into errors

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -233,7 +233,7 @@ var _graphTmpl = template.Must(
 	{{range $index, $ctor := .Ctors}}
 		subgraph cluster_{{$index}} {
 			constructor_{{$index}} [shape=plaintext label={{quote .Name}}];
-			{{- with .ErrorType}}color={{.Color}};{{end}}
+			{{with .ErrorType}}color={{.Color}};{{end}}
 			{{range .Results}}
 				{{- quote .String}} [{{.Attributes}}];
 			{{end}}

--- a/dig_test.go
+++ b/dig_test.go
@@ -2490,6 +2490,7 @@ func TestDotGraph(t *testing.T) {
 			GroupIndex: gi,
 		}
 	}
+
 	type t1 struct{}
 	type t2 struct{}
 	type t3 struct{}
@@ -2591,12 +2592,15 @@ func TestDotGraph(t *testing.T) {
 	t.Run("nested param object", func(t *testing.T) {
 		type in struct {
 			In
+
 			A    t1
 			Nest struct {
 				In
+
 				B    t2
 				Nest struct {
 					In
+
 					C t3
 				}
 			}
@@ -2617,17 +2621,20 @@ func TestDotGraph(t *testing.T) {
 	t.Run("nested result object", func(t *testing.T) {
 		type nested1 struct {
 			Out
+
 			D t4
 		}
 
 		type nested2 struct {
 			Out
+
 			C    t3
 			Nest nested1
 		}
 
 		type out struct {
 			Out
+
 			B    t2
 			Nest nested2
 		}
@@ -2752,6 +2759,7 @@ func TestDotGraph(t *testing.T) {
 func TestNewDotCtor(t *testing.T) {
 	type t1 struct{}
 	type t2 struct{}
+
 	n, err := newNode(func(A t1) t2 { return t2{} }, nodeOptions{})
 	require.NoError(t, err)
 
@@ -2763,6 +2771,7 @@ func TestNewDotCtor(t *testing.T) {
 	}
 
 	ctor := newDotCtor(n)
+	assert.Equal(t, n.id, ctor.ID)
 	assert.Equal(t, "function1", ctor.Name)
 	assert.Equal(t, "pkg1", ctor.Package)
 	assert.Equal(t, "file1", ctor.File)
@@ -2855,5 +2864,155 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func(in) t2 { return t2{} })
 
 		VerifyVisualization(t, "grouped", c)
+	})
+
+	t.Run("constructor fails with an error", func(t *testing.T) {
+		c := New()
+
+		type in1 struct {
+			In
+
+			C []t1 `group:"g1"`
+		}
+
+		type in2 struct {
+			In
+
+			A []t2 `group:"g2"`
+			B t3   `name:"n3"`
+		}
+
+		type out1 struct {
+			Out
+
+			B t3 `name:"n3"`
+			C t2 `group:"g2"`
+		}
+
+		type out2 struct {
+			Out
+
+			D t2 `group:"g2"`
+		}
+
+		type out3 struct {
+			Out
+
+			A t1 `group:"g1"`
+			B t2 `group:"g2"`
+		}
+
+		c.Provide(func(in1) out1 { return out1{} })
+		c.Provide(func(in2) t4 { return t4{} })
+		c.Provide(func() out2 { return out2{} })
+		c.Provide(func() (out3, error) { return out3{}, fmt.Errorf("great sadness") })
+		c.Invoke(func(t4 t4) { return })
+
+		VerifyVisualization(t, "error", c)
+	})
+
+	t.Run("missing types", func(t *testing.T) {
+		c := New()
+
+		c.Provide(func(A t1, B t2, C t3) t4 { return t4{} })
+		c.Invoke(func(t4 t4) { return })
+
+		VerifyVisualization(t, "missing", c)
+	})
+}
+
+func TestFailNodes(t *testing.T) {
+	tparam := func(t reflect.Type, n string, g string, o bool) *dot.Param {
+		return &dot.Param{
+			Node: &dot.Node{
+				Type:  t,
+				Name:  n,
+				Group: g,
+			},
+			Optional: o,
+		}
+	}
+
+	tresult := func(t reflect.Type, n string, g string, gi int) *dot.Result {
+		return &dot.Result{
+			Node: &dot.Node{
+				Type:  t,
+				Name:  n,
+				Group: g,
+			},
+			GroupIndex: gi,
+		}
+	}
+
+	type t1 struct{}
+	type t2 struct{}
+	type t3 struct{}
+	type t4 struct{}
+
+	type1 := reflect.TypeOf(t1{})
+	type2 := reflect.TypeOf(t2{})
+	type3 := reflect.TypeOf(t3{})
+	type4 := reflect.TypeOf(t4{})
+
+	p1 := tparam(type1, "", "", false)
+	p2 := tparam(type2, "", "", false)
+	p3 := tparam(type3, "", "", false)
+	p4 := tparam(type4, "", "", false)
+
+	r1 := tresult(type1, "", "", 0)
+	r2 := tresult(type2, "", "", 0)
+	r3 := tresult(type3, "", "", 0)
+	r4 := tresult(type4, "", "", 0)
+
+	t.Parallel()
+
+	t.Run("missing nodes", func(t *testing.T) {
+		c := New()
+
+		c.addMissingNodes([]*dot.Param{p1, p2})
+		assert.Equal(t, []*dot.Result{r1, r2}, c.dg.Failed.RootCauses)
+
+		c.addMissingNodes([]*dot.Param{p3, p4})
+		assert.Equal(t, []*dot.Result{r1, r2}, c.dg.Failed.RootCauses)
+		assert.Equal(t, []*dot.Result{r3, r4}, c.dg.Failed.TransitiveFailures)
+	})
+
+	t.Run("fail nodes", func(t *testing.T) {
+		c := New()
+		ctor1 := &dot.Ctor{ID: 1234}
+		ctor2 := &dot.Ctor{ID: 5678}
+
+		c.dg.AddCtor(ctor1, []*dot.Param{}, []*dot.Result{})
+		c.dg.AddCtor(ctor2, []*dot.Param{}, []*dot.Result{})
+
+		c.failNodes([]*dot.Param{p1, p2}, 1234)
+		assert.Equal(t, []*dot.Result{r1, r2}, c.dg.Failed.RootCauses)
+		assert.Equal(t, "red", ctor1.ErrorType.Color())
+
+		c.failNodes([]*dot.Param{p3, p4}, 5678)
+		assert.Equal(t, []*dot.Result{r1, r2}, c.dg.Failed.RootCauses)
+		assert.Equal(t, []*dot.Result{r3, r4}, c.dg.Failed.TransitiveFailures)
+		assert.Equal(t, "orange", ctor2.ErrorType.Color())
+	})
+
+	t.Run("fail group node", func(t *testing.T) {
+		c := New()
+		ctor1 := &dot.Ctor{ID: 1234}
+		ctor2 := &dot.Ctor{ID: 5678}
+
+		groupResult1 := tresult(type1, "", "foo", 0)
+		groupResult2 := tresult(type1, "", "foo", 1)
+
+		c.dg.AddCtor(ctor1, []*dot.Param{}, []*dot.Result{groupResult1})
+		c.dg.AddCtor(ctor2, []*dot.Param{}, []*dot.Result{groupResult2})
+
+		c.failGroupNodes("foo", type1, 5678)
+		assert.Equal(t, []*dot.Result{groupResult2}, c.dg.Failed.RootCauses)
+		assert.Equal(t, "red", ctor2.ErrorType.Color())
+
+		c.failGroupNodes("foo", type1, 1234)
+		assert.Equal(t, []*dot.Result{groupResult2}, c.dg.Failed.RootCauses)
+		assert.Equal(t, []*dot.Result{groupResult1}, c.dg.Failed.TransitiveFailures)
+		assert.Equal(t, "orange", ctor1.ErrorType.Color())
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -2923,7 +2923,7 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func(in2) t4 { return t4{} })
 		c.Provide(func() out2 { return out2{} })
 		c.Provide(func() (out3, error) { return out3{}, fmt.Errorf("great sadness") })
-		c.Invoke(func(t4 t4) { return })
+		err := c.Invoke(func(t4 t4) { return })
 
 		VerifyVisualizationError(t, "error", err)
 	})

--- a/error.go
+++ b/error.go
@@ -322,7 +322,7 @@ func (e errMissingManyTypes) updateGraph(g *dot.Graph) {
 			},
 		}
 	}
-	g.MissingNodes(missing)
+	g.AddMissingNodes(missing)
 }
 
 type errVisualizer interface {

--- a/internal/dot/graph_test.go
+++ b/internal/dot/graph_test.go
@@ -171,6 +171,7 @@ func TestFailNodes(t *testing.T) {
 		dg.AddCtor(c1, []*Param{}, []*Result{r2})
 
 		dg.FailNodes([]*Result{r1}, 123)
+
 		assert.Equal(t, []*Result{r1}, dg.Failed.RootCauses)
 		assert.Equal(t, 0, len(dg.Failed.TransitiveFailures))
 		assert.Equal(t, rootCause, c0.ErrorType)

--- a/param.go
+++ b/param.go
@@ -238,6 +238,7 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 		if ps.Optional {
 			return reflect.Zero(ps.Type), nil
 		}
+		c.addMissingNodes(ps.DotParam())
 		return _noValue, newErrMissingType(c, key{name: ps.Name, t: ps.Type})
 	}
 
@@ -253,6 +254,7 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 			return reflect.Zero(ps.Type), nil
 		}
 
+		c.failNodes(ps.DotParam(), n.ID())
 		return _noValue, errParamSingleFailed{Key: key{t: ps.Type, name: ps.Name}, Reason: err}
 	}
 
@@ -432,6 +434,7 @@ func newParamGroupedSlice(f reflect.StructField) (paramGroupedSlice, error) {
 func (pt paramGroupedSlice) Build(c containerStore) (reflect.Value, error) {
 	for _, n := range c.getGroupProviders(pt.Group, pt.Type.Elem()) {
 		if err := n.Call(c); err != nil {
+			c.failGroupNodes(pt.Group, pt.Type.Elem(), n.ID())
 			return _noValue, errParamGroupFailed{
 				Key:    key{group: pt.Group, t: pt.Type.Elem()},
 				Reason: err,

--- a/param.go
+++ b/param.go
@@ -238,7 +238,6 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 		if ps.Optional {
 			return reflect.Zero(ps.Type), nil
 		}
-		c.addMissingNodes(ps.DotParam())
 		return _noValue, newErrMissingType(c, key{name: ps.Name, t: ps.Type})
 	}
 
@@ -254,8 +253,10 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 			return reflect.Zero(ps.Type), nil
 		}
 
-		c.failNodes(ps.DotParam(), n.ID())
-		return _noValue, errParamSingleFailed{Key: key{t: ps.Type, name: ps.Name}, Reason: err}
+		return _noValue, errParamSingleFailed{
+			Key:    key{t: ps.Type, name: ps.Name},
+			Reason: err,
+		}
 	}
 
 	// If we get here, it's impossible for the value to be absent from the
@@ -434,8 +435,8 @@ func newParamGroupedSlice(f reflect.StructField) (paramGroupedSlice, error) {
 func (pt paramGroupedSlice) Build(c containerStore) (reflect.Value, error) {
 	for _, n := range c.getGroupProviders(pt.Group, pt.Type.Elem()) {
 		if err := n.Call(c); err != nil {
-			c.failGroupNodes(pt.Group, pt.Type.Elem(), n.ID())
 			return _noValue, errParamGroupFailed{
+				CtorID: n.ID(),
 				Key:    key{group: pt.Group, t: pt.Type.Elem()},
 				Reason: err,
 			}

--- a/testdata/empty.dot
+++ b/testdata/empty.dot
@@ -1,4 +1,5 @@
 digraph {
 	graph [compound=true];
 	
+	
 }

--- a/testdata/error.dot
+++ b/testdata/error.dot
@@ -1,0 +1,52 @@
+digraph {
+	graph [compound=true];
+	"[type=dig.t1 group=g1]" [shape=diamond label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>> color=red];
+		"[type=dig.t1 group=g1]" -> "dig.t1[group=g1]0";
+		
+	"[type=dig.t2 group=g2]" [shape=diamond label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>> color=orange];
+		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]0";
+		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]1";
+		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]2";
+		
+	
+		subgraph cluster_0 {
+			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];color=orange;
+			"dig.t3[name=n3]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: n3</FONT>>];
+			"dig.t2[group=g2]0" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
+			
+		}
+		
+		
+			constructor_0 -> "[type=dig.t1 group=g1]" [ltail=cluster_0];
+		
+		subgraph cluster_1 {
+			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];color=orange;
+			"dig.t4" [label=<dig.t4>];
+			
+		}
+		
+			constructor_1 -> "dig.t3[name=n3]" [ltail=cluster_1];
+		
+		
+			constructor_1 -> "[type=dig.t2 group=g2]" [ltail=cluster_1];
+		
+		subgraph cluster_2 {
+			constructor_2 [shape=plaintext label="TestVisualize.func6.3"];
+			"dig.t2[group=g2]1" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
+			
+		}
+		
+		
+		subgraph cluster_3 {
+			constructor_3 [shape=plaintext label="TestVisualize.func6.4"];color=red;
+			"dig.t1[group=g1]0" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
+			"dig.t2[group=g2]2" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
+			
+		}
+		
+		
+	"dig.t2[group=g2]0" [color=orange];
+	"dig.t4" [color=orange];
+	"dig.t1[group=g1]0" [color=red];
+	
+}

--- a/testdata/error.dot
+++ b/testdata/error.dot
@@ -1,9 +1,9 @@
 digraph {
 	graph [compound=true];
-	"[type=dig.t1 group=g1]" [shape=diamond label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
+	"[type=dig.t1 group=g1]" [shape=diamond label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>> color=red];
 		"[type=dig.t1 group=g1]" -> "dig.t1[group=g1]0";
 		
-	"[type=dig.t2 group=g2]" [shape=diamond label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
+	"[type=dig.t2 group=g2]" [shape=diamond label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>> color=orange];
 		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]0";
 		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]1";
 		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]2";
@@ -11,6 +11,7 @@ digraph {
 	
 		subgraph cluster_0 {
 			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];
+			color=orange;
 			"dig.t3[name=n3]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: n3</FONT>>];
 			"dig.t2[group=g2]0" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
@@ -21,6 +22,7 @@ digraph {
 		
 		subgraph cluster_1 {
 			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];
+			
 			"dig.t4" [label=<dig.t4>];
 			
 		}
@@ -32,6 +34,7 @@ digraph {
 		
 		subgraph cluster_2 {
 			constructor_2 [shape=plaintext label="TestVisualize.func6.3"];
+			
 			"dig.t2[group=g2]1" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
 		}
@@ -39,11 +42,15 @@ digraph {
 		
 		subgraph cluster_3 {
 			constructor_3 [shape=plaintext label="TestVisualize.func6.4"];
+			color=red;
 			"dig.t1[group=g1]0" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
 			"dig.t2[group=g2]2" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
 		}
 		
 		
+	"dig.t2[group=g2]0" [color=orange];
+	"dig.t4" [color=orange];
+	"dig.t1[group=g1]0" [color=red];
 	
 }

--- a/testdata/error.dot
+++ b/testdata/error.dot
@@ -1,16 +1,16 @@
 digraph {
 	graph [compound=true];
-	"[type=dig.t1 group=g1]" [shape=diamond label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>> color=red];
+	"[type=dig.t1 group=g1]" [shape=diamond label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
 		"[type=dig.t1 group=g1]" -> "dig.t1[group=g1]0";
 		
-	"[type=dig.t2 group=g2]" [shape=diamond label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>> color=orange];
+	"[type=dig.t2 group=g2]" [shape=diamond label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]0";
 		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]1";
 		"[type=dig.t2 group=g2]" -> "dig.t2[group=g2]2";
 		
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];color=orange;
+			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];
 			"dig.t3[name=n3]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: n3</FONT>>];
 			"dig.t2[group=g2]0" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
@@ -20,7 +20,7 @@ digraph {
 			constructor_0 -> "[type=dig.t1 group=g1]" [ltail=cluster_0];
 		
 		subgraph cluster_1 {
-			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];color=orange;
+			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];
 			"dig.t4" [label=<dig.t4>];
 			
 		}
@@ -38,15 +38,12 @@ digraph {
 		
 		
 		subgraph cluster_3 {
-			constructor_3 [shape=plaintext label="TestVisualize.func6.4"];color=red;
+			constructor_3 [shape=plaintext label="TestVisualize.func6.4"];
 			"dig.t1[group=g1]0" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
 			"dig.t2[group=g2]2" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
 		}
 		
 		
-	"dig.t2[group=g2]0" [color=orange];
-	"dig.t4" [color=orange];
-	"dig.t1[group=g1]0" [color=red];
 	
 }

--- a/testdata/grouped.dot
+++ b/testdata/grouped.dot
@@ -6,25 +6,27 @@ digraph {
 		
 	
 		subgraph cluster_0 {
-			"TestVisualize.func5.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func5.1"];
 			"dig.t3[group=foo]0" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
 		}
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func5.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func5.2"];
 			"dig.t3[group=foo]1" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
 		}
 		
 		
 		subgraph cluster_2 {
-			"TestVisualize.func5.3" [shape=plaintext];
+			constructor_2 [shape=plaintext label="TestVisualize.func5.3"];
 			"dig.t2" [label=<dig.t2>];
 			
 		}
 		
-		"TestVisualize.func5.3" -> "[type=dig.t3 group=foo]" [ltail=cluster_2];
 		
+			constructor_2 -> "[type=dig.t3 group=foo]" [ltail=cluster_2];
+		
+	
 }

--- a/testdata/grouped.dot
+++ b/testdata/grouped.dot
@@ -7,6 +7,7 @@ digraph {
 	
 		subgraph cluster_0 {
 			constructor_0 [shape=plaintext label="TestVisualize.func5.1"];
+			
 			"dig.t3[group=foo]0" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
 		}
@@ -14,6 +15,7 @@ digraph {
 		
 		subgraph cluster_1 {
 			constructor_1 [shape=plaintext label="TestVisualize.func5.2"];
+			
 			"dig.t3[group=foo]1" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
 		}
@@ -21,6 +23,7 @@ digraph {
 		
 		subgraph cluster_2 {
 			constructor_2 [shape=plaintext label="TestVisualize.func5.3"];
+			
 			"dig.t2" [label=<dig.t2>];
 			
 		}

--- a/testdata/missing.dot
+++ b/testdata/missing.dot
@@ -1,0 +1,22 @@
+digraph {
+	graph [compound=true];
+	
+		subgraph cluster_0 {
+			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];color=orange;
+			"dig.t4" [label=<dig.t4>];
+			
+		}
+		
+			constructor_0 -> "dig.t1" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t2" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t3" [ltail=cluster_0];
+		
+		
+	"dig.t4" [color=orange];
+	"dig.t1" [color=red];
+	"dig.t2" [color=red];
+	"dig.t3" [color=red];
+	
+}

--- a/testdata/missing.dot
+++ b/testdata/missing.dot
@@ -2,7 +2,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];color=orange;
+			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];
 			"dig.t4" [label=<dig.t4>];
 			
 		}
@@ -14,7 +14,6 @@ digraph {
 			constructor_0 -> "dig.t3" [ltail=cluster_0];
 		
 		
-	"dig.t4" [color=orange];
 	"dig.t1" [color=red];
 	"dig.t2" [color=red];
 	"dig.t3" [color=red];

--- a/testdata/missing.dot
+++ b/testdata/missing.dot
@@ -3,6 +3,7 @@ digraph {
 	
 		subgraph cluster_0 {
 			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];
+			
 			"dig.t4" [label=<dig.t4>];
 			
 		}
@@ -14,6 +15,7 @@ digraph {
 			constructor_0 -> "dig.t3" [ltail=cluster_0];
 		
 		
+	"dig.t4" [color=orange];
 	"dig.t1" [color=red];
 	"dig.t2" [color=red];
 	"dig.t3" [color=red];

--- a/testdata/missingDep.dot
+++ b/testdata/missingDep.dot
@@ -1,0 +1,6 @@
+digraph {
+	graph [compound=true];
+	
+	"dig.t1" [color=red];
+	
+}

--- a/testdata/named.dot
+++ b/testdata/named.dot
@@ -2,19 +2,21 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func3.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func3.1"];
 			"dig.t1[name=bar]" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Name: bar</FONT>>];
 			"dig.t2[name=baz]" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Name: baz</FONT>>];
 			
 		}
-		"TestVisualize.func3.1" -> "dig.t3[name=foo]" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t3[name=foo]" [ltail=cluster_0];
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func3.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func3.2"];
 			"dig.t3[name=foo]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
 			
 		}
 		
 		
+	
 }

--- a/testdata/named.dot
+++ b/testdata/named.dot
@@ -3,6 +3,7 @@ digraph {
 	
 		subgraph cluster_0 {
 			constructor_0 [shape=plaintext label="TestVisualize.func3.1"];
+			
 			"dig.t1[name=bar]" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Name: bar</FONT>>];
 			"dig.t2[name=baz]" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Name: baz</FONT>>];
 			
@@ -13,6 +14,7 @@ digraph {
 		
 		subgraph cluster_1 {
 			constructor_1 [shape=plaintext label="TestVisualize.func3.2"];
+			
 			"dig.t3[name=foo]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
 			
 		}

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -3,6 +3,7 @@ digraph {
 	
 		subgraph cluster_0 {
 			constructor_0 [shape=plaintext label="TestVisualize.func4.1"];
+			
 			"dig.t1" [label=<dig.t1>];
 			
 		}
@@ -10,6 +11,7 @@ digraph {
 		
 		subgraph cluster_1 {
 			constructor_1 [shape=plaintext label="TestVisualize.func4.2"];
+			
 			"dig.t2" [label=<dig.t2>];
 			
 		}

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -2,18 +2,20 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func4.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func4.1"];
 			"dig.t1" [label=<dig.t1>];
 			
 		}
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func4.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func4.2"];
 			"dig.t2" [label=<dig.t2>];
 			
 		}
-		"TestVisualize.func4.2" -> "dig.t1" [ltail=cluster_1 style=dashed];
+		
+			constructor_1 -> "dig.t1" [ltail=cluster_1 style=dashed];
 		
 		
+	
 }

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -2,7 +2,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func2.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func2.1"];
 			"dig.t1" [label=<dig.t1>];
 			"dig.t2" [label=<dig.t2>];
 			
@@ -10,13 +10,16 @@ digraph {
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func2.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func2.2"];
 			"dig.t3" [label=<dig.t3>];
 			"dig.t4" [label=<dig.t4>];
 			
 		}
-		"TestVisualize.func2.2" -> "dig.t1" [ltail=cluster_1];
-		"TestVisualize.func2.2" -> "dig.t2" [ltail=cluster_1];
+		
+			constructor_1 -> "dig.t1" [ltail=cluster_1];
+		
+			constructor_1 -> "dig.t2" [ltail=cluster_1];
 		
 		
+	
 }

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -3,6 +3,7 @@ digraph {
 	
 		subgraph cluster_0 {
 			constructor_0 [shape=plaintext label="TestVisualize.func2.1"];
+			
 			"dig.t1" [label=<dig.t1>];
 			"dig.t2" [label=<dig.t2>];
 			
@@ -11,6 +12,7 @@ digraph {
 		
 		subgraph cluster_1 {
 			constructor_1 [shape=plaintext label="TestVisualize.func2.2"];
+			
 			"dig.t3" [label=<dig.t3>];
 			"dig.t4" [label=<dig.t4>];
 			

--- a/visualize_golden_test.go
+++ b/visualize_golden_test.go
@@ -53,3 +53,24 @@ func VerifyVisualization(t *testing.T, testname string, c *Container) {
 	assert.Equal(t, want, got,
 		"Output did not match. Make sure you updated the testdata by running 'go test -generate'")
 }
+
+func VerifyVisualizationError(t *testing.T, testname string, e error) {
+	var b bytes.Buffer
+	require.NoError(t, VisualizeError(e, &b))
+
+	dotFile := filepath.Join("testdata", testname+".dot")
+
+	if *generate {
+		err := ioutil.WriteFile(dotFile, b.Bytes(), 0644)
+		require.NoError(t, err)
+		return
+	}
+
+	wantBytes, err := ioutil.ReadFile(dotFile)
+	require.NoError(t, err)
+
+	got := b.String()
+	want := string(wantBytes)
+	assert.Equal(t, want, got,
+		"Output did not match. Make sure you updated the testdata by running 'go test -generate'")
+}


### PR DESCRIPTION
Made `Visualize` and `VisualizeError` separate methods. 
```go
Visualize(*Container, io.Writer, ...VisualizeOption) error
```
`Visualize` takes a container and parses the dependency graph in the container into a DOT format graph with no error detection/representation, and writes it to an `io.Writer`.
```go
VisualizeError(error, io.Writer, ...VisualizeOption) error
```
 `VisualizeError` takes in an error that is generated on `Invoke` failure. It parses the dependency graph included in the error and updates the graph to reflect failing nodes, and writes it to an `io.Writer`.