### PR TITLE
Implementing a dig.As ProvideOption

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -151,9 +151,6 @@ func Group(group string) ProvideOption {
 	})
 }
 
-// As is a ProvideOption that specifies that the struct produced by the constructor
-// implements the given interface
-
 // As is a ProvideOption that specifies that the value produced by the
 // constructor implements one or more other interfaces.  The value will be made
 // available as that interface in the container.
@@ -659,7 +656,7 @@ type node struct {
 
 type nodeOptions struct {
 	// If specified, all values produced by this node have the provided name
-	// belong to the specified value group or implement any of the interfaces
+	// belong to the specified value group or implement any of the interfaces.
 	ResultName  string
 	ResultGroup string
 	ResultAs    []interface{}

--- a/dig.go
+++ b/dig.go
@@ -86,16 +86,16 @@ func (o *provideOptions) Validate() error {
 		t := reflect.TypeOf(i)
 
 		if t == nil {
-			return fmt.Errorf("invalid dig.As(nil): as needs to be ptr to interface")
+			return fmt.Errorf("invalid dig.As(nil): argument must be a pointer to an interface")
 		}
 
 		if t.Kind() != reflect.Ptr {
-			return fmt.Errorf("invalid dig.As(%s): as needs to be ptr to interface", t.Kind())
+			return fmt.Errorf("invalid dig.As(%v): argument must be a pointer to an interface", t)
 		}
 
-		pointingTo := reflect.Indirect(reflect.ValueOf(i))
+		pointingTo := t.Elem()
 		if pointingTo.Kind() != reflect.Interface {
-			return fmt.Errorf("invalid dig.As(%s): as needs to be ptr to interface", pointingTo.Kind())
+			return fmt.Errorf("invalid dig.As(*%v): argument must be a pointer to an interface", pointingTo)
 		}
 	}
 	return nil

--- a/dig_test.go
+++ b/dig_test.go
@@ -1488,27 +1488,27 @@ func TestProvideInvalidAs(t *testing.T) {
 		{
 			name:        "as param is not an type interface",
 			param:       123,
-			expectedErr: "invalid dig.As(int): as needs to be ptr to interface",
+			expectedErr: "invalid dig.As(int): argument must be a pointer to an interface",
 		},
 		{
 			name:        "as param is a pointer to struct",
 			param:       ptrToStruct,
-			expectedErr: "invalid dig.As(struct): as needs to be ptr to interface",
+			expectedErr: "invalid dig.As(*struct { name string }): argument must be a pointer to an interface",
 		},
 		{
 			name:        "as param is a nil interface",
 			param:       nilInterface,
-			expectedErr: "invalid dig.As(nil): as needs to be ptr to interface",
+			expectedErr: "invalid dig.As(nil): argument must be a pointer to an interface",
 		},
 		{
 			name:        "as param is a nil",
 			param:       nil,
-			expectedErr: "invalid dig.As(nil): as needs to be ptr to interface",
+			expectedErr: "invalid dig.As(nil): argument must be a pointer to an interface",
 		},
 		{
 			name:        "as param is a func",
 			param:       func() {},
-			expectedErr: "invalid dig.As(func): as needs to be ptr to interface",
+			expectedErr: "invalid dig.As(func()): argument must be a pointer to an interface",
 		},
 	}
 	for _, tt := range tests {

--- a/dig_test.go
+++ b/dig_test.go
@@ -666,6 +666,13 @@ func TestEndToEndSuccess(t *testing.T) {
 		}, As(new(io.Reader))), "failed to provide")
 	})
 
+	t.Run("As different interface", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() io.ReadCloser {
+			panic("this function should not be called")
+		}, As(new(io.Reader), new(io.Closer))), "failed to provide")
+	})
+
 	t.Run("invoke on a type that depends on named parameters", func(t *testing.T) {
 		c := New()
 		type A struct{ idx int }

--- a/dig_test.go
+++ b/dig_test.go
@@ -1527,16 +1527,28 @@ func TestProvideInvalidAs(t *testing.T) {
 	}
 }
 
-func TestProvideGroupAndName(t *testing.T) {
+func TestProvideIncompatibleOptions(t *testing.T) {
 	t.Parallel()
 
-	c := New()
-	err := c.Provide(func() io.Reader {
-		panic("this function must not be called")
-	}, Group("foo"), Name("bar"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot use named values with value groups: "+
-		"name:\"bar\" provided with group:\"foo\"")
+	t.Run("group and name", func(t *testing.T) {
+		c := New()
+		err := c.Provide(func() io.Reader {
+			panic("this function must not be called")
+		}, Group("foo"), Name("bar"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use named values with value groups: "+
+			"name:\"bar\" provided with group:\"foo\"")
+	})
+
+	t.Run("group and As", func(t *testing.T) {
+		c := New()
+		err := c.Provide(func() *bytes.Buffer {
+			panic("this function must not be called")
+		}, Group("foo"), As(new(io.Reader)))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use dig.As with value groups: "+
+			`dig.As provided with group:"foo"`)
+	})
 }
 
 func TestCantProvideUntypedNil(t *testing.T) {

--- a/dig_test.go
+++ b/dig_test.go
@@ -659,6 +659,13 @@ func TestEndToEndSuccess(t *testing.T) {
 		}))
 	})
 
+	t.Run("As same interface", func(t *testing.T) {
+		c := New()
+		require.NoError(t, c.Provide(func() io.Reader {
+			panic("this function should not be called")
+		}, As(new(io.Reader))), "failed to provide")
+	})
+
 	t.Run("invoke on a type that depends on named parameters", func(t *testing.T) {
 		c := New()
 		type A struct{ idx int }

--- a/dig_test.go
+++ b/dig_test.go
@@ -65,12 +65,14 @@ func TestEndToEndSuccess(t *testing.T) {
 
 	t.Run("struct constructor", func(t *testing.T) {
 		c := New()
-		var buf bytes.Buffer
-		buf.WriteString("foo")
-		require.NoError(t, c.Provide(func() bytes.Buffer { return buf }), "provide failed")
+		require.NoError(t, c.Provide(func() bytes.Buffer {
+			var buf bytes.Buffer
+			buf.WriteString("foo")
+			return buf
+		}), "provide failed")
 		require.NoError(t, c.Invoke(func(b bytes.Buffer) {
 			// ensure we're getting back the buffer we put in
-			require.Equal(t, "foo", buf.String(), "invoke got new buffer")
+			require.Equal(t, "foo", b.String(), "invoke got new buffer")
 		}), "invoke failed")
 	})
 
@@ -601,6 +603,30 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, 1, p.A1.idx)
 			assert.Equal(t, 2, p.A2.idx)
 		}), "both objects should be successfully resolved on Invoke")
+	})
+
+	t.Run("struct constructor with as interface option", func(t *testing.T) {
+		c := New()
+
+		provider := c.Provide(
+			func() *bytes.Buffer {
+				var buf bytes.Buffer
+				buf.WriteString("foo")
+				return &buf
+			},
+			As(new(fmt.Stringer), new(io.Reader)),
+		)
+
+		require.NoError(t, provider, "provide failed")
+
+		require.NoError(t, c.Invoke(
+			func(s fmt.Stringer, r io.Reader) {
+				require.Equal(t, "foo", s.String(), "invoke got new buffer")
+				got, err := ioutil.ReadAll(r)
+				assert.NoError(t, err, "failed to read from reader")
+				require.Equal(t, "foo", string(got), "invoke got new buffer")
+			},
+		), "invoke failed")
 	})
 
 	t.Run("invoke on a type that depends on named parameters", func(t *testing.T) {
@@ -1446,6 +1472,61 @@ func TestProvideInvalidGroup(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid dig.Group(\"foo`bar\"): group names cannot contain backquotes")
 }
 
+func TestProvideInvalidAs(t *testing.T) {
+	ptrToStruct := &struct {
+		name string
+	}{
+		name: "example",
+	}
+	var nilInterface io.Reader
+	c := New()
+	tests := []struct {
+		name        string
+		param       interface{}
+		expectedErr string
+	}{
+		{
+			name:        "as param is not an type interface",
+			param:       123,
+			expectedErr: "invalid dig.As(int): as needs to be ptr to interface",
+		},
+		{
+			name:        "as param is a pointer to struct",
+			param:       ptrToStruct,
+			expectedErr: "invalid dig.As(struct): as needs to be ptr to interface",
+		},
+		{
+			name:        "as param is a nil interface",
+			param:       nilInterface,
+			expectedErr: "invalid dig.As(nil): as needs to be ptr to interface",
+		},
+		{
+			name:        "as param is a nil",
+			param:       nil,
+			expectedErr: "invalid dig.As(nil): as needs to be ptr to interface",
+		},
+		{
+			name:        "as param is a func",
+			param:       func() {},
+			expectedErr: "invalid dig.As(func): as needs to be ptr to interface",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.Provide(
+				func() *bytes.Buffer {
+					var buf bytes.Buffer
+					return &buf
+				},
+				As(tt.param),
+			)
+
+			require.Error(t, err, "provide must fail")
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
 func TestProvideGroupAndName(t *testing.T) {
 	t.Parallel()
 
@@ -1825,6 +1906,32 @@ func TestProvideFailures(t *testing.T) {
 		)
 	})
 
+	t.Run("out returning multiple instances of the same type and As option", func(t *testing.T) {
+		c := New()
+		type A struct{ idx int }
+		type ret struct {
+			Out
+
+			A1 A // same type A provided three times
+			A2 A
+			A3 A
+		}
+
+		err := c.Provide(func() ret {
+			return ret{
+				A1: A{idx: 1},
+				A2: A{idx: 2},
+				A3: A{idx: 3},
+			}
+		}, As(new(interface{})))
+		require.Error(t, err, "provide must return error")
+		assertErrorMatches(t, err,
+			`function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide dig.A from \[0\].A2:`,
+			`already provided by \[0\].A1`,
+		)
+	})
+
 	t.Run("provide multiple instances with the same name", func(t *testing.T) {
 		c := New()
 		type A struct{}
@@ -1904,6 +2011,46 @@ func TestProvideFailures(t *testing.T) {
 			`cannot build a result object by embedding \*dig.Out, embed dig.Out instead:`,
 			`dig.out embeds \*dig.Out`,
 		)
+	})
+
+	t.Run("provide the same implemented interface", func(t *testing.T) {
+		c := New()
+		err := c.Provide(
+			func() *bytes.Buffer {
+				var buf bytes.Buffer
+				return &buf
+			},
+			As(new(io.Reader)),
+			As(new(io.Reader)),
+		)
+
+		require.Error(t, err, "provide must fail")
+		assert.Contains(t, err.Error(), "cannot provide io.Reader")
+		assert.Contains(t, err.Error(), "already provided")
+	})
+
+	t.Run("provide the same implementation with as interface", func(t *testing.T) {
+		c := New()
+		err := c.Provide(
+			func() *bytes.Buffer {
+				var buf bytes.Buffer
+				return &buf
+			},
+			As(new(io.Reader)),
+		)
+		require.NoError(t, err, "provide must not fail here")
+
+		err = c.Provide(
+			func() *bytes.Buffer {
+				var buf bytes.Buffer
+				return &buf
+			},
+			As(new(io.Reader)),
+		)
+
+		require.Error(t, err, "provide must fail")
+		assert.Contains(t, err.Error(), "cannot provide *bytes.Buffer")
+		assert.Contains(t, err.Error(), "already provided")
 	})
 }
 

--- a/graph_test.go
+++ b/graph_test.go
@@ -21,6 +21,7 @@
 package dig
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"reflect"
@@ -437,6 +438,19 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func(in) out1 { return out1{} })
 		c.Provide(func() out2 { return out2{} })
 		VerifyVisualization(t, "named", c)
+	})
+
+	t.Run("dig.As two types", func(t *testing.T) {
+		c := New()
+
+		require.NoError(t, c.Provide(
+			func() *bytes.Buffer {
+				panic("this function should not be called")
+			},
+			As(new(io.Reader), new(io.Writer)),
+		))
+
+		VerifyVisualization(t, "dig_as_two", c)
 	})
 
 	t.Run("optional params", func(t *testing.T) {

--- a/result.go
+++ b/result.go
@@ -256,6 +256,12 @@ func newResultSingle(t reflect.Type, opts resultOptions) (resultSingle, error) {
 		if !t.Implements(ifaceType) {
 			return r, fmt.Errorf("invalid dig.As: %v does not implement %v", t, ifaceType)
 		}
+		if ifaceType == t {
+			// Special case:
+			//   c.Provide(func() io.Reader, As(new(io.Reader)))
+			// Ignore instead of erroring out.
+			continue
+		}
 		r.As = append(r.As, ifaceType)
 	}
 

--- a/testdata/dig_as_two.dot
+++ b/testdata/dig_as_two.dot
@@ -1,0 +1,16 @@
+digraph {
+	rankdir=RL;
+	graph [compound=true];
+	
+		subgraph cluster_0 {
+			constructor_0 [shape=plaintext label="TestVisualize.func4.1"];
+			
+			"*bytes.Buffer" [label=<*bytes.Buffer>];
+			"io.Reader" [label=<io.Reader>];
+			"io.Writer" [label=<io.Writer>];
+			
+		}
+		
+		
+	
+}

--- a/testdata/error.dot
+++ b/testdata/error.dot
@@ -10,7 +10,7 @@ digraph {
 		
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];
+			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];
 			color=orange;
 			"dig.t3[name=n3]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: n3</FONT>>];
 			"dig.t2[group=g2]0" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
@@ -21,7 +21,7 @@ digraph {
 			constructor_0 -> "[type=dig.t1 group=g1]" [ltail=cluster_0];
 		
 		subgraph cluster_1 {
-			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];
+			constructor_1 [shape=plaintext label="TestVisualize.func7.2"];
 			color=orange;
 			"dig.t4" [label=<dig.t4>];
 			
@@ -33,7 +33,7 @@ digraph {
 			constructor_1 -> "[type=dig.t2 group=g2]" [ltail=cluster_1];
 		
 		subgraph cluster_2 {
-			constructor_2 [shape=plaintext label="TestVisualize.func6.4"];
+			constructor_2 [shape=plaintext label="TestVisualize.func7.4"];
 			color=red;
 			"dig.t1[group=g1]0" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];
 			"dig.t2[group=g2]2" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];

--- a/testdata/grouped.dot
+++ b/testdata/grouped.dot
@@ -7,7 +7,7 @@ digraph {
 		
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func5.1"];
+			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];
 			
 			"dig.t3[group=foo]0" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
@@ -15,7 +15,7 @@ digraph {
 		
 		
 		subgraph cluster_1 {
-			constructor_1 [shape=plaintext label="TestVisualize.func5.2"];
+			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];
 			
 			"dig.t3[group=foo]1" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
 			
@@ -23,7 +23,7 @@ digraph {
 		
 		
 		subgraph cluster_2 {
-			constructor_2 [shape=plaintext label="TestVisualize.func5.3"];
+			constructor_2 [shape=plaintext label="TestVisualize.func6.3"];
 			
 			"dig.t2" [label=<dig.t2>];
 			

--- a/testdata/missing.dot
+++ b/testdata/missing.dot
@@ -3,7 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];
+			constructor_0 [shape=plaintext label="TestVisualize.func8.1"];
 			color=orange;
 			"dig.t4" [label=<dig.t4>];
 			

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -3,7 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func4.1"];
+			constructor_0 [shape=plaintext label="TestVisualize.func5.1"];
 			
 			"dig.t1" [label=<dig.t1>];
 			
@@ -11,7 +11,7 @@ digraph {
 		
 		
 		subgraph cluster_1 {
-			constructor_1 [shape=plaintext label="TestVisualize.func4.2"];
+			constructor_1 [shape=plaintext label="TestVisualize.func5.2"];
 			
 			"dig.t2" [label=<dig.t2>];
 			

--- a/testdata/prune_constructor_result.dot
+++ b/testdata/prune_constructor_result.dot
@@ -6,7 +6,7 @@ digraph {
 		
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func6.6.1.2"];
+			constructor_0 [shape=plaintext label="TestVisualize.func7.6.1.2"];
 			color=orange;
 			"dig.t4" [label=<dig.t4>];
 			
@@ -16,7 +16,7 @@ digraph {
 			constructor_0 -> "[type=dig.t2 group=g2]" [ltail=cluster_0];
 		
 		subgraph cluster_1 {
-			constructor_1 [shape=plaintext label="TestVisualize.func6.6.1.3"];
+			constructor_1 [shape=plaintext label="TestVisualize.func7.6.1.3"];
 			color=red;
 			"dig.t2[group=g2]1" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];
 			

--- a/testdata/prune_non_root_nodes.dot
+++ b/testdata/prune_non_root_nodes.dot
@@ -3,7 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
-			constructor_0 [shape=plaintext label="TestVisualize.func6.6.2.2"];
+			constructor_0 [shape=plaintext label="TestVisualize.func7.6.2.2"];
 			color=red;
 			"dig.t4" [label=<dig.t4>];
 			


### PR DESCRIPTION
This adds a dig.As option which allows the caller to specify a
constructor and a list of interfaces that the constructed struct
implements.

Closes #197