### PR TITLE
Print multi-line error messages with %+v

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -695,7 +695,7 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 // Checks that all direct dependencies of the provided param are present in
 // the container. Returns an error if not.
 func shallowCheckDependencies(c containerStore, p param) error {
-	var missing errMissingManyTypes
+	var err errMissingTypes
 	var addMissingNodes []*dot.Param
 	walkParam(p, paramVisitorFunc(func(p param) bool {
 		ps, ok := p.(paramSingle)
@@ -704,15 +704,15 @@ func shallowCheckDependencies(c containerStore, p param) error {
 		}
 
 		if ns := c.getValueProviders(ps.Name, ps.Type); len(ns) == 0 && !ps.Optional {
-			missing = append(missing, newErrMissingType(c, key{name: ps.Name, t: ps.Type}))
+			err = append(err, newErrMissingTypes(c, key{name: ps.Name, t: ps.Type})...)
 			addMissingNodes = append(addMissingNodes, ps.DotParam()...)
 		}
 
 		return true
 	}))
 
-	if len(missing) > 0 {
-		return missing
+	if len(err) > 0 {
+		return err
 	}
 	return nil
 }

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -60,7 +60,7 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 		err := c.Provide(func() B { return B{} })
 		require.Error(t, err, "B should fail to provide")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+ \(\S+:\d+\)`,
 			`cannot provide dig.A from \[0\]:`,
 			`already provided by "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+`,
 		)

--- a/dig_go19_test.go
+++ b/dig_go19_test.go
@@ -60,7 +60,8 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 		err := c.Provide(func() B { return B{} })
 		require.Error(t, err, "B should fail to provide")
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+ \(\S+:\d+\)`,
+			`cannot provide function "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+`,
+			`dig_go19_test.go:\d+`, // file:line
 			`cannot provide dig.A from \[0\]:`,
 			`already provided by "go.uber.org/dig".TestEndToEndSuccessWithAliases\S+`,
 		)

--- a/dig_test.go
+++ b/dig_test.go
@@ -864,8 +864,10 @@ func TestEndToEndSuccess(t *testing.T) {
 		err := c.Invoke(func(B) {})
 		require.Error(t, err, "invoking with B param should error out")
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestEndToEndSuccess.func\S+ \(\S+/dig_test.go:\d+\):`,
-			"missing type: dig.B",
+			`missing dependencies for function "go.uber.org/dig".TestEndToEndSuccess.func\S+`,
+			`dig_test.go:\d+`, // file:line
+			"missing type:",
+			"dig.B",
 		)
 	})
 }
@@ -1209,7 +1211,8 @@ func TestGroups(t *testing.T) {
 		assertErrorMatches(t, err,
 			`could not build arguments for function "go.uber.org/dig".TestGroups`,
 			`could not build value group string\[group="x"\]:`,
-			`received non-nil error from function "go.uber.org/dig".TestGroups\S+ \(\S+:\d+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestGroups\S+`,
+			`dig_test.go:\d+`, // file:line
 			"great sadness",
 		)
 		assert.Equal(t, gaveErr, RootCause(err))
@@ -1269,7 +1272,8 @@ func TestProvideConstructorErrors(t *testing.T) {
 				err := c.Provide(tt.constructor)
 				require.Error(t, err, "provide should fail")
 				assertErrorMatches(t, err,
-					`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\):`,
+					`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+`,
+					`dig_test.go:\d+`, // file:line
 					`bad argument 1:`,
 					`cannot depend on result objects:`,
 					tt.msg)
@@ -1293,9 +1297,11 @@ func TestProvideConstructorErrors(t *testing.T) {
 		require.Error(t, err)
 
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+`,
+			`dig_test.go:\d+`, // file:line
 			`bad result 1:`,
-			"cannot specify a name for result objects: dig.out embeds dig.Out",
+			"cannot specify a name for result objects:",
+			"dig.out embeds dig.Out",
 		)
 	})
 
@@ -1320,9 +1326,11 @@ func TestProvideConstructorErrors(t *testing.T) {
 		require.Error(t, err)
 
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+`,
+			`dig_test.go:\d+`, // file:line
 			`bad field "Result1" of dig.Result2:`,
-			"cannot specify a name for result objects: dig.Result1 embeds dig.Out",
+			"cannot specify a name for result objects:",
+			"dig.Result1 embeds dig.Out",
 		)
 	})
 }
@@ -1346,9 +1354,11 @@ func TestProvideRespectsConstructorErrors(t *testing.T) {
 		var called bool
 		err := c.Invoke(func(b *bytes.Buffer) { called = true })
 		assertErrorMatches(t, err,
-			`could not build arguments for function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+`,
+			`dig_test.go:\d+`, // file:line
 			`failed to build \*bytes.Buffer:`,
-			`received non-nil error from function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+ \(\S+:\d+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+`,
+			`dig_test.go:\d+`, // file:line
 			`oh no`)
 		assert.False(t, called, "shouldn't call invoked function when deps aren't available")
 	})
@@ -1492,7 +1502,8 @@ func TestCantProvideParameterObjects(t *testing.T) {
 		})
 		require.Error(t, err, "provide should fail")
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestCantProvideParameterObjects\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestCantProvideParameterObjects\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad result 1:",
 			`cannot provide parameter objects:`,
 			`dig.Args embeds a dig.In`,
@@ -1508,7 +1519,8 @@ func TestCantProvideParameterObjects(t *testing.T) {
 		err := c.Provide(func() (*Args, error) { return args, nil })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestCantProvideParameterObjects\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestCantProvideParameterObjects\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad result 1:",
 			`cannot provide parameter objects:`,
 			`\*dig.Args embeds a dig.In`,
@@ -1562,7 +1574,8 @@ func TestProvideCycleFails(t *testing.T) {
 		require.Error(t, err, "expected error when introducing cycle")
 		require.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`this function introduces a cycle:`,
 			`\*dig.C provided by "go.uber.org/dig".TestProvideCycleFails\S+ \(\S+\)`,
 			`depends on \*dig.B provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
@@ -1608,7 +1621,8 @@ func TestProvideCycleFails(t *testing.T) {
 		require.Error(t, err, "expected error when introducing cycle")
 		require.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`this function introduces a cycle:`,
 			`dig.C provided by "go.uber.org/dig".TestProvideCycleFails\S+ \(\S+\)`,
 			`depends on dig.B provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
@@ -1678,7 +1692,8 @@ func TestProvideCycleFails(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`this function introduces a cycle:`,
 			`\*dig.D provided by "go.uber.org/dig".TestProvideCycleFails\S+ \(\S+\)`,
 			`depends on int\[group="bar"\] provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
@@ -1818,7 +1833,8 @@ func TestProvideFailures(t *testing.T) {
 		})
 		require.Error(t, err, "provide must return error")
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			`cannot provide dig.A from \[0\].A2:`,
 			`already provided by \[0\].A1`,
 		)
@@ -1843,7 +1859,8 @@ func TestProvideFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected error on the second provide")
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			`cannot provide \*dig.A\[name="foo"\] from \[0\].A:`,
 			`already provided by "go.uber.org/dig".TestProvideFailures\S+`,
 		)
@@ -1862,7 +1879,8 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() out1 { return out1{a2: A{77}} })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad result 1:",
 			`bad field "a2" of dig.out1:`,
 			`unexported fields not allowed in dig.Out, did you mean to export "a2" \(dig.A\)\?`,
@@ -1879,7 +1897,8 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() *out { return &out{String: "foo"} })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad result 1:",
 			`cannot return a pointer to a result object, use a value instead:`,
 			`\*dig.out is a pointer to a struct that embeds dig.Out`,
@@ -1898,7 +1917,8 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() out { return out{String: "foo"} })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad result 1:",
 			`cannot build a result object by embedding \*dig.Out, embed dig.Out instead:`,
 			`dig.out embeds \*dig.Out`,
@@ -1929,8 +1949,10 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(*bytes.Buffer) {})
 		require.Error(t, err, "expected failure")
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+\):`,
-			`missing type: \*bytes.Buffer`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`,
+			`missing type:`,
+			`\*bytes.Buffer`,
 		)
 	})
 
@@ -1952,8 +1974,10 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "expected invoke error")
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+\):`,
-			`missing type: \*dig.type2`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`\*dig.type2`,
 		)
 	})
 
@@ -1969,8 +1993,10 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err, "invoke should fail")
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`missing type: \*bytes.Buffer\[name="foo"\]`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`\*bytes.Buffer\[name="foo"\]`,
 		)
 	})
 
@@ -1997,10 +2023,13 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err, "invoke must fail")
 		assertErrorMatches(t, err,
-			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			`failed to build \*dig.type3:`,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`missing type: \*dig.type1`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`\*dig.type1`,
 		)
 		// We don't expect type2 to be mentioned in the list because it's
 		// optional
@@ -2027,12 +2056,14 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "invoke must fail")
 		assertErrorMatches(t, err,
-			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			`failed to build dig.type3:`,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`missing types:`,
 			"dig.type1",
-			`\*dig.type2 \(did you mean dig.type2\?\)`,
+			`\*dig.type2 \(did you mean (to use )?dig.type2\?\)`,
 		)
 	})
 
@@ -2077,7 +2108,8 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "expected provide error")
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad argument 1:",
 			`bad field "Args" of dig.args:`,
 			`bad field "Buffer" of dig.nestedArgs:`,
@@ -2145,11 +2177,14 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected invoke error")
 		assertErrorMatches(t, err,
-			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			`failed to build \*dig.dep:`,
-			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`failed to build \*dig.failed:`,
-			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`failed`,
 		)
 		assert.Equal(t, errFailed, RootCause(err), "root cause must match")
@@ -2187,8 +2222,10 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Invoke(func(param2) {})
 		require.Error(t, err, "provide should return error since cases don't match")
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
-			`missing type: dig.A\[name="camelcase"\]`)
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`dig.A\[name="camelcase"\]`)
 	})
 
 	t.Run("in unexported member gets an error", func(t *testing.T) {
@@ -2222,7 +2259,8 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Provide(func(in) int { return 0 })
 		require.Error(t, err, "Provide must fail")
 		assertErrorMatches(t, err,
-			`cannot provide function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
+			`cannot provide function "go.uber.org/dig".TestInvokeFailures\S+`,
+			`dig_test.go:\d+`, // file:line
 			"bad argument 1:",
 			`bad field "foo" of dig.in:`,
 			`unexported fields not allowed in dig.In, did you mean to export "foo" \(string\)\?`,
@@ -2336,19 +2374,25 @@ func TestInvokeFailures(t *testing.T) {
 			name        string
 			provide     interface{}
 			invoke      interface{}
-			errContains string
+			errContains []string
 		}{
 			{
-				name:        "value missing, pointer present",
-				provide:     func() *A { return &A{} },
-				invoke:      func(A) {},
-				errContains: `missing type: dig.A \(did you mean \*dig.A\?\)`,
+				name:    "value missing, pointer present",
+				provide: func() *A { return &A{} },
+				invoke:  func(A) {},
+				errContains: []string{
+					`missing type:`,
+					`dig.A \(did you mean (to use )?\*dig.A\?\)`,
+				},
 			},
 			{
-				name:        "pointer missing, value present",
-				provide:     func() A { return A{} },
-				invoke:      func(*A) {},
-				errContains: `missing type: \*dig.A \(did you mean dig.A\?\)`,
+				name:    "pointer missing, value present",
+				provide: func() A { return A{} },
+				invoke:  func(*A) {},
+				errContains: []string{
+					`missing type:`,
+					`\*dig.A \(did you mean (to use )?dig.A\?\)`,
+				},
 			},
 			{
 				name:    "named pointer missing, value present",
@@ -2359,7 +2403,10 @@ func TestInvokeFailures(t *testing.T) {
 					*A `name:"hello"`
 				}) {
 				},
-				errContains: `missing type: \*dig.A\[name="hello"\] \(did you mean dig.A\[name="hello"\]\?\)`,
+				errContains: []string{
+					`missing type:`,
+					`\*dig.A\[name="hello"\] \(did you mean (to use )?dig.A\[name="hello"\]\?\)`,
+				},
 			},
 		}
 
@@ -2370,10 +2417,13 @@ func TestInvokeFailures(t *testing.T) {
 
 				err := c.Invoke(tc.invoke)
 				require.Error(t, err)
+
+				lines := append([]string{
+					`dig_test.go:\d+`, // file:line
+				}, tc.errContains...)
 				assertErrorMatches(t, err,
-					`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-					tc.errContains,
-				)
+					`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+					lines...)
 			})
 		}
 	})
@@ -2386,8 +2436,10 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`missing type: io.Reader \(did you mean \*bytes.Reader\?\)`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`io.Reader \(did you mean (to use )?\*bytes.Reader\?\)`,
 		)
 	})
 
@@ -2402,8 +2454,10 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`missing type: io.Reader \(did you mean \*bytes.Buffer, or \*bytes.Reader\?\)`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`io.Reader \(did you mean (to use one of )?\*bytes.Buffer, or \*bytes.Reader\?\)`,
 		)
 	})
 
@@ -2418,10 +2472,10 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`missing types:`,
-			`io.Reader \(did you mean \*bytes.Buffer, or \*bytes.Reader\?\);`,
-			`io.Writer \(did you mean \*bytes.Buffer\?\)`,
+			`io.Writer \(did you mean (to use )?\*bytes.Buffer\?\)`,
 		)
 	})
 
@@ -2435,8 +2489,10 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`missing type: \*bytes.Buffer \(did you mean io.Writer\?\)`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`\*bytes.Buffer \(did you mean (to use )?io.Writer\?\)`,
 		)
 	})
 
@@ -2452,8 +2508,10 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`missing type: \*bytes.Buffer \(did you mean io.Reader, or io.Writer\?\)`,
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			`missing type:`,
+			`\*bytes.Buffer \(did you mean (to use one of )?io.Reader, or io.Writer\?\)`,
 		)
 	})
 
@@ -2470,7 +2528,8 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "expected Invoke error")
 		assertErrorMatches(t, err,
-			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+`,
+			`dig_test.go:\d+`, // file:line
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2498,7 +2557,8 @@ func TestInvokeFailures(t *testing.T) {
 			"failed to build dig.B",
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+`,
 			"failed to build dig.A",
-			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+`,
+			`dig_test.go:\d+`, // file:line
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2525,7 +2585,8 @@ func TestInvokeFailures(t *testing.T) {
 		assertErrorMatches(t, err,
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func\S+`,
 			"failed to build dig.A:",
-			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+`,
+			`dig_test.go:\d+`, // file:line
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2555,11 +2616,13 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "expected Invoke error")
 		assertErrorMatches(t, err,
-			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func\S+`,
+			`dig_test.go:\d+`, // file:line
 			"failed to build dig.B:",
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func\S+`,
 			"failed to build dig.A:",
-			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+`,
+			`dig_test.go:\d+`, // file:line
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2593,10 +2656,13 @@ func TestInvokeFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected failure")
 		assertErrorMatches(t, err,
-			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
+			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
 			`could not build value group dig.B\[group="b"\]:`,
-			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
-			"missing type: dig.A",
+			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+`,
+			`dig_test.go:\d+`, // file:line
+			"missing type:",
+			"dig.A",
 		)
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -865,8 +865,7 @@ func TestEndToEndSuccess(t *testing.T) {
 		require.Error(t, err, "invoking with B param should error out")
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestEndToEndSuccess.func\S+ \(\S+/dig_test.go:\d+\):`,
-			"type dig.B is not in the container,",
-			"did you mean to Provide it?",
+			"missing type: dig.B",
 		)
 	})
 }
@@ -1931,7 +1930,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err, "expected failure")
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+\):`,
-			`type \*bytes.Buffer is not in the container, did you mean to Provide it\?`,
+			`missing type: \*bytes.Buffer`,
 		)
 	})
 
@@ -1954,7 +1953,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err, "expected invoke error")
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+\):`,
-			`type \*dig.type2 is not in the container, did you mean to Provide it\?`,
+			`missing type: \*dig.type2`,
 		)
 	})
 
@@ -1971,7 +1970,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err, "invoke should fail")
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`type \*bytes.Buffer\[name="foo"\] is not in the container, did you mean to Provide it\?`,
+			`missing type: \*bytes.Buffer\[name="foo"\]`,
 		)
 	})
 
@@ -2001,7 +2000,7 @@ func TestInvokeFailures(t *testing.T) {
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
 			`failed to build \*dig.type3:`,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`type \*dig.type1 is not in the container, did you mean to Provide it\?`,
+			`missing type: \*dig.type1`,
 		)
 		// We don't expect type2 to be mentioned in the list because it's
 		// optional
@@ -2031,8 +2030,8 @@ func TestInvokeFailures(t *testing.T) {
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
 			`failed to build dig.type3:`,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`the following types are not in the container:`,
-			"dig.type1;",
+			`missing types:`,
+			"dig.type1",
 			`\*dig.type2 \(did you mean dig.type2\?\)`,
 		)
 	})
@@ -2189,7 +2188,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err, "provide should return error since cases don't match")
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
-			`type dig.A\[name="camelcase"\] is not in the container, did you mean to Provide it`)
+			`missing type: dig.A\[name="camelcase"\]`)
 	})
 
 	t.Run("in unexported member gets an error", func(t *testing.T) {
@@ -2343,13 +2342,13 @@ func TestInvokeFailures(t *testing.T) {
 				name:        "value missing, pointer present",
 				provide:     func() *A { return &A{} },
 				invoke:      func(A) {},
-				errContains: `type dig.A is not in the container, did you mean to use \*dig.A\?`,
+				errContains: `missing type: dig.A \(did you mean \*dig.A\?\)`,
 			},
 			{
 				name:        "pointer missing, value present",
 				provide:     func() A { return A{} },
 				invoke:      func(*A) {},
-				errContains: `type \*dig.A is not in the container, did you mean to use dig.A?`,
+				errContains: `missing type: \*dig.A \(did you mean dig.A\?\)`,
 			},
 			{
 				name:    "named pointer missing, value present",
@@ -2360,7 +2359,7 @@ func TestInvokeFailures(t *testing.T) {
 					*A `name:"hello"`
 				}) {
 				},
-				errContains: `type \*dig.A\[name="hello"\] is not in the container, did you mean to use dig.A\[name="hello"\]?`,
+				errContains: `missing type: \*dig.A\[name="hello"\] \(did you mean dig.A\[name="hello"\]\?\)`,
 			},
 		}
 
@@ -2388,7 +2387,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err)
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`type io.Reader is not in the container, did you mean to use \*bytes.Reader\?`,
+			`missing type: io.Reader \(did you mean \*bytes.Reader\?\)`,
 		)
 	})
 
@@ -2404,7 +2403,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err)
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`type io.Reader is not in the container, did you mean to use one of \*bytes.Buffer, or \*bytes.Reader\?`,
+			`missing type: io.Reader \(did you mean \*bytes.Buffer, or \*bytes.Reader\?\)`,
 		)
 	})
 
@@ -2420,7 +2419,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err)
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`the following types are not in the container:`,
+			`missing types:`,
 			`io.Reader \(did you mean \*bytes.Buffer, or \*bytes.Reader\?\);`,
 			`io.Writer \(did you mean \*bytes.Buffer\?\)`,
 		)
@@ -2437,7 +2436,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err)
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`type \*bytes.Buffer is not in the container, did you mean to use io.Writer\?`,
+			`missing type: \*bytes.Buffer \(did you mean io.Writer\?\)`,
 		)
 	})
 
@@ -2454,7 +2453,7 @@ func TestInvokeFailures(t *testing.T) {
 		require.Error(t, err)
 		assertErrorMatches(t, err,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+\):`,
-			`type \*bytes.Buffer is not in the container, did you mean to use one of io.Reader, or io.Writer\?`,
+			`missing type: \*bytes.Buffer \(did you mean io.Reader, or io.Writer\?\)`,
 		)
 	})
 
@@ -2597,7 +2596,7 @@ func TestInvokeFailures(t *testing.T) {
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
 			`could not build value group dig.B\[group="b"\]:`,
 			`missing dependencies for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
-			"type dig.A is not in the container, did you mean to Provide it?",
+			"missing type: dig.A",
 		)
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -1210,7 +1210,7 @@ func TestGroups(t *testing.T) {
 		assertErrorMatches(t, err,
 			`could not build arguments for function "go.uber.org/dig".TestGroups`,
 			`could not build value group string\[group="x"\]:`,
-			`function "go.uber.org/dig".TestGroups\S+ \(\S+:\d+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestGroups\S+ \(\S+:\d+\):`,
 			"great sadness",
 		)
 		assert.Equal(t, gaveErr, RootCause(err))
@@ -1270,7 +1270,7 @@ func TestProvideConstructorErrors(t *testing.T) {
 				err := c.Provide(tt.constructor)
 				require.Error(t, err, "provide should fail")
 				assertErrorMatches(t, err,
-					`function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\) cannot be provided:`,
+					`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\):`,
 					`bad argument 1:`,
 					`cannot depend on result objects:`,
 					tt.msg)
@@ -1294,7 +1294,7 @@ func TestProvideConstructorErrors(t *testing.T) {
 		require.Error(t, err)
 
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\):`,
 			`bad result 1:`,
 			"cannot specify a name for result objects: dig.out embeds dig.Out",
 		)
@@ -1321,7 +1321,7 @@ func TestProvideConstructorErrors(t *testing.T) {
 		require.Error(t, err)
 
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideConstructorErrors\S+ \(\S+:\d+\):`,
 			`bad field "Result1" of dig.Result2:`,
 			"cannot specify a name for result objects: dig.Result1 embeds dig.Out",
 		)
@@ -1349,7 +1349,7 @@ func TestProvideRespectsConstructorErrors(t *testing.T) {
 		assertErrorMatches(t, err,
 			`could not build arguments for function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+ \(\S+:\d+\):`,
 			`failed to build \*bytes.Buffer:`,
-			`function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+ \(\S+:\d+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestProvideRespectsConstructorErrors\S+ \(\S+:\d+\):`,
 			`oh no`)
 		assert.False(t, called, "shouldn't call invoked function when deps aren't available")
 	})
@@ -1493,7 +1493,7 @@ func TestCantProvideParameterObjects(t *testing.T) {
 		})
 		require.Error(t, err, "provide should fail")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestCantProvideParameterObjects\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestCantProvideParameterObjects\S+ \(\S+:\d+\):`,
 			"bad result 1:",
 			`cannot provide parameter objects:`,
 			`dig.Args embeds a dig.In`,
@@ -1509,7 +1509,7 @@ func TestCantProvideParameterObjects(t *testing.T) {
 		err := c.Provide(func() (*Args, error) { return args, nil })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestCantProvideParameterObjects\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestCantProvideParameterObjects\S+ \(\S+:\d+\):`,
 			"bad result 1:",
 			`cannot provide parameter objects:`,
 			`\*dig.Args embeds a dig.In`,
@@ -1563,7 +1563,7 @@ func TestProvideCycleFails(t *testing.T) {
 		require.Error(t, err, "expected error when introducing cycle")
 		require.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\):`,
 			`this function introduces a cycle:`,
 			`\*dig.C provided by "go.uber.org/dig".TestProvideCycleFails\S+ \(\S+\)`,
 			`depends on \*dig.B provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
@@ -1609,7 +1609,7 @@ func TestProvideCycleFails(t *testing.T) {
 		require.Error(t, err, "expected error when introducing cycle")
 		require.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\):`,
 			`this function introduces a cycle:`,
 			`dig.C provided by "go.uber.org/dig".TestProvideCycleFails\S+ \(\S+\)`,
 			`depends on dig.B provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
@@ -1679,7 +1679,7 @@ func TestProvideCycleFails(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, IsCycleDetected(err))
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+:\d+\):`,
 			`this function introduces a cycle:`,
 			`\*dig.D provided by "go.uber.org/dig".TestProvideCycleFails\S+ \(\S+\)`,
 			`depends on int\[group="bar"\] provided by "go.uber.org/dig".TestProvideCycleFails.\S+ \(\S+\)`,
@@ -1819,7 +1819,7 @@ func TestProvideFailures(t *testing.T) {
 		})
 		require.Error(t, err, "provide must return error")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
 			`cannot provide dig.A from \[0\].A2:`,
 			`already provided by \[0\].A1`,
 		)
@@ -1844,7 +1844,7 @@ func TestProvideFailures(t *testing.T) {
 		})
 		require.Error(t, err, "expected error on the second provide")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
 			`cannot provide \*dig.A\[name="foo"\] from \[0\].A:`,
 			`already provided by "go.uber.org/dig".TestProvideFailures\S+`,
 		)
@@ -1863,7 +1863,7 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() out1 { return out1{a2: A{77}} })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
 			"bad result 1:",
 			`bad field "a2" of dig.out1:`,
 			`unexported fields not allowed in dig.Out, did you mean to export "a2" \(dig.A\)\?`,
@@ -1880,7 +1880,7 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() *out { return &out{String: "foo"} })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
 			"bad result 1:",
 			`cannot return a pointer to a result object, use a value instead:`,
 			`\*dig.out is a pointer to a struct that embeds dig.Out`,
@@ -1899,7 +1899,7 @@ func TestProvideFailures(t *testing.T) {
 		err := c.Provide(func() out { return out{String: "foo"} })
 		require.Error(t, err)
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestProvideFailures\S+ \(\S+:\d+\):`,
 			"bad result 1:",
 			`cannot build a result object by embedding \*dig.Out, embed dig.Out instead:`,
 			`dig.out embeds \*dig.Out`,
@@ -2078,7 +2078,7 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "expected provide error")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
 			"bad argument 1:",
 			`bad field "Args" of dig.args:`,
 			`bad field "Buffer" of dig.nestedArgs:`,
@@ -2150,7 +2150,7 @@ func TestInvokeFailures(t *testing.T) {
 			`failed to build \*dig.dep:`,
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
 			`failed to build \*dig.failed:`,
-			`function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.\S+ \(\S+:\d+\):`,
 			`failed`,
 		)
 		assert.Equal(t, errFailed, RootCause(err), "root cause must match")
@@ -2223,7 +2223,7 @@ func TestInvokeFailures(t *testing.T) {
 		err := c.Provide(func(in) int { return 0 })
 		require.Error(t, err, "Provide must fail")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\) cannot be provided:`,
+			`cannot provide function "go.uber.org/dig".TestInvokeFailures\S+ \(\S+:\d+\):`,
 			"bad argument 1:",
 			`bad field "foo" of dig.in:`,
 			`unexported fields not allowed in dig.In, did you mean to export "foo" \(string\)\?`,
@@ -2471,7 +2471,7 @@ func TestInvokeFailures(t *testing.T) {
 
 		require.Error(t, err, "expected Invoke error")
 		assertErrorMatches(t, err,
-			`function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2499,7 +2499,7 @@ func TestInvokeFailures(t *testing.T) {
 			"failed to build dig.B",
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures\S+`,
 			"failed to build dig.A",
-			`function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2526,7 +2526,7 @@ func TestInvokeFailures(t *testing.T) {
 		assertErrorMatches(t, err,
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func\S+`,
 			"failed to build dig.A:",
-			`function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))
@@ -2560,7 +2560,7 @@ func TestInvokeFailures(t *testing.T) {
 			"failed to build dig.B:",
 			`could not build arguments for function "go.uber.org/dig".TestInvokeFailures.func\S+`,
 			"failed to build dig.A:",
-			`function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\) returned a non-nil error:`,
+			`received non-nil error from function "go.uber.org/dig".TestInvokeFailures.func\S+ \(\S+\):`,
 			"great sadness",
 		)
 		assert.Equal(t, errors.New("great sadness"), RootCause(err))

--- a/graph_test.go
+++ b/graph_test.go
@@ -21,6 +21,8 @@
 package dig
 
 import (
+	"fmt"
+	"io"
 	"reflect"
 	"testing"
 
@@ -554,8 +556,23 @@ type nestedErr struct {
 	err error
 }
 
-func (err nestedErr) Error() string { return "oh no" }
-func (err nestedErr) cause() error  { return err.err }
+var _ causer = nestedErr{}
+
+func (e nestedErr) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e nestedErr) Format(w fmt.State, c rune) {
+	formatCauser(e, w, c)
+}
+
+func (e nestedErr) cause() error {
+	return e.err
+}
+
+func (e nestedErr) writeMessage(w io.Writer, _ string) {
+	io.WriteString(w, "oh no")
+}
 
 func TestCanVisualizeError(t *testing.T) {
 	tests := []struct {

--- a/internal/digreflect/func.go
+++ b/internal/digreflect/func.go
@@ -45,8 +45,21 @@ type Func struct {
 
 // String returns a string representation of the function.
 func (f *Func) String() string {
-	// "path/to/package".MyFunction (path/to/file.go:42)
-	return fmt.Sprintf("%q.%v (%v:%v)", f.Package, f.Name, f.File, f.Line)
+	return fmt.Sprint(f)
+}
+
+// Format implements fmt.Formatter for Func, printing a single-line
+// representation for %v and a multi-line one for %+v.
+func (f *Func) Format(w fmt.State, c rune) {
+	if w.Flag('+') && c == 'v' {
+		// "path/to/package".MyFunction
+		// 	path/to/file.go:42
+		fmt.Fprintf(w, "%q.%v", f.Package, f.Name)
+		fmt.Fprintf(w, "\n\t%v:%v", f.File, f.Line)
+	} else {
+		// "path/to/package".MyFunction (path/to/file.go:42)
+		fmt.Fprintf(w, "%q.%v (%v:%v)", f.Package, f.Name, f.File, f.Line)
+	}
 }
 
 // InspectFunc inspects and returns runtime information about the given

--- a/param.go
+++ b/param.go
@@ -238,7 +238,7 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 		if ps.Optional {
 			return reflect.Zero(ps.Type), nil
 		}
-		return _noValue, newErrMissingType(c, key{name: ps.Name, t: ps.Type})
+		return _noValue, newErrMissingTypes(c, key{name: ps.Name, t: ps.Type})
 	}
 
 	for _, n := range providers {


### PR DESCRIPTION
*Commits are individually reviewable.*

This adds a series of commits that add support for printing multi-line error
messages when `%+v` is used.

To do so, we implement [`fmt.Formatter`][1] on all relevant error types,
interpreting `%v` the old way and `%+v` as a signal to be prettier.

  [1]: https://golang.org/pkg/fmt/#Formatter

Implementation `fmt.Formatter` as-is for the error-chain types (those
implementing the `causer` interface) causes a fair amount of duplication so
this change also adds some convenience around it. Specifically, these types
now implement a means of printing just their error message to the output,
deferring to a shared implementation to print the chain of causes.

Finally, as tests that verify error messages all use the same helper
(`assertErrorMatches`), the helper was split into two subtests. One of the
subtests verifies the old behavior and the latter verifies the new `%+v`
behavior.

Refs T2587659