### PR TITLE
Add Export option to Provide

### DIFF
--- a/provide.go
+++ b/provide.go
@@ -304,7 +304,18 @@ func (o provideLocationOption) applyProvideOption(opts *provideOptions) {
 
 // Export is a ProvideOption which specifies that the provided function should
 // be made available to all Scopes available in the application, regardless
-// of from which Scope it was provided.
+// of from which Scope it was provided. By default, it is false.
+//
+// For example,
+//  c := New()
+//  s1 := c.Scope("child 1")
+//  s2:= c.Scope("child 2")
+//  s1.Provide(func() *bytes.Buffer { ... })
+// does not allow the constructor returning *bytes.Buffer to be made available to
+// the root Container c or its sibling Scope s2.
+//
+// With Export, you can make this constructor available to all the Scopes:
+//  s1.Provide(func() *bytes.Buffer { ... }, Export(true))
 func Export(export bool) ProvideOption {
 	return provideExportOption{exported: export}
 }

--- a/provide.go
+++ b/provide.go
@@ -304,7 +304,7 @@ func (o provideLocationOption) applyProvideOption(opts *provideOptions) {
 
 // Export is a ProvideOption which specifies that the provided function should
 // be made available to all Scopes available in the application, regardless
-// of from which Scope it was provided. By default, it is false.
+// of which Scope it was provided from. By default, it is false.
 //
 // For example,
 //  c := New()

--- a/provide_test.go
+++ b/provide_test.go
@@ -88,9 +88,6 @@ func TestLocationForPCString(t *testing.T) {
 }
 
 func TestExportString(t *testing.T) {
-	opt1 := Export(true)
-	opt2 := Export(false)
-
-	assert.Equal(t, fmt.Sprint(opt1), "Export(true)")
-	assert.Equal(t, fmt.Sprint(opt2), "Export(false)")
+	assert.Equal(t, fmt.Sprint(Export(true)), "Export(true)")
+	assert.Equal(t, fmt.Sprint(Export(false)), "Export(false)")
 }

--- a/provide_test.go
+++ b/provide_test.go
@@ -86,3 +86,11 @@ func TestLocationForPCString(t *testing.T) {
 	opt := LocationForPC(reflect.ValueOf(func() {}).Pointer())
 	assert.Contains(t, fmt.Sprint(opt), `LocationForPC("go.uber.org/dig".TestLocationForPCString.func1 `)
 }
+
+func TestExportString(t *testing.T) {
+	opt1 := Export(true)
+	opt2 := Export(false)
+
+	assert.Equal(t, fmt.Sprint(opt1), "Export(true)")
+	assert.Equal(t, fmt.Sprint(opt2), "Export(false)")
+}

--- a/scope.go
+++ b/scope.go
@@ -244,6 +244,15 @@ func (s *Scope) cycleDetectedError(cycle []int) error {
 	return errCycleDetected{Path: path, scope: s}
 }
 
+// Returns the root Scope that can be reached from this Scope.
+func (s *Scope) rootScope() *Scope {
+	curr := s
+	for curr.parentScope != nil {
+		curr = curr.parentScope
+	}
+	return curr
+}
+
 // String representation of the entire Scope
 func (s *Scope) String() string {
 	b := &bytes.Buffer{}


### PR DESCRIPTION
This adds `Export` option to `Provide`, which specifies that the provided constructor should be made available to all the Scopes in the same scope tree.

For example:
```
c := New()
s1 := c.Scope("child 1")
s2 := c.Scope("child 2")
s2.Provide(func() *A { ... })
c.Invoke(func(a *A) { ... }) // errors
s1.Invoke(func(a *A) { ...}) // errors
```
will error out on `Invoke` because constructor providing `*A` is provided to the `s2` only. 

With `Export` option, the child can provide this to all the Scopes in effect:
```
c := New()
s1 := c.Scope("child 1")
s2 := c.Scope("child 2")
s2.Provide(func() *A { ... }, Export(true))
c.Invoke(func(a *A) { ... })  // works!
s1.Invoke(func(a *A) { ... }) // works!
```
The implementation is quite simple - if this option is set, we provide it to the root Container. That provides the constructor visibility to all the scopes in effect. 