### PR TITLE
Prevent wasteful recursion by counting visits to params in verifyAcyclic

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -753,7 +753,7 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 func shallowCheckDependencies(c containerStore, p param) error {
 	var missing errMissingManyTypes
 	var addMissingNodes []*dot.Param
-	walkParam(p, paramVisitorFunc(func(p param) bool {
+	walkParam(p, NewParamVisitorAtMostTwice(make(map[string]int), func(p param) bool {
 		ps, ok := p.(paramSingle)
 		if !ok {
 			return true

--- a/param_test.go
+++ b/param_test.go
@@ -163,3 +163,27 @@ func TestParamGroupSliceErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestParamVisitorCountAccumulates(t *testing.T) {
+	visitorCounts := make(map[string]int)
+
+	params := []paramSingle{
+		{Name: "param 1"},
+		{Name: "param 2"},
+		{Name: "param 2"},
+		{Name: "param 2"},
+		{Name: "param 2"},
+	}
+
+	visitor := NewParamVisitorAtMostTwice(visitorCounts, func(param) bool { return true })
+	for _, p := range params {
+		visitor.Visit(p)
+	}
+
+	assert.Equal(t, visitorCounts[params[0].String()], 1)
+	assert.Equal(t, visitorCounts[params[2].String()], 2)
+
+	// By confirming "param 2" count is only 2 we have implicitly confirmed
+	// visitor.f was only called twice on "param 2", i.e. redundant recursions
+	// were avoided.
+}


### PR DESCRIPTION
In a private test suite I instantiate a FX application in each test to execute blackbox functionality assessment. Logging the `detectCycles` call yielded the following data:

```
[dn-fx] dnathe4th@~/gopath/src/xxx: grep "detectCycles" dig.log | wc -l
 23991368
[dn-fx] dnathe4th@~/gopath/src/xxx: grep "detectCycles" dig.log | sort | uniq -c | sort -nr | head -n 5
9229660 detectCycles with (dot.CtorID=86815168)
6579496 detectCycles with (dot.CtorID=95051312)
3842944 detectCycles with (dot.CtorID=98789856)
1543708 detectCycles with (dot.CtorID=98919152)
```

Nearly 24M calls to detectCycles were made, with the top parameter experiencing over 9M calls. This `dig` logic accounted for ~60% of my test suite execution time.

With the changes from this PR:
```
[dn-fx] dnathe4th@~/gopath/src/xxx: grep "detectCycles" dig.log | wc -l
    9232
```
Only OVER9000 calls are made once the redundant recursions are avoided.