### PR TITLE
visualize: Include package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- GraphViz visualization of the graph now includes names of packages next to
+  constructors.
 
 ## [1.8.0] - 2019-11-14
 ### Changed

--- a/graph.go
+++ b/graph.go
@@ -102,6 +102,9 @@ var _graphTmpl = template.Must(
 	{{end -}}
 	{{range $index, $ctor := .Ctors}}
 		subgraph cluster_{{$index}} {
+			{{ with .Package }}label = {{ quote .}};
+			{{ end -}}
+
 			constructor_{{$index}} [shape=plaintext label={{quote .Name}}];
 			{{with .ErrorType}}color={{.Color}};{{end}}
 			{{range .Results}}

--- a/testdata/error.dot
+++ b/testdata/error.dot
@@ -10,6 +10,7 @@ digraph {
 		
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func6.1"];
 			color=orange;
 			"dig.t3[name=n3]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: n3</FONT>>];
@@ -21,6 +22,7 @@ digraph {
 			constructor_0 -> "[type=dig.t1 group=g1]" [ltail=cluster_0];
 		
 		subgraph cluster_1 {
+			label = "go.uber.org/dig";
 			constructor_1 [shape=plaintext label="TestVisualize.func6.2"];
 			color=orange;
 			"dig.t4" [label=<dig.t4>];
@@ -33,6 +35,7 @@ digraph {
 			constructor_1 -> "[type=dig.t2 group=g2]" [ltail=cluster_1];
 		
 		subgraph cluster_2 {
+			label = "go.uber.org/dig";
 			constructor_2 [shape=plaintext label="TestVisualize.func6.4"];
 			color=red;
 			"dig.t1[group=g1]0" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Group: g1</FONT>>];

--- a/testdata/grouped.dot
+++ b/testdata/grouped.dot
@@ -7,6 +7,7 @@ digraph {
 		
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func5.1"];
 			
 			"dig.t3[group=foo]0" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
@@ -15,6 +16,7 @@ digraph {
 		
 		
 		subgraph cluster_1 {
+			label = "go.uber.org/dig";
 			constructor_1 [shape=plaintext label="TestVisualize.func5.2"];
 			
 			"dig.t3[group=foo]1" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Group: foo</FONT>>];
@@ -23,6 +25,7 @@ digraph {
 		
 		
 		subgraph cluster_2 {
+			label = "go.uber.org/dig";
 			constructor_2 [shape=plaintext label="TestVisualize.func5.3"];
 			
 			"dig.t2" [label=<dig.t2>];

--- a/testdata/missing.dot
+++ b/testdata/missing.dot
@@ -3,6 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func7.1"];
 			color=orange;
 			"dig.t4" [label=<dig.t4>];

--- a/testdata/named.dot
+++ b/testdata/named.dot
@@ -3,6 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func3.1"];
 			
 			"dig.t1[name=bar]" [label=<dig.t1<BR /><FONT POINT-SIZE="10">Name: bar</FONT>>];
@@ -14,6 +15,7 @@ digraph {
 		
 		
 		subgraph cluster_1 {
+			label = "go.uber.org/dig";
 			constructor_1 [shape=plaintext label="TestVisualize.func3.2"];
 			
 			"dig.t3[name=foo]" [label=<dig.t3<BR /><FONT POINT-SIZE="10">Name: foo</FONT>>];

--- a/testdata/optional.dot
+++ b/testdata/optional.dot
@@ -3,6 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func4.1"];
 			
 			"dig.t1" [label=<dig.t1>];
@@ -11,6 +12,7 @@ digraph {
 		
 		
 		subgraph cluster_1 {
+			label = "go.uber.org/dig";
 			constructor_1 [shape=plaintext label="TestVisualize.func4.2"];
 			
 			"dig.t2" [label=<dig.t2>];

--- a/testdata/prune_constructor_result.dot
+++ b/testdata/prune_constructor_result.dot
@@ -6,6 +6,7 @@ digraph {
 		
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func6.6.1.2"];
 			color=orange;
 			"dig.t4" [label=<dig.t4>];
@@ -16,6 +17,7 @@ digraph {
 			constructor_0 -> "[type=dig.t2 group=g2]" [ltail=cluster_0];
 		
 		subgraph cluster_1 {
+			label = "go.uber.org/dig";
 			constructor_1 [shape=plaintext label="TestVisualize.func6.6.1.3"];
 			color=red;
 			"dig.t2[group=g2]1" [label=<dig.t2<BR /><FONT POINT-SIZE="10">Group: g2</FONT>>];

--- a/testdata/prune_non_root_nodes.dot
+++ b/testdata/prune_non_root_nodes.dot
@@ -3,6 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func6.6.2.2"];
 			color=red;
 			"dig.t4" [label=<dig.t4>];

--- a/testdata/simple.dot
+++ b/testdata/simple.dot
@@ -3,6 +3,7 @@ digraph {
 	graph [compound=true];
 	
 		subgraph cluster_0 {
+			label = "go.uber.org/dig";
 			constructor_0 [shape=plaintext label="TestVisualize.func2.1"];
 			
 			"dig.t1" [label=<dig.t1>];
@@ -12,6 +13,7 @@ digraph {
 		
 		
 		subgraph cluster_1 {
+			label = "go.uber.org/dig";
 			constructor_1 [shape=plaintext label="TestVisualize.func2.2"];
 			
 			"dig.t3" [label=<dig.t3>];


### PR DESCRIPTION
GraphViz visualizations generated by Dig include only the name of the
constructor and the types generated by that constructor. For our
internal ecosystem, this means it's just a series of `New` functions.

This change addresses this by including the name of the package in which
the constructor was defined.

Refs T5322775

---

Previews:

![error](https://user-images.githubusercontent.com/41730/75925794-346fe680-5e1e-11ea-9bca-5d9c0bb206a5.png)

![grouped](https://user-images.githubusercontent.com/41730/75925852-48b3e380-5e1e-11ea-822d-7769f700bcfe.png)

![prune_constructor_result](https://user-images.githubusercontent.com/41730/75925884-579a9600-5e1e-11ea-92aa-a6c5346eef55.png)
