### PR TITLE
Fix bug in a parallel test

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -1653,6 +1653,7 @@ func TestProvideInvalidAs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
There was a bug in the Dig.As error cases test which was using
t.Parallel to run the tests in parallel. But it was doing that using
a loop iterator, so tt was being changed during test execution.

Note this manifests in a quite cryptic way - codecov complained some
lines were not being covered, even though tests explicitly used those
cases.