### PR TITLE
Add ability to allow unexported fields in dig.In structs

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	_optionalTag = "optional"
-	_nameTag     = "name"
+	_optionalTag        = "optional"
+	_nameTag            = "name"
+	_allowUnexportedTag = "allowUnexported"
 )
 
 // Unique identification of an object in the graph.
@@ -733,6 +734,24 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 	}
 
 	return optional, err
+}
+
+// Checks if unexported fields in an In struct are allowed. The struct field
+// MUST be an _inType.
+func isUnexportedFieldAllowed(f reflect.StructField) (bool, error) {
+	tag := f.Tag.Get(_allowUnexportedTag)
+	if tag == "" {
+		return false, nil
+	}
+
+	allowed, err := strconv.ParseBool(tag)
+	if err != nil {
+		err = errf(
+			"invalid value %q for %q tag on field %v",
+			tag, _allowUnexportedTag, f.Name, err)
+	}
+
+	return allowed, err
 }
 
 // Checks that all direct dependencies of the provided param are present in

--- a/dig.go
+++ b/dig.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	_optionalTag        = "optional"
-	_nameTag            = "name"
-	_allowUnexportedTag = "allowUnexported"
+	_optionalTag         = "optional"
+	_nameTag             = "name"
+	_ignoreUnexportedTag = "ignore-unexported"
 )
 
 // Unique identification of an object in the graph.
@@ -736,10 +736,10 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 	return optional, err
 }
 
-// Checks if unexported fields in an In struct are allowed. The struct field
-// MUST be an _inType.
-func isUnexportedFieldAllowed(f reflect.StructField) (bool, error) {
-	tag := f.Tag.Get(_allowUnexportedTag)
+// Checks if ignoring unexported files in an In struct is allowed.
+// The struct field MUST be an _inType.
+func isIgnoreUnexportedSet(f reflect.StructField) (bool, error) {
+	tag := f.Tag.Get(_ignoreUnexportedTag)
 	if tag == "" {
 		return false, nil
 	}
@@ -748,7 +748,7 @@ func isUnexportedFieldAllowed(f reflect.StructField) (bool, error) {
 	if err != nil {
 		err = errf(
 			"invalid value %q for %q tag on field %v",
-			tag, _allowUnexportedTag, f.Name, err)
+			tag, _ignoreUnexportedTag, f.Name, err)
 	}
 
 	return allowed, err

--- a/dig_test.go
+++ b/dig_test.go
@@ -344,7 +344,7 @@ func TestEndToEndSuccess(t *testing.T) {
 		}))
 	})
 
-	t.Run("allow unexported fields", func(t *testing.T) {
+	t.Run("ignore unexported fields", func(t *testing.T) {
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
@@ -354,7 +354,7 @@ func TestEndToEndSuccess(t *testing.T) {
 
 		c := New()
 		type param struct {
-			In `allowUnexported:"true"`
+			In `ignore-unexported:"true"`
 
 			T1 *type1 // regular 'ol type
 			T2 *type2 `optional:"true"` // optional type present in the graph
@@ -2947,7 +2947,7 @@ func TestUnexportedFieldsFailures(t *testing.T) {
 
 		c := New()
 		type param struct {
-			In `allowUnexported:""`
+			In `ignore-unexported:""`
 
 			T1 *type1 // regular 'ol type
 			T2 *type2 `optional:"true"` // optional type present in the graph
@@ -2973,7 +2973,7 @@ func TestUnexportedFieldsFailures(t *testing.T) {
 
 		c := New()
 		type param struct {
-			In `allowUnexported:"foo"`
+			In `ignore-unexported:"foo"`
 
 			T1 *type1 // regular 'ol type
 			T2 *type2 `optional:"true"` // optional type present in the graph
@@ -2986,6 +2986,6 @@ func TestUnexportedFieldsFailures(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(),
-			`bad argument 1: invalid value "foo" for "allowUnexported" tag on field In: strconv.ParseBool: parsing "foo": invalid syntax`)
+			`bad argument 1: invalid value "foo" for "ignore-unexported" tag on field In: strconv.ParseBool: parsing "foo": invalid syntax`)
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -348,8 +348,8 @@ func TestEndToEndSuccess(t *testing.T) {
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
-		constructor := func() (*type1, *type2) {
-			return &type1{}, &type2{}
+		constructor := func() (*type1, *type2, *type3) {
+			return &type1{}, &type2{}, &type3{}
 		}
 
 		c := New()
@@ -364,6 +364,7 @@ func TestEndToEndSuccess(t *testing.T) {
 		require.NoError(t, c.Invoke(func(p param) {
 			require.NotNil(t, p.T1, "whole param struct should not be nil")
 			assert.NotNil(t, p.T2, "optional type in the graph should not return nil")
+			assert.Nil(t, p.t3, "unexported field should not be set")
 		}))
 	})
 

--- a/param.go
+++ b/param.go
@@ -289,10 +289,10 @@ func newParamObject(t reflect.Type) (paramObject, error) {
 
 	// Check if the In type supports unexported fields.
 	var allowUnexported bool
-	var err error
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if f.Type == _inType {
+			var err error
 			allowUnexported, err = isUnexportedFieldAllowed(f)
 			if err != nil {
 				return po, err

--- a/param.go
+++ b/param.go
@@ -287,13 +287,13 @@ func (po paramObject) DotParam() []*dot.Param {
 func newParamObject(t reflect.Type) (paramObject, error) {
 	po := paramObject{Type: t}
 
-	// Check if the In type supports unexported fields.
-	var allowUnexported bool
+	// Check if the In type supports ignoring unexported fields.
+	var ignoreUnexported bool
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if f.Type == _inType {
 			var err error
-			allowUnexported, err = isUnexportedFieldAllowed(f)
+			ignoreUnexported, err = isIgnoreUnexportedSet(f)
 			if err != nil {
 				return po, err
 			}
@@ -307,7 +307,7 @@ func newParamObject(t reflect.Type) (paramObject, error) {
 			// Skip over the dig.In embed.
 			continue
 		}
-		if f.PkgPath != "" && allowUnexported {
+		if f.PkgPath != "" && ignoreUnexported {
 			// Skip over an unexported field if it is allowed.
 			continue
 		}

--- a/param_test.go
+++ b/param_test.go
@@ -106,7 +106,7 @@ func TestParamObjectWithUnexportedFieldsSuccess(t *testing.T) {
 	type type2 struct{}
 
 	type in struct {
-		In `allowUnexported:"true"`
+		In `ignore-unexported:"true"`
 
 		T1 type1
 		t2 type2
@@ -143,7 +143,7 @@ func TestParamObjectFailure(t *testing.T) {
 	t.Run("unexported field with empty tag value gets an error", func(t *testing.T) {
 		type A struct{}
 		type in struct {
-			In `allowUnexported:""`
+			In `ignore-unexported:""`
 
 			A1 A
 			a2 A
@@ -158,7 +158,7 @@ func TestParamObjectFailure(t *testing.T) {
 	t.Run("unexported field with invalid tag value gets an error", func(t *testing.T) {
 		type A struct{}
 		type in struct {
-			In `allowUnexported:"foo"`
+			In `ignore-unexported:"foo"`
 
 			A1 A
 			a2 A
@@ -167,7 +167,7 @@ func TestParamObjectFailure(t *testing.T) {
 		_, err := newParamObject(reflect.TypeOf(in{}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(),
-			`invalid value "foo" for "allowUnexported" tag on field In: strconv.ParseBool: parsing "foo": invalid syntax`)
+			`invalid value "foo" for "ignore-unexported" tag on field In: strconv.ParseBool: parsing "foo": invalid syntax`)
 	})
 }
 


### PR DESCRIPTION
In order for unexported fields to be allowed, an 
"allowUnexported=true" struct tag should be used on the embedded dig.In 
field.

Resolves: https://github.com/uber-go/dig/issues/273