### PR TITLE
Fix typo to make misspell happy again

### DIFF
--- a/types.go
+++ b/types.go
@@ -117,7 +117,7 @@ func embedsType(i interface{}, e reflect.Type) bool {
 	// TODO: this function doesn't consider e being a pointer.
 	// given `type A foo { *In }`, this function would return false for
 	// embedding dig.In, which makes for some extra error checking in places
-	// that call this funciton. Might be worthwhile to consider reflect.Indirect
+	// that call this function. Might be worthwhile to consider reflect.Indirect
 	// usage to clean up the callers.
 
 	if i == nil {


### PR DESCRIPTION
Found a typo via https://goreportcard.com/report/github.com/uber-go/dig, this is a quick fix for it.