### PR TITLE
Change travis go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ go_import_path: go.uber.org/dig
 
 matrix:
   include:
-    - go: 1.7
-    - go: 1.8
     - go: 1.9
+    - go: 1.10
+    - go: 1.11
       env: LINT=1
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ go_import_path: go.uber.org/dig
 
 matrix:
   include:
-    - go: 1.9
-    - go: 1.10
-    - go: 1.11
+    - go: "1.10"
+    - go: "1.11"
       env: LINT=1
 
 cache:


### PR DESCRIPTION
Travis is config is quite out of date. Change to using a more recent set of go versions.