### PR TITLE
Preparing release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.8.0] - 2019-11-14
 ### Changed
 - Migrated to Go modules.
 
@@ -147,7 +147,7 @@ First release candidate.
 
 Initial release.
 
-[Unreleased]: https://github.com/uber-go/dig/compare/v1.7.0...HEAD
+[1.8.0]: https://github.com/uber-go/dig/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/uber-go/dig/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/uber-go/dig/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/uber-go/dig/compare/v1.5.0...v1.5.1


### PR DESCRIPTION
This sets up release v1.8.0. The only change in this release is the
migration to Go modules.

We backed out #233; we'll try it again in #252.

List of changes: https://github.com/uber-go/dig/compare/v1.7.0...v1.8.0