### PR TITLE
VisualizeOption: Add GraphErr to VisualizeOption

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -217,18 +217,18 @@ type VisualizeOption interface {
 }
 
 type visualizeOptions struct {
-	GraphErr error
+	VisualizeError error
 }
 
 type visualizeOptionFunc func(*visualizeOptions)
 
 func (f visualizeOptionFunc) applyVisualizeOption(opts *visualizeOptions) { f(opts) }
 
-// GraphErr is a VisualizeOption that specifies the error updates to the graph
+// VisualizeError is a VisualizeOption that specifies the error updates to the graph
 // that should be made before visualizing it.
-func GraphErr(err error) VisualizeOption {
+func VisualizeError(err error) VisualizeOption {
 	return visualizeOptionFunc(func(opts *visualizeOptions) {
-		opts.GraphErr = err
+		opts.VisualizeError = err
 	})
 }
 
@@ -304,8 +304,8 @@ func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
 		o.applyVisualizeOption(&options)
 	}
 
-	if options.GraphErr != nil {
-		if err := updateGraph(dg, options.GraphErr); err != nil {
+	if options.VisualizeError != nil {
+		if err := updateGraph(dg, options.VisualizeError); err != nil {
 			return err
 		}
 	}

--- a/dig_test.go
+++ b/dig_test.go
@@ -2926,7 +2926,7 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func() (out3, error) { return out3{}, fmt.Errorf("great sadness") })
 		err := c.Invoke(func(t4 t4) { return })
 
-		VerifyVisualizationError(t, "error", err)
+		VerifyVisualization(t, "error", c, GraphErr(err))
 	})
 
 	t.Run("missing types", func(t *testing.T) {
@@ -2935,19 +2935,13 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func(A t1, B t2, C t3) t4 { return t4{} })
 		err := c.Invoke(func(t4 t4) { return })
 
-		VerifyVisualizationError(t, "missing", err)
+		VerifyVisualization(t, "missing", c, GraphErr(err))
 	})
 
 	t.Run("missing dependency", func(t *testing.T) {
 		c := New()
 		err := c.Invoke(func(t1 t1) { return })
 
-		VerifyVisualizationError(t, "missingDep", err)
-	})
-
-	t.Run("no graph", func(t *testing.T) {
-		var b bytes.Buffer
-		assertErrorMatches(t, VisualizeError(fmt.Errorf("great sadness"), &b),
-			"no graph included in error: great sadness")
+		VerifyVisualization(t, "missingDep", c, GraphErr(err))
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -2926,7 +2926,7 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func() (out3, error) { return out3{}, fmt.Errorf("great sadness") })
 		err := c.Invoke(func(t4 t4) { return })
 
-		VerifyVisualization(t, "error", c, GraphErr(err))
+		VerifyVisualization(t, "error", c, VisualizeError(err))
 	})
 
 	t.Run("missing types", func(t *testing.T) {
@@ -2935,13 +2935,13 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func(A t1, B t2, C t3) t4 { return t4{} })
 		err := c.Invoke(func(t4 t4) { return })
 
-		VerifyVisualization(t, "missing", c, GraphErr(err))
+		VerifyVisualization(t, "missing", c, VisualizeError(err))
 	})
 
 	t.Run("missing dependency", func(t *testing.T) {
 		c := New()
 		err := c.Invoke(func(t1 t1) { return })
 
-		VerifyVisualization(t, "missingDep", c, GraphErr(err))
+		VerifyVisualization(t, "missingDep", c, VisualizeError(err))
 	})
 }

--- a/error.go
+++ b/error.go
@@ -113,14 +113,11 @@ func (e errConstructorFailed) Error() string {
 // errArgumentsFailed is returned when a function could not be run because one
 // of its dependencies failed to build for any reason.
 type errArgumentsFailed struct {
-	Container *Container
-	Func      *digreflect.Func
-	Reason    error
+	Func   *digreflect.Func
+	Reason error
 }
 
 func (e errArgumentsFailed) cause() error { return e.Reason }
-
-func (e errArgumentsFailed) container() *Container { return e.Container }
 
 func (e errArgumentsFailed) Error() string {
 	return fmt.Sprintf("could not build arguments for function %v: %v", e.Func, e.Reason)
@@ -129,14 +126,11 @@ func (e errArgumentsFailed) Error() string {
 // errMissingDependencies is returned when the dependencies of a function are
 // not available in the container.
 type errMissingDependencies struct {
-	Container *Container
-	Func      *digreflect.Func
-	Reason    error
+	Func   *digreflect.Func
+	Reason error
 }
 
 func (e errMissingDependencies) cause() error { return e.Reason }
-
-func (e errMissingDependencies) container() *Container { return e.Container }
 
 func (e errMissingDependencies) Error() string {
 	return fmt.Sprintf("missing dependencies for function %v: %v", e.Func, e.Reason)
@@ -327,8 +321,4 @@ func (e errMissingManyTypes) updateGraph(g *dot.Graph) {
 
 type errVisualizer interface {
 	updateGraph(*dot.Graph)
-}
-
-type errEntryPoint interface {
-	container() *Container
 }

--- a/visualize_golden_test.go
+++ b/visualize_golden_test.go
@@ -33,30 +33,9 @@ import (
 
 var generate = flag.Bool("generate", false, "generates output to testdata/ if set")
 
-func VerifyVisualization(t *testing.T, testname string, c *Container) {
+func VerifyVisualization(t *testing.T, testname string, c *Container, opts ...VisualizeOption) {
 	var b bytes.Buffer
-	require.NoError(t, Visualize(c, &b))
-
-	dotFile := filepath.Join("testdata", testname+".dot")
-
-	if *generate {
-		err := ioutil.WriteFile(dotFile, b.Bytes(), 0644)
-		require.NoError(t, err)
-		return
-	}
-
-	wantBytes, err := ioutil.ReadFile(dotFile)
-	require.NoError(t, err)
-
-	got := b.String()
-	want := string(wantBytes)
-	assert.Equal(t, want, got,
-		"Output did not match. Make sure you updated the testdata by running 'go test -generate'")
-}
-
-func VerifyVisualizationError(t *testing.T, testname string, e error) {
-	var b bytes.Buffer
-	require.NoError(t, VisualizeError(e, &b))
+	require.NoError(t, Visualize(c, &b, opts...))
 
 	dotFile := filepath.Join("testdata", testname+".dot")
 


### PR DESCRIPTION
Instead of having `Visualize` and `VisualizeError` as different methods, the error is now passed to `Visualize` as a `VisualizeOption`. When we call 
```go
Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error
```
with an error in `opts`, the graph is updated with the errors before being parsed into DOT-format.