### PR TITLE
dot: Index constructors to prevent name collision

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -241,17 +241,17 @@ var _graphTmpl = template.Must(
 	{{end -}}
 	{{range $index, $ctor := .Ctors}}
 		subgraph cluster_{{$index}} {
-			{{quote .Name}} [shape=plaintext];
+			constructor_{{$index}} [shape=plaintext label={{quote .Name}}];
 			{{- with .State}}color={{.Color}};{{end}}
 			{{range .Results}}
 				{{- quote .String}} [{{.Attributes}}];
 			{{end}}
 		}
 		{{range .Params}}
-			{{- quote $ctor.Name}} -> {{quote .String}} [ltail=cluster_{{$index}}{{if .Optional}} style=dashed{{end}}];
+			constructor_{{$index}} -> {{quote .String}} [ltail=cluster_{{$index}}{{if .Optional}} style=dashed{{end}}];
 		{{end}}
 		{{range .GroupParams}}
-			{{- quote $ctor.Name}} -> {{quote .String}} [ltail=cluster_{{$index}}];
+			constructor_{{$index}} -> {{quote .String}} [ltail=cluster_{{$index}}];
 		{{end -}}
 	{{end}}
 	{{range .Failed.TransitiveFailures}}

--- a/testdata/error.dot
+++ b/testdata/error.dot
@@ -10,32 +10,35 @@ digraph {
 		
 	
 		subgraph cluster_0 {
-			"TestVisualize.func6.1" [shape=plaintext];color=orange;
+			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];color=orange;
 			"dig.t3[name=n3]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: n3</FONT>>];
 			"dig.t2[group=g2]0" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
 		}
 		
-		"TestVisualize.func6.1" -> "[type=dig.t1 group=g1]" [ltail=cluster_0];
+		
+			constructor_0 -> "[type=dig.t1 group=g1]" [ltail=cluster_0];
 		
 		subgraph cluster_1 {
-			"TestVisualize.func6.2" [shape=plaintext];color=orange;
+			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];color=orange;
 			"dig.t4" [label=<dig.t4>];
 			
 		}
-		"TestVisualize.func6.2" -> "dig.t3[name=n3]" [ltail=cluster_1];
 		
-		"TestVisualize.func6.2" -> "[type=dig.t2 group=g2]" [ltail=cluster_1];
+			constructor_1 -> "dig.t3[name=n3]" [ltail=cluster_1];
+		
+		
+			constructor_1 -> "[type=dig.t2 group=g2]" [ltail=cluster_1];
 		
 		subgraph cluster_2 {
-			"TestVisualize.func6.3" [shape=plaintext];
+			constructor_2 [shape=plaintext label="TestVisualize.func6.3"];
 			"dig.t2[group=g2]1" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			
 		}
 		
 		
 		subgraph cluster_3 {
-			"TestVisualize.func6.4" [shape=plaintext];color=red;
+			constructor_3 [shape=plaintext label="TestVisualize.func6.4"];color=red;
 			"dig.t1[group=g1]0" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
 			"dig.t2[group=g2]2" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			

--- a/testdata/grouped.dot
+++ b/testdata/grouped.dot
@@ -6,26 +6,27 @@ digraph {
 		
 	
 		subgraph cluster_0 {
-			"TestVisualize.func5.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func5.1"];
 			"dig.t3[group=foo]0" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
 		}
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func5.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func5.2"];
 			"dig.t3[group=foo]1" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
 		}
 		
 		
 		subgraph cluster_2 {
-			"TestVisualize.func5.3" [shape=plaintext];
+			constructor_2 [shape=plaintext label="TestVisualize.func5.3"];
 			"dig.t2" [label=<dig.t2>];
 			
 		}
 		
-		"TestVisualize.func5.3" -> "[type=dig.t3 group=foo]" [ltail=cluster_2];
+		
+			constructor_2 -> "[type=dig.t3 group=foo]" [ltail=cluster_2];
 		
 	
 }

--- a/testdata/missing.dot
+++ b/testdata/missing.dot
@@ -2,13 +2,16 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func7.1" [shape=plaintext];color=orange;
+			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];color=orange;
 			"dig.t4" [label=<dig.t4>];
 			
 		}
-		"TestVisualize.func7.1" -> "dig.t1" [ltail=cluster_0];
-		"TestVisualize.func7.1" -> "dig.t2" [ltail=cluster_0];
-		"TestVisualize.func7.1" -> "dig.t3" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t1" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t2" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t3" [ltail=cluster_0];
 		
 		
 	"dig.t4" [color=orange];

--- a/testdata/named.dot
+++ b/testdata/named.dot
@@ -2,16 +2,17 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func3.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func3.1"];
 			"dig.t1[name=bar]" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Name: bar</FONT>>];
 			"dig.t2[name=baz]" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Name: baz</FONT>>];
 			
 		}
-		"TestVisualize.func3.1" -> "dig.t3[name=foo]" [ltail=cluster_0];
+		
+			constructor_0 -> "dig.t3[name=foo]" [ltail=cluster_0];
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func3.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func3.2"];
 			"dig.t3[name=foo]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];
 			
 		}

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -2,18 +2,19 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func4.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func4.1"];
 			"dig.t1" [label=<dig.t1>];
 			
 		}
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func4.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func4.2"];
 			"dig.t2" [label=<dig.t2>];
 			
 		}
-		"TestVisualize.func4.2" -> "dig.t1" [ltail=cluster_1 style=dashed];
+		
+			constructor_1 -> "dig.t1" [ltail=cluster_1 style=dashed];
 		
 		
 	

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -2,7 +2,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			"TestVisualize.func2.1" [shape=plaintext];
+			constructor_0 [shape=plaintext label="TestVisualize.func2.1"];
 			"dig.t1" [label=<dig.t1>];
 			"dig.t2" [label=<dig.t2>];
 			
@@ -10,13 +10,15 @@ digraph {
 		
 		
 		subgraph cluster_1 {
-			"TestVisualize.func2.2" [shape=plaintext];
+			constructor_1 [shape=plaintext label="TestVisualize.func2.2"];
 			"dig.t3" [label=<dig.t3>];
 			"dig.t4" [label=<dig.t4>];
 			
 		}
-		"TestVisualize.func2.2" -> "dig.t1" [ltail=cluster_1];
-		"TestVisualize.func2.2" -> "dig.t2" [ltail=cluster_1];
+		
+			constructor_1 -> "dig.t1" [ltail=cluster_1];
+		
+			constructor_1 -> "dig.t2" [ltail=cluster_1];
 		
 		
 	


### PR DESCRIPTION
Constructor nodes are named with their index to prevent collision when multiple constructors have the same name (eg. `New`). The constructor name is used as the node label instead.