### PR TITLE
Preparing release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,6 @@ First release candidate.
 
 Initial release.
 
-[Unreleased]: https://github.com/uber-go/dig/compare/v1.10.0...HEAD
 [1.10.0]: https://github.com/uber-go/dig/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/uber-go/dig/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/uber-go/dig/compare/v1.7.0...v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- No changes yet.
+## [1.10.0] - 2020-06-16
+### Added
+- Introduce `DryRun` Option which, when set to true, disables invocation
+  of functions supplied to `Provide` and `Invoke`. This option will be
+  used to build no-op containers, for example for `fx.ValidateApp` method.
 
 ## [1.9.0] - 2020-03-31
 ### Added
@@ -162,7 +165,8 @@ First release candidate.
 
 Initial release.
 
-[Unreleased]: https://github.com/uber-go/dig/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/uber-go/dig/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/uber-go/dig/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/uber-go/dig/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/uber-go/dig/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/uber-go/dig/compare/v1.6.0...v1.7.0


### PR DESCRIPTION
This sets up release v1.10.0. The only change in this release is addition of `DryOption`.

List of changes: [v1.9.0...v1.10.0](https://github.com/uber-go/dig/compare/v1.9.0...v1.10.0)