### PR TITLE
Expose "Group" Provide option

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -564,7 +564,7 @@ func (c *Container) provide(ctor interface{}, opts provideOptions) error {
 	n, err := newNode(
 		ctor,
 		nodeOptions{
-			ResultName: opts.Name,
+			ResultName:  opts.Name,
 			ResultGroup: opts.Group,
 		},
 	)
@@ -741,7 +741,7 @@ type node struct {
 type nodeOptions struct {
 	// If specified, all values produced by this node have the provided name
 	// or belong to the specified value group
-	ResultName string
+	ResultName  string
 	ResultGroup string
 }
 
@@ -758,7 +758,7 @@ func newNode(ctor interface{}, opts nodeOptions) (*node, error) {
 	results, err := newResultList(
 		ctype,
 		resultOptions{
-			Name: opts.ResultName,
+			Name:  opts.ResultName,
 			Group: opts.ResultGroup,
 		},
 	)

--- a/dig.go
+++ b/dig.go
@@ -118,7 +118,7 @@ func Name(name string) ProvideOption {
 }
 
 // Group is a ProvideOption that specifies that all values produced by a
-// constructor should be members of the same group. See also the package
+// constructor should be added to the specified group. See also the package
 // documentation about Value Groups.
 //
 // This option cannot be provided for constructors which produce result

--- a/dig.go
+++ b/dig.go
@@ -62,7 +62,8 @@ type optionFunc func(*Container)
 func (f optionFunc) applyOption(c *Container) { f(c) }
 
 type provideOptions struct {
-	Name string
+	Name  string
+	Group string
 }
 
 func (o *provideOptions) Validate() error {
@@ -105,6 +106,17 @@ func (f provideOptionFunc) applyProvideOption(opts *provideOptions) { f(opts) }
 func Name(name string) ProvideOption {
 	return provideOptionFunc(func(opts *provideOptions) {
 		opts.Name = name
+	})
+}
+
+// Group is a ProvideOption that specifies that all values produced by a
+// constructor should be members of the same group. Since all members of a
+// group must be of same type, this option cannot be provided for constructors
+// that return different types. See also the package documentation about
+// Value Groups.
+func Group(group string) ProvideOption {
+	return provideOptionFunc(func(opts *provideOptions) {
+		opts.Group = group
 	})
 }
 

--- a/dig.go
+++ b/dig.go
@@ -118,10 +118,8 @@ func Name(name string) ProvideOption {
 }
 
 // Group is a ProvideOption that specifies that all values produced by a
-// constructor should be members of the same group. Since all members of a
-// group must be of same type, this option cannot be provided for constructors
-// that return different types. See also the package documentation about
-// Value Groups.
+// constructor should be members of the same group. See also the package
+// documentation about Value Groups.
 //
 // This option cannot be provided for constructors which produce result
 // objects.

--- a/dig_test.go
+++ b/dig_test.go
@@ -943,18 +943,6 @@ func TestGroups(t *testing.T) {
 		}), "invoke failed")
 	})
 
-	t.Run("group options only allow constructors that return values of the same type", func(t *testing.T) {
-		c := New(setRand(rand.New(rand.NewSource(0))))
-
-		provide := func(i int) {
-			require.Error(t, c.Provide(func() (int, string) {
-				return i, "uh-oh"
-			}, Group("val")), "This Provide should fail")
-		}
-
-		provide(1)
-	})
-
 	t.Run("group options may not be provided for result structs", func(t *testing.T) {
 		c := New(setRand(rand.New(rand.NewSource(0))))
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -1433,7 +1433,7 @@ func TestProvideGroupAndName(t *testing.T) {
 		panic("this function must not be called")
 	}, Group("foo"), Name("bar"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot use named values with value groups: " +
+	assert.Contains(t, err.Error(), "cannot use named values with value groups: "+
 		"name:\"bar\" provided with group:\"foo\"")
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -919,6 +919,60 @@ func TestGroups(t *testing.T) {
 		}), "invoke failed")
 	})
 
+	t.Run("groups are provided via option", func(t *testing.T) {
+		c := New(setRand(rand.New(rand.NewSource(0))))
+
+		provide := func(i int) {
+			require.NoError(t, c.Provide(func() int {
+				return i
+			}, Group("val")), "failed to provide ")
+		}
+
+		provide(1)
+		provide(2)
+		provide(3)
+
+		type in struct {
+			In
+
+			Values []int `group:"val"`
+		}
+
+		require.NoError(t, c.Invoke(func(i in) {
+			assert.Equal(t, []int{2, 3, 1}, i.Values)
+		}), "invoke failed")
+	})
+
+	t.Run("group options only allow constructors that return values of the same type", func(t *testing.T) {
+		c := New(setRand(rand.New(rand.NewSource(0))))
+
+		provide := func(i int) {
+			require.Error(t, c.Provide(func() (int, string) {
+				return i, "uh-oh"
+			}, Group("val")), "This Provide should fail")
+		}
+
+		provide(1)
+	})
+
+	t.Run("group options may not be provided for result structs", func(t *testing.T) {
+		c := New(setRand(rand.New(rand.NewSource(0))))
+
+		type out struct {
+			Out
+
+			Value int `group:"val"`
+		}
+
+		provide := func(i int) {
+			require.Error(t, c.Provide(func() out {
+				return out{Value: i}
+			}, Group("val")), "This Provide should fail")
+		}
+
+		provide(1)
+	})
+
 	t.Run("constructor is called at most once", func(t *testing.T) {
 		c := New(setRand(rand.New(rand.NewSource(0))))
 
@@ -1370,6 +1424,29 @@ func TestProvideInvalidName(t *testing.T) {
 	}, Name("foo`bar"))
 	require.Error(t, err, "Provide must fail")
 	assert.Contains(t, err.Error(), "invalid dig.Name(\"foo`bar\"): names cannot contain backquotes")
+}
+
+func TestProvideInvalidGroup(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	err := c.Provide(func() io.Reader {
+		panic("this function must not be called")
+	}, Group("foo`bar"))
+	require.Error(t, err, "Provide must fail")
+	assert.Contains(t, err.Error(), "invalid dig.Group(\"foo`bar\"): group names cannot contain backquotes")
+}
+
+func TestProvideGroupAndName(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	err := c.Provide(func() io.Reader {
+		panic("this function must not be called")
+	}, Group("foo"), Name("bar"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use named values with value groups: " +
+		"name:\"bar\" provided with group:\"foo\"")
 }
 
 func TestCantProvideUntypedNil(t *testing.T) {

--- a/result.go
+++ b/result.go
@@ -186,27 +186,12 @@ func newResultList(ctype reflect.Type, opts resultOptions) (resultList, error) {
 		resultIndexes: make([]int, ctype.NumOut()),
 	}
 
-	isGroup := len(opts.Group) > 0
-	var groupType reflect.Type
-	if ctype.NumOut() > 0 {
-		groupType = ctype.Out(0)
-	}
-
 	resultIdx := 0
 	for i := 0; i < ctype.NumOut(); i++ {
 		t := ctype.Out(i)
 		if isError(t) {
 			rl.resultIndexes[i] = -1
 			continue
-		}
-
-		if isGroup && t != groupType {
-			return rl, fmt.Errorf(
-				"cannot use the group provide option with constructors that return " +
-					"multiple types: a constructor is trying to return type %v and type %v",
-					t,
-					groupType,
-			)
 		}
 
 		r, err := newResult(t, opts)

--- a/result.go
+++ b/result.go
@@ -186,12 +186,24 @@ func newResultList(ctype reflect.Type, opts resultOptions) (resultList, error) {
 		resultIndexes: make([]int, ctype.NumOut()),
 	}
 
+	isGroup := len(opts.Group) > 0
+	groupType := ctype.Out(0)
+
 	resultIdx := 0
 	for i := 0; i < ctype.NumOut(); i++ {
 		t := ctype.Out(i)
 		if isError(t) {
 			rl.resultIndexes[i] = -1
 			continue
+		}
+
+		if isGroup && t != groupType {
+			return rl, fmt.Errorf(
+				"cannot use the group provide option with constructors that return " +
+					"multiple types: a constructor is trying to return type %v and type %v",
+					t,
+					groupType,
+			)
 		}
 
 		r, err := newResult(t, opts)

--- a/result.go
+++ b/result.go
@@ -59,7 +59,7 @@ type resultOptions struct {
 	// If set, this is the name of the associated result value.
 	//
 	// For Result Objects, name:".." tags on fields override this.
-	Name string
+	Name  string
 	Group string
 }
 

--- a/result.go
+++ b/result.go
@@ -60,6 +60,7 @@ type resultOptions struct {
 	//
 	// For Result Objects, name:".." tags on fields override this.
 	Name string
+	Group string
 }
 
 // newResult builds a result from the given type.
@@ -79,6 +80,8 @@ func newResult(t reflect.Type, opts resultOptions) (result, error) {
 		return nil, fmt.Errorf(
 			"cannot return a pointer to a result object, use a value instead: "+
 				"%v is a pointer to a struct that embeds dig.Out", t)
+	case len(opts.Group) > 0:
+		return resultGrouped{Type: t, Group: opts.Group}, nil
 	default:
 		return resultSingle{Type: t, Name: opts.Name}, nil
 	}
@@ -272,6 +275,11 @@ func newResultObject(t reflect.Type, opts resultOptions) (resultObject, error) {
 	if len(opts.Name) > 0 {
 		return ro, fmt.Errorf(
 			"cannot specify a name for result objects: %v embeds dig.Out", t)
+	}
+
+	if len(opts.Group) > 0 {
+		return ro, fmt.Errorf(
+			"cannot specify a group for result objects: %v embeds dig.Out", t)
 	}
 
 	for i := 0; i < t.NumField(); i++ {

--- a/result.go
+++ b/result.go
@@ -187,7 +187,10 @@ func newResultList(ctype reflect.Type, opts resultOptions) (resultList, error) {
 	}
 
 	isGroup := len(opts.Group) > 0
-	groupType := ctype.Out(0)
+	var groupType reflect.Type
+	if ctype.NumOut() > 0 {
+		groupType = ctype.Out(0)
+	}
 
 	resultIdx := 0
 	for i := 0; i < ctype.NumOut(); i++ {


### PR DESCRIPTION
The commits are mostly individually reviewable.

This is a step towards a solution for [#610 (fx)](https://github.com/uber-go/fx/issues/610) for both named values and value groups. This will allow fx to expose its own Group option, which will allow users to form value groups without needing fx.Out.