### PR TITLE
tests: Better use of assertErrorMatches

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -1626,14 +1626,9 @@ func TestProvideCycleFails(t *testing.T) {
 		assert.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
 			`cycle detected in dependency graph:`,
-		)
-		assertErrorMatches(t, err,
+			`\*dig.C provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
 			`depends on \*dig.B provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
-		)
-		assertErrorMatches(t, err,
 			`depends on \*dig.A provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
-		)
-		assertErrorMatches(t, err,
 			`depends on \*dig.C provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
 		)
 	})


### PR DESCRIPTION
The test for DeferAcyclicVerification was making N separate calls to
assertErrorMatches which doesn't verify that the different components of
the error messages appear in the correct order.

This switches to "correct" usage so that we're verifying that the
correct types appear in the error messages at the correct spot. In this
case, we want "C depends on B depends on A depends on C".