### PR TITLE
[WIP] Expose a "Group" ProvideOption

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -62,7 +62,8 @@ type optionFunc func(*Container)
 func (f optionFunc) applyOption(c *Container) { f(c) }
 
 type provideOptions struct {
-	Name string
+	Name  string
+	Group string
 }
 
 func (o *provideOptions) Validate() error {
@@ -105,6 +106,17 @@ func (f provideOptionFunc) applyProvideOption(opts *provideOptions) { f(opts) }
 func Name(name string) ProvideOption {
 	return provideOptionFunc(func(opts *provideOptions) {
 		opts.Name = name
+	})
+}
+
+// Group is a ProvideOption that specifies that all values produced by a
+// constructor should be members of the same group. Since all members of a
+// group must be of same type, this option cannot be provided for constructors
+// that return different types. See also the package documentation about
+// Value Groups.
+func Group(group string) ProvideOption {
+	return provideOptionFunc(func(opts *provideOptions) {
+		opts.Group = group
 	})
 }
 

--- a/result.go
+++ b/result.go
@@ -186,12 +186,24 @@ func newResultList(ctype reflect.Type, opts resultOptions) (resultList, error) {
 		resultIndexes: make([]int, ctype.NumOut()),
 	}
 
+	isGroup := len(opts.Group) > 0
+	groupType := ctype.Out(0)
+
 	resultIdx := 0
 	for i := 0; i < ctype.NumOut(); i++ {
 		t := ctype.Out(i)
 		if isError(t) {
 			rl.resultIndexes[i] = -1
 			continue
+		}
+
+		if isGroup && t != groupType {
+			return rl, fmt.Errorf(
+				"cannot use the group provide option with constructors that return " +
+					"multiple types: a constructor is trying to return type %v and type %v",
+					t,
+					groupType,
+			)
 		}
 
 		r, err := newResult(t, opts)

--- a/result.go
+++ b/result.go
@@ -60,6 +60,7 @@ type resultOptions struct {
 	//
 	// For Result Objects, name:".." tags on fields override this.
 	Name string
+	Group string
 }
 
 // newResult builds a result from the given type.
@@ -79,6 +80,8 @@ func newResult(t reflect.Type, opts resultOptions) (result, error) {
 		return nil, fmt.Errorf(
 			"cannot return a pointer to a result object, use a value instead: "+
 				"%v is a pointer to a struct that embeds dig.Out", t)
+	case len(opts.Group) > 0:
+		return resultGrouped{Type: t, Group: opts.Group}, nil
 	default:
 		return resultSingle{Type: t, Name: opts.Name}, nil
 	}
@@ -272,6 +275,11 @@ func newResultObject(t reflect.Type, opts resultOptions) (resultObject, error) {
 	if len(opts.Name) > 0 {
 		return ro, fmt.Errorf(
 			"cannot specify a name for result objects: %v embeds dig.Out", t)
+	}
+
+	if len(opts.Group) > 0 {
+		return ro, fmt.Errorf(
+			"cannot specify a group for result objects: %v embeds dig.Out", t)
 	}
 
 	for i := 0; i < t.NumField(); i++ {


### PR DESCRIPTION
The commits are mostly individually reviewable.

This is a step towards a solution for [#610 (fx)](https://github.com/uber-go/fx/issues/610) for both named values and value groups. This will allow fx to expose its own Group option, which will allow users to form value groups without needing fx.Out.