### PR TITLE
Add support to GroupInvoke

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"os"
 	"reflect"
@@ -3111,4 +3112,38 @@ func TestProvideInfoOption(t *testing.T) {
 		assert.Equal(t, "*dig.type3", info2.Inputs[0].String())
 		assert.Equal(t, "*dig.type4", info2.Outputs[0].String())
 	})
+}
+
+func TestGroupInvoke(t *testing.T) {
+	type TestParam struct {
+		Name  string
+		Value string
+	}
+
+	type TestParam1 struct {
+		AdditionaInfo string
+	}
+
+	singletonIOC := New()
+	singletonIOC.Provide(func() *TestParam {
+		return &TestParam{
+			Name:  "TestName",
+			Value: "TestValue",
+		}
+	})
+
+	customIOC := New()
+	customIOC.Provide(func() *TestParam1 {
+		return &TestParam1{
+			AdditionaInfo: "Some info",
+		}
+	})
+
+	function := func(p *TestParam, p1 *TestParam1) {
+		fmt.Print("Test")
+	}
+
+	if err := GroupInvoke(function, singletonIOC, customIOC); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -3140,7 +3140,17 @@ func TestGroupInvoke(t *testing.T) {
 	})
 
 	function := func(p *TestParam, p1 *TestParam1) {
-		fmt.Print("Test")
+		res1 := &TestParam{
+			Name:  "TestName",
+			Value: "TestValue",
+		}
+
+		res2 := &TestParam1{
+			AdditionaInfo: "Some info",
+		}
+
+		assert.Equal(t, res1, p)
+		assert.Equal(t, res2, p1)
 	}
 
 	if err := GroupInvoke(function, singletonIOC, customIOC); err != nil {

--- a/param.go
+++ b/param.go
@@ -206,6 +206,20 @@ func (pl paramList) BuildList(c containerStore) ([]reflect.Value, error) {
 	return args, nil
 }
 
+// UnsafeBuildList returns an ordered list of values which may be passed directly
+// to the underlying constructor without interruption in case of missing field.
+func (pl paramList) UnsafeBuildList(c containerStore) ([]reflect.Value, error) {
+	args := make([]reflect.Value, len(pl.Params))
+	for i, p := range pl.Params {
+		var err error
+		args[i], err = p.Build(c)
+		if err != nil {
+			continue
+		}
+	}
+	return args, nil
+}
+
 // paramSingle is an explicitly requested type, optionally with a name.
 //
 // This object must be present in the graph as-is unless it's specified as


### PR DESCRIPTION
This implementation allows developers to invoke specific function between multiple containers.
This may be useful in case of you have a container instantiated at application startup (singleton container) and a second container instantiated just before handle every HTTP request (factory container).

With _GroupInvoke_ you can resolve dependencies across singleton and factory container.