### PR TITLE
CanVisualizeError: Determine if error is visualizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added `Visualize` function to parse the graph in a container into DOT format
+  to allow visualization of errors types dependency relationship of types in
+  container.
+- Added `CanVisualizeError` function to determine if an error can be visualized
+  in the graph.
 - Added `Name` option for `Provide` to add named values to the container
   without rewriting constructors. See package documentation for more
   information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added `Visualize` function to parse the graph in a container into DOT format
-  to allow visualization of errors types dependency relationship of types in
-  container.
+- Added `Visualize` function to visualize the state of the container in the
+  GraphViz DOT format. This allows visualization of error types and the
+  dependency relationships of types in the container.
 - Added `CanVisualizeError` function to determine if an error can be visualized
   in the graph.
 - Added `Name` option for `Provide` to add named values to the container

--- a/dig.go
+++ b/dig.go
@@ -253,6 +253,7 @@ func updateGraph(dg *dot.Graph, err error) error {
 		err = e.cause()
 	}
 
+	// If there are no errVisualizers included, we do not modify the graph.
 	if len(errors) == 0 {
 		return nil
 	}
@@ -318,6 +319,12 @@ func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
 	}
 
 	return _graphTmpl.Execute(w, dg)
+}
+
+// CanVisualizeError returns true if the error is an errVisualizer.
+func CanVisualizeError(err error) bool {
+	_, ok := err.(errVisualizer)
+	return ok
 }
 
 func (c *Container) createGraph() *dot.Graph {

--- a/dig.go
+++ b/dig.go
@@ -323,8 +323,18 @@ func Visualize(c *Container, w io.Writer, opts ...VisualizeOption) error {
 
 // CanVisualizeError returns true if the error is an errVisualizer.
 func CanVisualizeError(err error) bool {
-	_, ok := err.(errVisualizer)
-	return ok
+	for {
+		if _, ok := err.(errVisualizer); ok {
+			return true
+		}
+		e, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = e.cause()
+	}
+
+	return false
 }
 
 func (c *Container) createGraph() *dot.Graph {

--- a/dig_test.go
+++ b/dig_test.go
@@ -2951,11 +2951,22 @@ type VisualizableErr struct{}
 func (err VisualizableErr) updateGraph(dg *dot.Graph) {}
 func (err VisualizableErr) Error() string             { return "great sadness" }
 
+type NestedErr struct {
+	err error
+}
+
+func (err NestedErr) Error() string { return "oh no" }
+func (err NestedErr) cause() error  { return err.err }
+
 func TestCanVisualizeError(t *testing.T) {
 	unvisualizableErr := fmt.Errorf("great sadness")
+	nestedUnvisualizableErr := NestedErr{err: unvisualizableErr}
 	visualizableErr := VisualizableErr{}
+	nestedVisualizableErr := NestedErr{err: visualizableErr}
 
 	assert.Error(t, visualizableErr)
-	assert.True(t, CanVisualizeError(visualizableErr))
 	assert.False(t, CanVisualizeError(unvisualizableErr))
+	assert.False(t, CanVisualizeError(nestedUnvisualizableErr))
+	assert.True(t, CanVisualizeError(visualizableErr))
+	assert.True(t, CanVisualizeError(nestedVisualizableErr))
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -2945,3 +2945,17 @@ func TestVisualize(t *testing.T) {
 		VerifyVisualization(t, "missingDep", c, VisualizeError(err))
 	})
 }
+
+type VisualizableErr struct{}
+
+func (err VisualizableErr) updateGraph(dg *dot.Graph) {}
+func (err VisualizableErr) Error() string             { return "great sadness" }
+
+func TestCanVisualizeError(t *testing.T) {
+	unvisualizableErr := fmt.Errorf("great sadness")
+	visualizableErr := VisualizableErr{}
+
+	assert.Error(t, visualizableErr)
+	assert.True(t, CanVisualizeError(visualizableErr))
+	assert.False(t, CanVisualizeError(unvisualizableErr))
+}


### PR DESCRIPTION
`dig.CanVisualizeError(err)` returns true if err is visualizable. This is used in fx to determine if we want to output the graph given an error.