### PR TITLE
Release v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.13.0] - 2021-09-21
+### Added
+- Introduce `As` Option which supports providing a type as interface(s)
+  it implements to the container.
+- Add `LocationForPC` ProvideOption which overrides the function inspection
+  for a program counter address to a provided function info.
 
 ## [1.12.0] - 2021-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.13.0] - 2021-09-21
 ### Added
-- Introduce `As` Option which supports providing a type as interface(s)
+- Introduce `As` option which supports providing a type as interface(s)
   it implements to the container.
-- Add `LocationForPC` ProvideOption which overrides the function inspection
+- Add `LocationForPC` option which overrides the function inspection
   for a program counter address to a provided function info.
 
 ## [1.12.0] - 2021-07-29

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dig
 
 // Version of the library.
-const Version = "1.13.0-dev"
+const Version = "1.13.0"


### PR DESCRIPTION
Prepare for v1.13.0 release of DIg. 

In this release:
- Introduce `As` Option which supports providing a type as interface(s)
  it implements to the container.
- Add `LocationForPC` ProvideOption which overrides the function inspection
  for a program counter address to a provided function info.