### PR TITLE
Add dig.Optional for marking optional params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Added `dig.Optional` embedded type to mark parameter structs as optional.
 
 ## [1.8.0] - 2019-11-14
 ### Changed

--- a/dig.go
+++ b/dig.go
@@ -673,6 +673,10 @@ func (n *node) Call(c containerStore) error {
 
 // Checks if a field of an In struct is optional.
 func isFieldOptional(f reflect.StructField) (bool, error) {
+	if IsOptional(f.Type) || (f.Type.Kind() == reflect.Ptr && IsOptional(f.Type.Elem())) {
+		return true, nil
+	}
+
 	tag := f.Tag.Get(_optionalTag)
 	if tag == "" {
 		return false, nil

--- a/param.go
+++ b/param.go
@@ -67,6 +67,8 @@ func newParam(t reflect.Type) (param, error) {
 		return nil, fmt.Errorf("cannot depend on result objects: %v embeds a dig.Out", t)
 	case IsIn(t):
 		return newParamObject(t)
+	case IsOptional(t) || (t.Kind() == reflect.Ptr && IsOptional(t.Elem())):
+		return paramSingle{Type: t, Optional: true}, nil
 	case embedsType(t, _inPtrType):
 		return nil, fmt.Errorf(
 			"cannot build a parameter object by embedding *dig.In, embed dig.In instead: "+

--- a/param_test.go
+++ b/param_test.go
@@ -81,6 +81,24 @@ func TestParamObjectSuccess(t *testing.T) {
 
 	})
 
+	t.Run("optional struct", func(t *testing.T) {
+		type opt struct {
+			Optional
+
+			T1 type1
+		}
+
+		p, err := newParam(reflect.TypeOf(opt{}))
+		require.NoError(t, err)
+
+		assert.True(t, p.(paramSingle).Optional)
+
+		p, err = newParam(reflect.TypeOf(&opt{}))
+		require.NoError(t, err)
+
+		assert.True(t, p.(paramSingle).Optional)
+	})
+
 	t.Run("named value", func(t *testing.T) {
 		require.Equal(t, "T3", po.Fields[2].FieldName)
 		t3, ok := po.Fields[2].Param.(paramSingle)

--- a/types.go
+++ b/types.go
@@ -26,12 +26,14 @@ import (
 )
 
 var (
-	_noValue    reflect.Value
-	_errType    = reflect.TypeOf((*error)(nil)).Elem()
-	_inPtrType  = reflect.TypeOf((*In)(nil))
-	_inType     = reflect.TypeOf(In{})
-	_outPtrType = reflect.TypeOf((*Out)(nil))
-	_outType    = reflect.TypeOf(Out{})
+	_noValue         reflect.Value
+	_errType         = reflect.TypeOf((*error)(nil)).Elem()
+	_inPtrType       = reflect.TypeOf((*In)(nil))
+	_inType          = reflect.TypeOf(In{})
+	_outPtrType      = reflect.TypeOf((*Out)(nil))
+	_outType         = reflect.TypeOf(Out{})
+	_optionalPtrType = reflect.TypeOf((*Optional)(nil))
+	_optionalType    = reflect.TypeOf(Optional{})
 )
 
 // Special interface embedded inside dig sentinel values (dig.In, dig.Out) to
@@ -80,6 +82,11 @@ type In struct{ digSentinel }
 //               information.
 type Out struct{ digSentinel }
 
+// Optional may be embedded into structs to request dig to treat them as
+// optional structs. When a constructor accepts such a struct, it gracefully
+// handles its absence.
+type Optional struct{ digSentinel }
+
 func isError(t reflect.Type) bool {
 	return t.Implements(_errType)
 }
@@ -110,6 +117,11 @@ func IsIn(o interface{}) bool {
 // tags.
 func IsOut(o interface{}) bool {
 	return embedsType(o, _outType)
+}
+
+// IsOptional checks whether the given struct is a dig.Optional struct.
+func IsOptional(o interface{}) bool {
+	return embedsType(o, _optionalType)
 }
 
 // Returns true if t embeds e or if any of the types embedded by t embed e.


### PR DESCRIPTION
Realized that fx can be improved so certain parameters provided, while in their absence, a default parameter value would be used.

Add a new `dig.Optional` type that can be embedded in structs to mark
that the dependency on them is optional.

