### PR TITLE
Options: Implement String()

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionStrings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DeferAcyclicVerification", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "DeferAcyclicVerification()", fmt.Sprint(DeferAcyclicVerification()))
+	})
+
+	t.Run("setRand", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("nil", func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, "setRand(0x0)", fmt.Sprint(setRand(nil)))
+		})
+
+		t.Run("non nil", func(t *testing.T) {
+			t.Parallel()
+
+			opt := setRand(rand.New(rand.NewSource(42)))
+			assert.NotEqual(t, "setRand(0x0)", fmt.Sprint(opt))
+			assert.Contains(t, fmt.Sprint(opt), "setRand(0x")
+		})
+	})
+
+	t.Run("DryRun", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "DryRun(true)", fmt.Sprint(DryRun(true)))
+		assert.Equal(t, "DryRun(false)", fmt.Sprint(DryRun(false)))
+	})
+}

--- a/provide_test.go
+++ b/provide_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvideOptionStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give ProvideOption
+		want string
+	}{
+		{
+			desc: "Name",
+			give: Name("foo"),
+			want: `Name("foo")`,
+		},
+		{
+			desc: "Group",
+			give: Group("bar"),
+			want: `Group("bar")`,
+		},
+		{
+			desc: "As",
+			give: As(new(io.Reader), new(io.Writer)),
+			want: `As(io.Reader, io.Writer)`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, fmt.Sprint(tt.give))
+		})
+	}
+}
+
+func TestFillProvideInfoString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "FillProvideInfo(0x0)", fmt.Sprint(FillProvideInfo(nil)))
+	})
+
+	t.Run("not nil", func(t *testing.T) {
+		t.Parallel()
+
+		opt := FillProvideInfo(new(ProvideInfo))
+		assert.NotEqual(t, fmt.Sprint(opt), "FillProvideInfo(0x0)")
+		assert.Contains(t, fmt.Sprint(opt), "FillProvideInfo(0x")
+	})
+}
+
+func TestLocationForPCString(t *testing.T) {
+	opt := LocationForPC(reflect.ValueOf(func() {}).Pointer())
+	assert.Contains(t, fmt.Sprint(opt), `LocationForPC("go.uber.org/dig".TestLocationForPCString.func1 `)
+}

--- a/visualize.go
+++ b/visualize.go
@@ -21,6 +21,7 @@
 package dig
 
 import (
+	"fmt"
 	"io"
 	"strconv"
 	"text/template"
@@ -37,10 +38,6 @@ type visualizeOptions struct {
 	VisualizeError error
 }
 
-type visualizeOptionFunc func(*visualizeOptions)
-
-func (f visualizeOptionFunc) applyVisualizeOption(opts *visualizeOptions) { f(opts) }
-
 // VisualizeError includes a visualization of the given error in the output of
 // Visualize if an error was returned by Invoke or Provide.
 //
@@ -51,9 +48,17 @@ func (f visualizeOptionFunc) applyVisualizeOption(opts *visualizeOptions) { f(op
 // This option has no effect if the error was nil or if it didn't contain any
 // information to visualize.
 func VisualizeError(err error) VisualizeOption {
-	return visualizeOptionFunc(func(opts *visualizeOptions) {
-		opts.VisualizeError = err
-	})
+	return visualizeErrorOption{err}
+}
+
+type visualizeErrorOption struct{ err error }
+
+func (o visualizeErrorOption) String() string {
+	return fmt.Sprintf("VisualizeError(%v)", o.err)
+}
+
+func (o visualizeErrorOption) applyVisualizeOption(opt *visualizeOptions) {
+	opt.VisualizeError = o.err
 }
 
 func updateGraph(dg *dot.Graph, err error) error {

--- a/visualize_test.go
+++ b/visualize_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@ package dig
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -642,4 +643,22 @@ func TestCanVisualizeError(t *testing.T) {
 			assert.Equal(t, tt.canVisualize, CanVisualizeError(tt.err))
 		})
 	}
+}
+
+func TestVisualizeErrorString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		opt := VisualizeError(nil)
+		assert.Equal(t, "VisualizeError(<nil>)", fmt.Sprint(opt))
+	})
+
+	t.Run("not nil", func(t *testing.T) {
+		t.Parallel()
+
+		opt := VisualizeError(errors.New("great sadness"))
+		assert.Equal(t, "VisualizeError(great sadness)", fmt.Sprint(opt))
+	})
 }


### PR DESCRIPTION
Change option implementations from function pointers
to objects implementing `String()`.

This makes it easier to debug options by printing them
and aligns with the recommended pattern for functional options
in [our style guide].

  [our style guide]: https://github.com/uber-go/guide/blob/master/style.md#functional-options
