### PR TITLE
errors: Add errf to support multi-line errors

### DIFF
--- a/cycle.go
+++ b/cycle.go
@@ -68,7 +68,7 @@ func verifyAcyclic(c containerStore, n provider, k key) error {
 		{Key: k, Func: n.Location()},
 	}, visited)
 	if err != nil {
-		err = errWrapf(err, "this function introduces a cycle")
+		err = errf("this function introduces a cycle", err)
 	}
 	return err
 }

--- a/dig.go
+++ b/dig.go
@@ -67,8 +67,8 @@ type provideOptions struct {
 func (o *provideOptions) Validate() error {
 	if len(o.Group) > 0 && len(o.Name) > 0 {
 		return errf(
-			"cannot use named values with value groups: name:%q provided with group:%q", o.Name, o.Group)
-
+			"cannot use named values with value groups",
+			"name:%q provided with group:%q", o.Name, o.Group)
 	}
 
 	// Names must be representable inside a backquoted string. The only
@@ -541,9 +541,9 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 
 		if conflict, ok := cv.keyPaths[k]; ok {
 			*cv.err = errf(
-				"cannot provide %v from %v: already provided by %v",
-				k, path, conflict)
-
+				"cannot provide %v from %v", k, path,
+				"already provided by %v", conflict,
+			)
 			return nil
 		}
 
@@ -554,9 +554,9 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 			}
 
 			*cv.err = errf(
-				"cannot provide %v from %v: already provided by %v",
-				k, path, strings.Join(cons, "; "))
-
+				"cannot provide %v from %v", k, path,
+				"already provided by %v", strings.Join(cons, "; "),
+			)
 			return nil
 		}
 

--- a/dig.go
+++ b/dig.go
@@ -411,7 +411,7 @@ func (c *Container) verifyAcyclic() error {
 	visited := make(map[key]struct{})
 	for _, n := range c.nodes {
 		if err := detectCycles(n, c, nil /* path */, visited); err != nil {
-			return errWrapf(err, "cycle detected in dependency graph")
+			return errf("cycle detected in dependency graph", err)
 		}
 	}
 
@@ -683,9 +683,10 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 
 	optional, err := strconv.ParseBool(tag)
 	if err != nil {
-		err = errWrapf(err,
+		err = errf(
 			"invalid value %q for %q tag on field %v",
-			tag, _optionalTag, f.Name)
+			tag, _optionalTag, f.Name, err)
+
 	}
 
 	return optional, err

--- a/dig.go
+++ b/dig.go
@@ -66,8 +66,9 @@ type provideOptions struct {
 
 func (o *provideOptions) Validate() error {
 	if len(o.Group) > 0 && len(o.Name) > 0 {
-		return fmt.Errorf(
+		return errf(
 			"cannot use named values with value groups: name:%q provided with group:%q", o.Name, o.Group)
+
 	}
 
 	// Names must be representable inside a backquoted string. The only
@@ -75,10 +76,10 @@ func (o *provideOptions) Validate() error {
 	// https://golang.org/ref/spec#raw_string_lit is that they cannot contain
 	// backquotes.
 	if strings.ContainsRune(o.Name, '`') {
-		return fmt.Errorf("invalid dig.Name(%q): names cannot contain backquotes", o.Name)
+		return errf("invalid dig.Name(%q): names cannot contain backquotes", o.Name)
 	}
 	if strings.ContainsRune(o.Group, '`') {
-		return fmt.Errorf("invalid dig.Group(%q): group names cannot contain backquotes", o.Group)
+		return errf("invalid dig.Group(%q): group names cannot contain backquotes", o.Group)
 	}
 	return nil
 }
@@ -331,7 +332,7 @@ func (c *Container) Provide(constructor interface{}, opts ...ProvideOption) erro
 		return errors.New("can't provide an untyped nil")
 	}
 	if ctype.Kind() != reflect.Func {
-		return fmt.Errorf("must provide constructor function, got %v (type %v)", constructor, ctype)
+		return errf("must provide constructor function, got %v (type %v)", constructor, ctype)
 	}
 
 	var options provideOptions
@@ -365,7 +366,7 @@ func (c *Container) Invoke(function interface{}, opts ...InvokeOption) error {
 		return errors.New("can't invoke an untyped nil")
 	}
 	if ftype.Kind() != reflect.Func {
-		return fmt.Errorf("can't invoke non-function %v (type %v)", function, ftype)
+		return errf("can't invoke non-function %v (type %v)", function, ftype)
 	}
 
 	pl, err := newParamList(ftype)
@@ -437,7 +438,7 @@ func (c *Container) provide(ctor interface{}, opts provideOptions) error {
 
 	ctype := reflect.TypeOf(ctor)
 	if len(keys) == 0 {
-		return fmt.Errorf("%v must provide at least one non-error type", ctype)
+		return errf("%v must provide at least one non-error type", ctype)
 	}
 
 	for k := range keys {
@@ -539,9 +540,10 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 		k := key{name: r.Name, t: r.Type}
 
 		if conflict, ok := cv.keyPaths[k]; ok {
-			*cv.err = fmt.Errorf(
+			*cv.err = errf(
 				"cannot provide %v from %v: already provided by %v",
 				k, path, conflict)
+
 			return nil
 		}
 
@@ -551,9 +553,10 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 				cons[i] = fmt.Sprint(p.Location())
 			}
 
-			*cv.err = fmt.Errorf(
+			*cv.err = errf(
 				"cannot provide %v from %v: already provided by %v",
 				k, path, strings.Join(cons, "; "))
+
 			return nil
 		}
 

--- a/error.go
+++ b/error.go
@@ -22,6 +22,7 @@ package dig
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -52,6 +53,120 @@ func RootCause(err error) error {
 			return err
 		}
 	}
+}
+
+// errf is a version of fmt.Errorf with support for a chain of multiple
+// formatted error messages.
+//
+// After msg, N arguments are consumed as formatting arguments for that
+// message, where N is the number of % symbols in msg. Following that, another
+// string may be added to become the next error in the chain. Each new error
+// is the `cause()` for the prior error.
+//
+//   err := errf(
+//     "could not process %v", thing,
+//     "name %q is invalid", thing.Name,
+//  )
+//  fmt.Println(err)  // could not process Thing: name Foo is invalid
+//  fmt.Println(RootCause(err))  // name Foo is invalid
+//
+// In place of a string, the last error can be another error, in which case it
+// will be treated as the cause of the prior error chain.
+//
+//   errf(
+//     "could not process %v", thing,
+//     "date %q could not be parsed", thing.Date,
+//     parseError,
+//  )
+func errf(msg string, args ...interface{}) error {
+	// By implementing buildErrf as a closure rather than a standalone
+	// function, we're able to ensure that it is called only from errf, or
+	// from itself (recursively). By controlling these invocations in such
+	// a tight space, we are able to easily verify manually that we
+	// checked len(args) > 0 before making the call.
+	var buildErrf func([]interface{}) error
+	buildErrf = func(args []interface{}) error {
+		arg, args := args[0], args[1:] // assume len(args) > 0
+		if arg == nil {
+			panic("It looks like you have found a bug in dig. " +
+				"Please file an issue at https://github.com/uber-go/dig/issues/ " +
+				"and provide the following message: " +
+				"arg must not be nil")
+		}
+
+		switch v := arg.(type) {
+		case string:
+			need := numFmtArgs(v)
+			if len(args) < need {
+				panic(fmt.Sprintf(
+					"It looks like you have found a bug in dig. "+
+						"Please file an issue at https://github.com/uber-go/dig/issues/ "+
+						"and provide the following message: "+
+						"string %q needs %v arguments, got %v", v, need, len(args)))
+			}
+
+			msg := fmt.Sprintf(v, args[:need]...)
+			args := args[need:]
+
+			// If we don't have anything left to chain with, build the
+			// final error.
+			if len(args) == 0 {
+				return errors.New(msg)
+			}
+
+			return wrappedError{
+				msg: msg,
+				err: buildErrf(args),
+			}
+		case error:
+			if len(args) > 0 {
+				panic(fmt.Sprintf(
+					"It looks like you have found a bug in dig. "+
+						"Please file an issue at https://github.com/uber-go/dig/issues/ "+
+						"and provide the following message: "+
+						"error must be the last element but got %v", args))
+			}
+
+			return v
+
+		default:
+			panic(fmt.Sprintf(
+				"It looks like you have found a bug in dig. "+
+					"Please file an issue at https://github.com/uber-go/dig/issues/ "+
+					"and provide the following message: "+
+					"unexpected errf-argument type %T", arg))
+		}
+	}
+
+	// Prepend msg to the args list so that we can re-use the same
+	// args processing logic. The msg is a string just for type-safety of
+	// the first error.
+	newArgs := make([]interface{}, len(args)+1)
+	newArgs[0] = msg
+	copy(newArgs[1:], args)
+	return buildErrf(newArgs)
+}
+
+// Returns the number of formatting arguments in the provided string. Does not
+// count escaped % symbols, specifically the string "%%".
+//
+//   fmt.Println(numFmtArgs("rate: %d%%"))  // 1
+func numFmtArgs(s string) int {
+	var (
+		count   int
+		percent bool // saw %
+	)
+	for _, c := range s {
+		if percent && c != '%' {
+			// Counts only if it's not a %%.
+			count++
+		}
+
+		// Next iteration should consider % only if the current %
+		// stands alone.
+		percent = !percent && c == '%'
+	}
+	return count
 }
 
 // errWrapf wraps an existing error with more contextual information.

--- a/error.go
+++ b/error.go
@@ -169,25 +169,6 @@ func numFmtArgs(s string) int {
 	return count
 }
 
-// errWrapf wraps an existing error with more contextual information.
-//
-// The given error is treated as the cause of the returned error (see causer).
-//
-//   RootCause(errWrapf(errWrapf(err, ...), ...)) == err
-//
-// Use errWrapf instead of fmt.Errorf if the message ends with ": <original error>".
-func errWrapf(err error, msg string, args ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	if len(args) > 0 {
-		msg = fmt.Sprintf(msg, args...)
-	}
-
-	return wrappedError{err: err, msg: msg}
-}
-
 type wrappedError struct {
 	err error
 	msg string

--- a/error_test.go
+++ b/error_test.go
@@ -31,34 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrWrapf(t *testing.T) {
-	t.Run("nil", func(t *testing.T) {
-		err := errWrapf(nil, "hi")
-		assert.NoError(t, err, "expected no error")
-		assert.NoError(t, RootCause(err), "root cause must be nil")
-	})
-
-	t.Run("single wrap", func(t *testing.T) {
-		err := errors.New("great sadness")
-		werr := errWrapf(err, "something went %s", "wrong")
-
-		assert.Equal(t, err, RootCause(werr), "root cause must match")
-		assert.Equal(t, "something went wrong: great sadness", werr.Error(),
-			"error message must match")
-	})
-
-	t.Run("double wrap", func(t *testing.T) {
-		err := errors.New("great sadness")
-
-		werr := errWrapf(err, "something went %s", "wrong")
-		werr = errWrapf(werr, "something else went wrong")
-
-		assert.Equal(t, err, RootCause(werr), "root cause must match")
-		assert.Equal(t, "something else went wrong: something went wrong: great sadness", werr.Error(),
-			"error message must match")
-	})
-}
-
 // assertErrorMatches matches error messages against the provided list of
 // strings.
 //

--- a/graph_test.go
+++ b/graph_test.go
@@ -21,7 +21,6 @@
 package dig
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -498,7 +497,7 @@ func TestVisualize(t *testing.T) {
 		c.Provide(func(in1) out1 { return out1{} })
 		c.Provide(func(in2) t4 { return t4{} })
 		c.Provide(func() out2 { return out2{} })
-		c.Provide(func() (out3, error) { return out3{}, fmt.Errorf("great sadness") })
+		c.Provide(func() (out3, error) { return out3{}, errf("great sadness") })
 		err := c.Invoke(func(t4 t4) { return })
 
 		VerifyVisualization(t, "error", c, VisualizeError(err))
@@ -509,7 +508,7 @@ func TestVisualize(t *testing.T) {
 				c := New()
 				c.Provide(func(in1) out1 { return out1{} })
 				c.Provide(func(in2) t4 { return t4{} })
-				c.Provide(func() (out2, error) { return out2{}, fmt.Errorf("great sadness") })
+				c.Provide(func() (out2, error) { return out2{}, errf("great sadness") })
 				c.Provide(func() out3 { return out3{} })
 				err := c.Invoke(func(t4 t4) { return })
 
@@ -519,7 +518,7 @@ func TestVisualize(t *testing.T) {
 			t.Run("if only the root node fails all node except for the root should be pruned", func(t *testing.T) {
 				c := New()
 				c.Provide(func(in1) out1 { return out1{} })
-				c.Provide(func(in2) (t4, error) { return t4{}, fmt.Errorf("great sadness") })
+				c.Provide(func(in2) (t4, error) { return t4{}, errf("great sadness") })
 				c.Provide(func() out2 { return out2{} })
 				c.Provide(func() out3 { return out3{} })
 				err := c.Invoke(func(t4 t4) { return })
@@ -566,12 +565,12 @@ func TestCanVisualizeError(t *testing.T) {
 	}{
 		{
 			desc:         "unvisualizable error",
-			err:          fmt.Errorf("great sadness"),
+			err:          errf("great sadness"),
 			canVisualize: false,
 		},
 		{
 			desc:         "nested unvisualizable error",
-			err:          nestedErr{err: fmt.Errorf("great sadness")},
+			err:          nestedErr{err: errf("great sadness")},
 			canVisualize: false,
 		},
 		{

--- a/param.go
+++ b/param.go
@@ -64,19 +64,17 @@ var (
 func newParam(t reflect.Type) (param, error) {
 	switch {
 	case IsOut(t) || (t.Kind() == reflect.Ptr && IsOut(t.Elem())) || embedsType(t, _outPtrType):
-		return nil, errf("cannot depend on result objects: %v embeds a dig.Out", t)
+		return nil, errf("cannot depend on result objects", "%v embeds a dig.Out", t)
 	case IsIn(t):
 		return newParamObject(t)
 	case embedsType(t, _inPtrType):
 		return nil, errf(
-			"cannot build a parameter object by embedding *dig.In, embed dig.In instead: "+
-				"%v embeds *dig.In", t)
-
+			"cannot build a parameter object by embedding *dig.In, embed dig.In instead",
+			"%v embeds *dig.In", t)
 	case t.Kind() == reflect.Ptr && IsIn(t.Elem()):
 		return nil, errf(
-			"cannot depend on a pointer to a parameter object, use a value instead: "+
-				"%v is a pointer to a struct that embeds dig.In", t)
-
+			"cannot depend on a pointer to a parameter object, use a value instead",
+			"%v is a pointer to a struct that embeds dig.In", t)
 	default:
 		return paramSingle{Type: t}, nil
 	}
@@ -422,12 +420,13 @@ func newParamGroupedSlice(f reflect.StructField) (paramGroupedSlice, error) {
 	optional, _ := isFieldOptional(f)
 	switch {
 	case f.Type.Kind() != reflect.Slice:
-		return pg, errf("value groups may be consumed as slices only: "+
+		return pg, errf("value groups may be consumed as slices only",
 			"field %q (%v) is not a slice", f.Name, f.Type)
 
 	case name != "":
 		return pg, errf(
-			"cannot use named values with value groups: name:%q requested with group:%q", name, pg.Group)
+			"cannot use named values with value groups",
+			"name:%q requested with group:%q", name, pg.Group)
 
 	case optional:
 		return pg, errors.New("value groups cannot be optional")

--- a/param.go
+++ b/param.go
@@ -64,17 +64,19 @@ var (
 func newParam(t reflect.Type) (param, error) {
 	switch {
 	case IsOut(t) || (t.Kind() == reflect.Ptr && IsOut(t.Elem())) || embedsType(t, _outPtrType):
-		return nil, fmt.Errorf("cannot depend on result objects: %v embeds a dig.Out", t)
+		return nil, errf("cannot depend on result objects: %v embeds a dig.Out", t)
 	case IsIn(t):
 		return newParamObject(t)
 	case embedsType(t, _inPtrType):
-		return nil, fmt.Errorf(
+		return nil, errf(
 			"cannot build a parameter object by embedding *dig.In, embed dig.In instead: "+
 				"%v embeds *dig.In", t)
+
 	case t.Kind() == reflect.Ptr && IsIn(t.Elem()):
-		return nil, fmt.Errorf(
+		return nil, errf(
 			"cannot depend on a pointer to a parameter object, use a value instead: "+
 				"%v is a pointer to a struct that embeds dig.In", t)
+
 	default:
 		return paramSingle{Type: t}, nil
 	}
@@ -345,7 +347,7 @@ func newParamObjectField(idx int, f reflect.StructField) (paramObjectField, erro
 	var p param
 	switch {
 	case f.PkgPath != "":
-		return pof, fmt.Errorf(
+		return pof, errf(
 			"unexported fields not allowed in dig.In, did you mean to export %q (%v)?",
 			f.Name, f.Type)
 
@@ -420,10 +422,11 @@ func newParamGroupedSlice(f reflect.StructField) (paramGroupedSlice, error) {
 	optional, _ := isFieldOptional(f)
 	switch {
 	case f.Type.Kind() != reflect.Slice:
-		return pg, fmt.Errorf("value groups may be consumed as slices only: "+
+		return pg, errf("value groups may be consumed as slices only: "+
 			"field %q (%v) is not a slice", f.Name, f.Type)
+
 	case name != "":
-		return pg, fmt.Errorf(
+		return pg, errf(
 			"cannot use named values with value groups: name:%q requested with group:%q", name, pg.Group)
 
 	case optional:

--- a/param.go
+++ b/param.go
@@ -179,7 +179,7 @@ func newParamList(ctype reflect.Type) (paramList, error) {
 	for i := 0; i < numArgs; i++ {
 		p, err := newParam(ctype.In(i))
 		if err != nil {
-			return pl, errWrapf(err, "bad argument %d", i+1)
+			return pl, errf("bad argument %d", i+1, err)
 		}
 		pl.Params = append(pl.Params, p)
 	}
@@ -298,7 +298,7 @@ func newParamObject(t reflect.Type) (paramObject, error) {
 
 		pof, err := newParamObjectField(i, f)
 		if err != nil {
-			return po, errWrapf(err, "bad field %q of %v", f.Name, t)
+			return po, errf("bad field %q of %v", f.Name, t, err)
 		}
 
 		po.Fields = append(po.Fields, pof)

--- a/result.go
+++ b/result.go
@@ -67,21 +67,19 @@ type resultOptions struct {
 func newResult(t reflect.Type, opts resultOptions) (result, error) {
 	switch {
 	case IsIn(t) || (t.Kind() == reflect.Ptr && IsIn(t.Elem())) || embedsType(t, _inPtrType):
-		return nil, errf("cannot provide parameter objects: %v embeds a dig.In", t)
+		return nil, errf("cannot provide parameter objects", "%v embeds a dig.In", t)
 	case isError(t):
 		return nil, errf("cannot return an error here, return it from the constructor instead")
 	case IsOut(t):
 		return newResultObject(t, opts)
 	case embedsType(t, _outPtrType):
 		return nil, errf(
-			"cannot build a result object by embedding *dig.Out, embed dig.Out instead: "+
-				"%v embeds *dig.Out", t)
-
+			"cannot build a result object by embedding *dig.Out, embed dig.Out instead",
+			"%v embeds *dig.Out", t)
 	case t.Kind() == reflect.Ptr && IsOut(t.Elem()):
 		return nil, errf(
-			"cannot return a pointer to a result object, use a value instead: "+
-				"%v is a pointer to a struct that embeds dig.Out", t)
-
+			"cannot return a pointer to a result object, use a value instead",
+			"%v is a pointer to a struct that embeds dig.Out", t)
 	case len(opts.Group) > 0:
 		return resultGrouped{Type: t, Group: opts.Group}, nil
 	default:
@@ -276,14 +274,12 @@ func newResultObject(t reflect.Type, opts resultOptions) (resultObject, error) {
 	ro := resultObject{Type: t}
 	if len(opts.Name) > 0 {
 		return ro, errf(
-			"cannot specify a name for result objects: %v embeds dig.Out", t)
-
+			"cannot specify a name for result objects", "%v embeds dig.Out", t)
 	}
 
 	if len(opts.Group) > 0 {
 		return ro, errf(
-			"cannot specify a group for result objects: %v embeds dig.Out", t)
-
+			"cannot specify a group for result objects", "%v embeds dig.Out", t)
 	}
 
 	for i := 0; i < t.NumField(); i++ {
@@ -397,8 +393,8 @@ func newResultGrouped(f reflect.StructField) (resultGrouped, error) {
 	switch {
 	case name != "":
 		return rg, errf(
-			"cannot use named values with value groups: name:%q provided with group:%q", name, rg.Group)
-
+			"cannot use named values with value groups",
+			"name:%q provided with group:%q", name, rg.Group)
 	case optional:
 		return rg, errors.New("value groups cannot be optional")
 	}

--- a/result.go
+++ b/result.go
@@ -198,7 +198,7 @@ func newResultList(ctype reflect.Type, opts resultOptions) (resultList, error) {
 
 		r, err := newResult(t, opts)
 		if err != nil {
-			return rl, errWrapf(err, "bad result %d", i+1)
+			return rl, errf("bad result %d", i+1, err)
 		}
 
 		rl.Results = append(rl.Results, r)
@@ -295,7 +295,7 @@ func newResultObject(t reflect.Type, opts resultOptions) (resultObject, error) {
 
 		rof, err := newResultObjectField(i, f, opts)
 		if err != nil {
-			return ro, errWrapf(err, "bad field %q of %v", f.Name, t)
+			return ro, errf("bad field %q of %v", f.Name, t, err)
 		}
 
 		ro.Fields = append(ro.Fields, rof)


### PR DESCRIPTION
*Commits are individually reviewable.*

Errors printed by dig are currently a massive wall of text. We've
received consistent feedback that these errors are difficult to read.
To help make these error messages more readable, we're going to split
them across multiple lines when printed with `%+v` instead of `%v`.

As a first step to doing this, we need to inform the system where
individual sections of error messages end so that newlines can be
introduced. A natual point for most errors in the form `foo: bar` is
after the `:`. So, `something went wrong: great sadness` could be
printed as the following with `%+v`.

    something went wrong:
    great sadness

To inform the system where error messages end, we're going to resort to
chaining error messages with our existing `wrappedError` typed. The
error above will become,

    wrappedError{
      msg: "something went wrong",
      cause: errors.New("great sadness"),
    }

Doing this by hand is cumbersome, so to build these error chains
conveniently, this change introduces an `errf(string, ...interface{})`
function. This will replace use of `fmt.Errorf` and our previous
`errWrapf` functions. It supports building chains of multiple formatted
errors by adding another printf-style string and its arguments when the
arguments for the previous string end.

    errf(
      "could not process %q (ID: %v)", thing, thingID,
      "request %v is invalid", requestID,
    )

The above will build an error chain where the second string is the
cause of the first. So the above is roughly equivalent to the following.

    wrappedError{
      msg: `could not process "foo" (ID: 12)`,
      err: errors.New("request 42 is invalid"),
    }

In addition to that, the function supports a standalone `error`
argument in place of a string for its last argument. This helps use
replace the `errWrapf` function we previously used.

    errf("could not parse %q", s, err)
    // equivalent to
    errWrapf(err, "could not parse %q", s)

    // Output:
    // could not parse "foo": not a number

You can interpret each string and its formatting arguments as one node
in the chain of errors, where the final node can be another such string
and its arguments, or a different `error`.

---

This change holds a series of individually reviewable changes that
introduce this functionality and transition existing usage of
`fmt.Errorf` and `errWrapf` over to it. Additionally, this also breaks
apart `fmt.Errorf`-based error messages on sentence boundaries so that
they are chained together, with the intent of having them broken across
multiple lines in the future.

    fmt.Errorf("cannot do x: thing y is invalid: %v", err)
    // becomes
    errf("cannot do x", "thing y is invalid", err)

This has no user-facing changes at this time, but the idea is that
we'll be able to print multi-line error messages, inserting newlines at
these boundaries.

Refs T2587659