### PR TITLE
WIP provide params to invoke 

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -476,7 +476,7 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 //
 // The function may return an error to indicate failure. The error will be
 // returned to the caller as-is.
-func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
+func (c *Container) Invoke(function interface{}, providedParams ...interface{}) error {
 	ftype := reflect.TypeOf(function)
 	if ftype == nil {
 		return errors.New("can't invoke an untyped nil")
@@ -485,7 +485,7 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 		return fmt.Errorf("can't invoke non-function %v (type %v)", function, ftype)
 	}
 
-	pl, err := newParamList(ftype)
+	pl, err := newParamList(ftype, providedParams...)
 	if err != nil {
 		return err
 	}

--- a/stringer.go
+++ b/stringer.go
@@ -104,3 +104,7 @@ func (pt paramGroupedSlice) String() string {
 	// io.Reader[group="foo"] refers to a group of io.Readers called 'foo'
 	return fmt.Sprintf("%v[group=%q]", pt.Type.Elem(), pt.Group)
 }
+
+func (pp paramProvided) String() string {
+	return fmt.Sprintf("%v[%v]", pp.Type, pp.Param)
+}


### PR DESCRIPTION
Would it be an idea to let `Invoke` take arguments that aren't coming from the container?

It seems rather straight forward to add this, which leads me to belief it's not in there for a (good) reason...?

I understand this PR would break BC and it would be better to have a new method, but opening the pR atm purely for discussion as it's also missing any tests atm so it's not ready to be merged anyway.  
If there's interest in merging it then I'll add `InvokeWithParam` or smt and add tests.

would be used something like;

```go

// my super complicated service
type MyService struct {
	Booyaa bool
}

// provide for my super complicated service
func NewMyService() *MyService {
	return &MyService{}
}

func CanWeBooyaa(ctx *gin.Context, service *MyService) {
	ctx.String(200, fmt.Sprintf("booyaa? %v! \n", service.Booyaa))
}

container := dig.New()
container.Provide(NewMyService)

ctx := &gin.Context{}
container.Invoke(CanWeBooyaa, ctx)

```