### PR TITLE
scope: Use an empty name for root

### DIFF
--- a/cycle_error.go
+++ b/cycle_error.go
@@ -48,7 +48,9 @@ func (e errCycleDetected) Error() string {
 	//
 	b := new(bytes.Buffer)
 
-	fmt.Fprintf(b, "[scope %q]\n", e.scope.name)
+	if name := e.scope.name; len(name) > 0 {
+		fmt.Fprintf(b, "[scope %q]\n", name)
+	}
 	for i, entry := range e.Path {
 		if i > 0 {
 			b.WriteString("\n\tdepends on ")

--- a/dig_test.go
+++ b/dig_test.go
@@ -1893,6 +1893,7 @@ func testProvideCycleFails(t *testing.T, dryRun bool) {
 			`depends on func\(\*dig.A\) \*dig.B provided by "go.uber.org/dig".testProvideCycleFails.\S+ \(\S+\)`,
 			`depends on func\(\*dig.C\) \*dig.A provided by "go.uber.org/dig".testProvideCycleFails.\S+ \(\S+\)`,
 		)
+		assert.NotContains(t, err.Error(), "[scope")
 		assert.Error(t, c.Invoke(func(c *C) {}), "expected invoking a function that uses a type that failed to provide to fail.")
 	})
 

--- a/scope.go
+++ b/scope.go
@@ -82,7 +82,6 @@ type Scope struct {
 
 func newScope() *Scope {
 	s := &Scope{
-		name:      "container",
 		providers: make(map[key][]*constructorNode),
 		values:    make(map[key]reflect.Value),
 		groups:    make(map[key][]reflect.Value),


### PR DESCRIPTION
In the original discussions for Scope, we said that the root scope
(`Container`) will have an empty name, not "container".

PR #305 introduced Scope with the default name "container".
Proposing this as a resolution to that pending discussion.
