### PR TITLE
cycle error: Use [scope "foo"]

### DIFF
--- a/cycle_error.go
+++ b/cycle_error.go
@@ -40,6 +40,7 @@ type errCycleDetected struct {
 func (e errCycleDetected) Error() string {
 	// We get something like,
 	//
+	//   [scope "foo"]
 	//   func(*bar) *foo provided by "path/to/package".NewFoo (path/to/file.go:42)
 	//   	depends on func(*baz) *bar provided by "another/package".NewBar (somefile.go:1)
 	//   	depends on func(*foo) baz provided by "somepackage".NewBar (anotherfile.go:2)
@@ -47,7 +48,7 @@ func (e errCycleDetected) Error() string {
 	//
 	b := new(bytes.Buffer)
 
-	fmt.Fprintf(b, "In Scope %s: \n", e.scope.name)
+	fmt.Fprintf(b, "[scope %q]\n", e.scope.name)
 	for i, entry := range e.Path {
 		if i > 0 {
 			b.WriteString("\n\tdepends on ")

--- a/scope_test.go
+++ b/scope_test.go
@@ -162,7 +162,7 @@ func TestScopeFailures(t *testing.T) {
 
 			if fails {
 				assert.Error(t, err, "expected a cycle to be introduced in the child")
-				assert.Contains(t, err.Error(), "In Scope child")
+				assert.Contains(t, err.Error(), `[scope "child"]`)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -177,7 +177,7 @@ func TestScopeFailures(t *testing.T) {
 			err := c.Provide(newC)
 			if fails {
 				assert.Error(t, err, "expected a cycle to be introduced in the child")
-				assert.Contains(t, err.Error(), "In Scope child")
+				assert.Contains(t, err.Error(), `[scope "child"]`)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -240,7 +240,7 @@ func TestScopeFailures(t *testing.T) {
 		// C <- A made available to all Scopes with Export provide.
 		err := child1.Provide(newC, Export(true))
 		assert.Error(t, err, "expected a cycle to be introduced in child 2")
-		assert.Contains(t, err.Error(), "In Scope child 2")
+		assert.Contains(t, err.Error(), `[scope "child 2"]`)
 	})
 
 	t.Run("private provides do not propagate upstream", func(t *testing.T) {


### PR DESCRIPTION
Instead of always printing "In scope foo" print `[scope "foo"]`.
