### PR TITLE
Add WithInfo and ConstructorInfo

### DIFF
--- a/dig.go
+++ b/dig.go
@@ -131,6 +131,10 @@ func Group(group string) ProvideOption {
 
 // ConstructorInfo provides information about the constructor's inputs and outputs
 // types as strings, as well as the ID of the constructor supplied to the Container.
+//
+// ID is a unique integer representing the constructor node in the dependency graph.
+// Inputs is a string slice with the types of the input parameters of the constructor.
+// Outputs is a string slice with the types of the results produced by the constructor.
 type ConstructorInfo struct {
 	ID      int
 	Inputs  []string

--- a/dig.go
+++ b/dig.go
@@ -527,11 +527,11 @@ func (c *Container) provide(ctor interface{}, opts provideOptions) error {
 		opts.Info.Inputs = make([]string, 0)
 		opts.Info.Outputs = make([]string, 0)
 
-		for _, res := range n.resultList.DotResult() {
+		for _, res := range n.ResultList().DotResult() {
 			opts.Info.Outputs = append(opts.Info.Outputs, res.Type.String())
 		}
 
-		for _, param := range n.paramList.DotParam() {
+		for _, param := range n.ParamList().DotParam() {
 			opts.Info.Inputs = append(opts.Info.Inputs, param.Type.String())
 		}
 	}

--- a/dig.go
+++ b/dig.go
@@ -144,7 +144,9 @@ type ConstructorInfo struct {
 
 // Input is a stringer that report the type of an input parameters of the constructor.
 type Input struct {
-	t reflect.Type
+	t           reflect.Type
+	optional    bool
+	name, group string
 }
 
 func (i *Input) String() string {
@@ -153,7 +155,8 @@ func (i *Input) String() string {
 
 // Output is a stringer that report the types of an output produced by the constructor.
 type Output struct {
-	t reflect.Type
+	t           reflect.Type
+	name, group string
 }
 
 func (o *Output) String() string {
@@ -550,11 +553,20 @@ func (c *Container) provide(ctor interface{}, opts provideOptions) error {
 		info.Outputs = make([]*Output, len(results))
 
 		for i, param := range params {
-			info.Inputs[i] = &Input{t: param.Type}
+			info.Inputs[i] = &Input{
+				t:        param.Type,
+				optional: param.Optional,
+				name:     param.Name,
+				group:    param.Group,
+			}
 		}
 
 		for i, res := range results {
-			info.Outputs[i] = &Output{t: res.Type}
+			info.Outputs[i] = &Output{
+				t:     res.Type,
+				name:  res.Name,
+				group: res.Group,
+			}
 		}
 	}
 	return nil
@@ -786,7 +798,6 @@ func isFieldOptional(f reflect.StructField) (bool, error) {
 		err = errf(
 			"invalid value %q for %q tag on field %v",
 			tag, _optionalTag, f.Name, err)
-
 	}
 
 	return optional, err

--- a/dig.go
+++ b/dig.go
@@ -62,7 +62,9 @@ func (f optionFunc) applyOption(c *Container) { f(c) }
 type provideOptions struct {
 	Name  string
 	Group string
+	Info  *ConstructorInfo
 }
+
 
 func (o *provideOptions) Validate() error {
 	if len(o.Group) > 0 && len(o.Name) > 0 {
@@ -125,6 +127,12 @@ func Name(name string) ProvideOption {
 func Group(group string) ProvideOption {
 	return provideOptionFunc(func(opts *provideOptions) {
 		opts.Group = group
+	})
+}
+
+func Info(info *ConstructorInfo) ProvideOption {
+	return provideOptionFunc(func(opts *provideOptions) {
+		opts.Info = info
 	})
 }
 
@@ -499,6 +507,9 @@ func (c *Container) provide(ctor interface{}, opts provideOptions) error {
 		c.isVerifiedAcyclic = true
 	}
 
+	opts.Info.ID = int(n.ID())
+	opts.Info.Inputs = n.ParamList()
+	opts.Info.Outputs = n.ResultList()
 	c.nodes = append(c.nodes, n)
 
 	return nil

--- a/dig.go
+++ b/dig.go
@@ -129,7 +129,16 @@ func Group(group string) ProvideOption {
 	})
 }
 
-// WithInfo is a ProvideOption that lets Info.
+// ConstructorInfo provides information about the constructor's inputs and outputs
+// types as strings, as well as the ID of the constructor supplied to the Container.
+type ConstructorInfo struct {
+	ID      int
+	Inputs  []string
+	Outputs []string
+}
+
+// WithInfo is a ProvideOption that writes info on what Dig was able to get out
+// out of the provided constructor into the provided ConstructorInfo.
 func WithInfo(info *ConstructorInfo) ProvideOption {
 	return provideOptionFunc(func(opts *provideOptions) {
 		opts.Info = info

--- a/dig.go
+++ b/dig.go
@@ -62,7 +62,7 @@ func (f optionFunc) applyOption(c *Container) { f(c) }
 type provideOptions struct {
 	Name  string
 	Group string
-	Info  *ConstructorInfo
+	Info  *ProvideInfo
 }
 
 func (o *provideOptions) Validate() error {
@@ -132,17 +132,17 @@ func Group(group string) ProvideOption {
 // ID is a unique integer representing the constructor node in the dependency graph.
 type ID int
 
-// ConstructorInfo provides information about the constructor's inputs and outputs
+// ProvideInfo provides information about the constructor's inputs and outputs
 // types as strings, as well as the ID of the constructor supplied to the Container.
 // It contains ID for the constructor, as well as slices of Input and Output types,
 // which are Stringers that report the types of the parameters and results respectively.
-type ConstructorInfo struct {
+type ProvideInfo struct {
 	ID      ID
 	Inputs  []*Input
 	Outputs []*Output
 }
 
-// Input is a stringer that report the type of an input parameters of the constructor.
+// Input contains information on an input parameter of the constructor.
 type Input struct {
 	t           reflect.Type
 	optional    bool
@@ -150,8 +150,8 @@ type Input struct {
 }
 
 func (i *Input) String() string {
-	toks := make([]string, 1, 4)
-	toks[0] = i.t.String()
+	toks := make([]string, 0, 3)
+	t := i.t.String()
 	if i.optional {
 		toks = append(toks, "optional")
 	}
@@ -162,21 +162,21 @@ func (i *Input) String() string {
 		toks = append(toks, fmt.Sprintf("group = %q", i.group))
 	}
 
-	if len(toks) == 1 {
-		return toks[0]
+	if len(toks) == 0 {
+		return t
 	}
-	return fmt.Sprintf("%v[%v]", toks[0], strings.Join(toks, ", "))
+	return fmt.Sprintf("%v[%v]", t, strings.Join(toks, ", "))
 }
 
-// Output is a stringer that report the types of an output produced by the constructor.
+// Output contains information on an output produced by the constructor.
 type Output struct {
 	t           reflect.Type
 	name, group string
 }
 
 func (o *Output) String() string {
-	toks := make([]string, 1, 3)
-	toks[0] = o.t.String()
+	toks := make([]string, 0, 2)
+	t := o.t.String()
 	if o.name != "" {
 		toks = append(toks, fmt.Sprintf("name = %q", o.name))
 	}
@@ -184,15 +184,15 @@ func (o *Output) String() string {
 		toks = append(toks, fmt.Sprintf("group = %q", o.group))
 	}
 
-	if len(toks) == 1 {
-		return toks[0]
+	if len(toks) == 0 {
+		return t
 	}
-	return fmt.Sprintf("%v[%v]", toks[0], strings.Join(toks, ", "))
+	return fmt.Sprintf("%v[%v]", t, strings.Join(toks, ", "))
 }
 
-// FillInfo is a ProvideOption that writes info on what Dig was able to get out
-// out of the provided constructor into the provided ConstructorInfo.
-func FillInfo(info *ConstructorInfo) ProvideOption {
+// FillProvideInfo is a ProvideOption that writes info on what Dig was able to get out
+// out of the provided constructor into the provided ProvideInfo.
+func FillProvideInfo(info *ProvideInfo) ProvideOption {
 	return provideOptionFunc(func(opts *provideOptions) {
 		opts.Info = info
 	})

--- a/dig.go
+++ b/dig.go
@@ -150,7 +150,22 @@ type Input struct {
 }
 
 func (i *Input) String() string {
-	return i.t.String()
+	toks := make([]string, 1, 4)
+	toks[0] = i.t.String()
+	if i.optional {
+		toks = append(toks, "optional")
+	}
+	if i.name != "" {
+		toks = append(toks, fmt.Sprintf("name = %q", i.name))
+	}
+	if i.group != "" {
+		toks = append(toks, fmt.Sprintf("group = %q", i.group))
+	}
+
+	if len(toks) == 1 {
+		return toks[0]
+	}
+	return fmt.Sprintf("%v[%v]", toks[0], strings.Join(toks, ", "))
 }
 
 // Output is a stringer that report the types of an output produced by the constructor.
@@ -160,7 +175,19 @@ type Output struct {
 }
 
 func (o *Output) String() string {
-	return o.t.String()
+	toks := make([]string, 1, 3)
+	toks[0] = o.t.String()
+	if o.name != "" {
+		toks = append(toks, fmt.Sprintf("name = %q", o.name))
+	}
+	if o.group != "" {
+		toks = append(toks, fmt.Sprintf("group = %q", o.group))
+	}
+
+	if len(toks) == 1 {
+		return toks[0]
+	}
+	return fmt.Sprintf("%v[%v]", toks[0], strings.Join(toks, ", "))
 }
 
 // FillInfo is a ProvideOption that writes info on what Dig was able to get out

--- a/dig_test.go
+++ b/dig_test.go
@@ -3002,13 +3002,13 @@ func TestConstructorInfoOption(t *testing.T) {
 
 		c := New()
 		info := ConstructorInfo{}
-		require.NoError(t, c.Provide(ctor, WithInfo(&info)))
+		require.NoError(t, c.Provide(ctor, FillInfo(&info)))
 
 		assert.Equal(t, 0, len(info.Inputs))
 		assert.Equal(t, 2, len(info.Outputs))
 
-		assert.Equal(t, "*dig.type1", info.Outputs[0])
-		assert.Equal(t, "*dig.type2", info.Outputs[1])
+		assert.Equal(t, "*dig.type1", info.Outputs[0].String())
+		assert.Equal(t, "*dig.type2", info.Outputs[1].String())
 	})
 
 	t.Run("two inputs and one output", func(t *testing.T) {
@@ -3020,14 +3020,14 @@ func TestConstructorInfoOption(t *testing.T) {
 		}
 		c := New()
 		info := ConstructorInfo{}
-		require.NoError(t, c.Provide(ctor, WithInfo(&info)))
+		require.NoError(t, c.Provide(ctor, FillInfo(&info)))
 
 		assert.Equal(t, 2, len(info.Inputs))
 		assert.Equal(t, 1, len(info.Outputs))
 
-		assert.Equal(t, "*dig.type3", info.Outputs[0])
-		assert.Equal(t, "*dig.type1", info.Inputs[0])
-		assert.Equal(t, "*dig.type2", info.Inputs[1])
+		assert.Equal(t, "*dig.type3", info.Outputs[0].String())
+		assert.Equal(t, "*dig.type1", info.Inputs[0].String())
+		assert.Equal(t, "*dig.type2", info.Inputs[1].String())
 	})
 
 	t.Run("two inputs, output and error", func(t *testing.T) {
@@ -3039,14 +3039,14 @@ func TestConstructorInfoOption(t *testing.T) {
 		}
 		c := New()
 		info := ConstructorInfo{}
-		require.NoError(t, c.Provide(ctor, WithInfo(&info)))
+		require.NoError(t, c.Provide(ctor, FillInfo(&info)))
 
 		assert.Equal(t, 2, len(info.Inputs))
 		assert.Equal(t, 1, len(info.Outputs))
 
-		assert.Equal(t, "*dig.type3", info.Outputs[0])
-		assert.Equal(t, "*dig.type1", info.Inputs[0])
-		assert.Equal(t, "*dig.type2", info.Inputs[1])
+		assert.Equal(t, "*dig.type3", info.Outputs[0].String())
+		assert.Equal(t, "*dig.type1", info.Inputs[0].String())
+		assert.Equal(t, "*dig.type2", info.Inputs[1].String())
 	})
 
 	t.Run("two inputs, two outputs", func(t *testing.T) {
@@ -3059,16 +3059,16 @@ func TestConstructorInfoOption(t *testing.T) {
 		}
 		c := New()
 		info := ConstructorInfo{}
-		require.NoError(t, c.Provide(ctor, WithInfo(&info)))
+		require.NoError(t, c.Provide(ctor, FillInfo(&info)))
 
 		assert.Equal(t, 2, len(info.Inputs))
 		assert.Equal(t, 2, len(info.Outputs))
 
-		assert.Equal(t, "*dig.type1", info.Inputs[0])
-		assert.Equal(t, "*dig.type2", info.Inputs[1])
+		assert.Equal(t, "*dig.type1", info.Inputs[0].String())
+		assert.Equal(t, "*dig.type2", info.Inputs[1].String())
 
-		assert.Equal(t, "*dig.type3", info.Outputs[0])
-		assert.Equal(t, "*dig.type4", info.Outputs[1])
+		assert.Equal(t, "*dig.type3", info.Outputs[0].String())
+		assert.Equal(t, "*dig.type4", info.Outputs[1].String())
 	})
 
 	t.Run("two ctors", func(t *testing.T) {
@@ -3085,8 +3085,8 @@ func TestConstructorInfoOption(t *testing.T) {
 		c := New()
 		info1 := ConstructorInfo{}
 		info2 := ConstructorInfo{}
-		require.NoError(t, c.Provide(ctor1, WithInfo(&info1)))
-		require.NoError(t, c.Provide(ctor2, WithInfo(&info2)))
+		require.NoError(t, c.Provide(ctor1, FillInfo(&info1)))
+		require.NoError(t, c.Provide(ctor2, FillInfo(&info2)))
 
 		assert.NotEqual(t, info1.ID, info2.ID)
 
@@ -3095,10 +3095,10 @@ func TestConstructorInfoOption(t *testing.T) {
 		assert.Equal(t, 1, len(info2.Inputs))
 		assert.Equal(t, 1, len(info2.Outputs))
 
-		assert.Equal(t, "*dig.type1", info1.Inputs[0])
-		assert.Equal(t, "*dig.type2", info1.Outputs[0])
+		assert.Equal(t, "*dig.type1", info1.Inputs[0].String())
+		assert.Equal(t, "*dig.type2", info1.Outputs[0].String())
 
-		assert.Equal(t, "*dig.type3", info2.Inputs[0])
-		assert.Equal(t, "*dig.type4", info2.Outputs[0])
+		assert.Equal(t, "*dig.type3", info2.Inputs[0].String())
+		assert.Equal(t, "*dig.type4", info2.Outputs[0].String())
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -2992,6 +2992,7 @@ func TestUnexportedFieldsFailures(t *testing.T) {
 }
 
 func TestConstructorInfoOption(t *testing.T) {
+	t.Parallel()
 	t.Run("two outputs", func(t *testing.T) {
 		type type1 struct{}
 		type type2 struct{}

--- a/dig_test.go
+++ b/dig_test.go
@@ -3001,10 +3001,10 @@ func TestProvideInfoOption(t *testing.T) {
 		}
 
 		c := New()
-		info := ProvideInfo{}
+		var info ProvideInfo
 		require.NoError(t, c.Provide(ctor, FillProvideInfo(&info)))
 
-		assert.Equal(t, 0, len(info.Inputs))
+		assert.Empty(t, info.Inputs)
 		assert.Equal(t, 2, len(info.Outputs))
 
 		assert.Equal(t, "*dig.type1", info.Outputs[0].String())
@@ -3019,7 +3019,7 @@ func TestProvideInfoOption(t *testing.T) {
 			return &type3{}
 		}
 		c := New()
-		info := ProvideInfo{}
+		var info ProvideInfo
 		require.NoError(t, c.Provide(ctor, Name("n"), FillProvideInfo(&info)))
 
 		assert.Equal(t, 2, len(info.Inputs))
@@ -3046,7 +3046,7 @@ func TestProvideInfoOption(t *testing.T) {
 			return &type3{}, nil
 		}
 		c := New()
-		info := ProvideInfo{}
+		var info ProvideInfo
 		require.NoError(t, c.Provide(ctor, FillProvideInfo(&info)))
 
 		assert.Equal(t, 4, len(info.Inputs))

--- a/types.go
+++ b/types.go
@@ -158,8 +158,10 @@ func embedsType(i interface{}, e reflect.Type) bool {
 	return false
 }
 
+// ConstructorInfo provides information about the constructor's inputs and outputs
+// types as strings, as well as the ID of the constructor supplied to the Container.
 type ConstructorInfo struct {
-	ID int
-	Inputs []string
+	ID      int
+	Inputs  []string
 	Outputs []string
 }

--- a/types.go
+++ b/types.go
@@ -157,11 +157,3 @@ func embedsType(i interface{}, e reflect.Type) bool {
 	// map[reflect.Type]struct{}.
 	return false
 }
-
-// ConstructorInfo provides information about the constructor's inputs and outputs
-// types as strings, as well as the ID of the constructor supplied to the Container.
-type ConstructorInfo struct {
-	ID      int
-	Inputs  []string
-	Outputs []string
-}

--- a/types.go
+++ b/types.go
@@ -157,3 +157,9 @@ func embedsType(i interface{}, e reflect.Type) bool {
 	// map[reflect.Type]struct{}.
 	return false
 }
+
+type ConstructorInfo struct {
+	ID int
+	Inputs []string
+	Outputs []string
+}


### PR DESCRIPTION
This adds WithInfo and ConstructorInfo, which allow users to get what Dig was able to extract out of the `Provide`d constructors.

Specifically, ConstructorInfo contains ID of the constructor (which is unique among all provided ctors), Inputs (parameters), and Outputs (results) types as Strings.

With these, users can introspect the constructor info that Dig was able to get out using reflection. For example:
```go
info := ConstructorInfo{}
c.Provide(someCtor, WithInfo(&info))

fmt.Println(info.ID) // Will print the ID of someCtor

for _, param := info.Inputs {
    fmt.Println(param) // will print the input parameters types of someCtor
}
 
for _, res := info.Outputs {
    fmt.Println(res) // will print the return types of someCtor
}
```

Refs GO-169 and #254. 