### PR TITLE
param: Search scopes during Build, support value groups

### DIFF
--- a/constructor.go
+++ b/constructor.go
@@ -151,7 +151,7 @@ func (n *constructorNode) Call(c containerStore) error {
 
 	// Commit the result to the original container that this constructor
 	// was supplied to. The provided constructor is only used for a view of
-	// the rest of the graph to instantiate the dependnecies of this
+	// the rest of the graph to instantiate the dependencies of this
 	// container.
 	receiver.Commit(n.s)
 	n.called = true

--- a/constructor.go
+++ b/constructor.go
@@ -148,7 +148,12 @@ func (n *constructorNode) Call(c containerStore) error {
 	if err := n.resultList.ExtractList(receiver, results); err != nil {
 		return errConstructorFailed{Func: n.location, Reason: err}
 	}
-	receiver.Commit(c)
+
+	// Commit the result to the original container that this constructor
+	// was supplied to. The provided constructor is only used for a view of
+	// the rest of the graph to instantiate the dependnecies of this
+	// container.
+	receiver.Commit(n.s)
 	n.called = true
 
 	return nil


### PR DESCRIPTION
This significantly changes how we instantiate dependencies for a
constructor and adds support for value groups.

Previously, for each parameter of a constructor, we attempted to
instantiate the value in every scope until one succeeded without
dependency errors. Effectively:

    for param in constructor
        for scope in scopes_to_root
            err = scope.instantiate(param)
            if err != missing_dependencies {
                return err
            }

This made the behavior less certain because we were relying on fuzzily
matching errors.

With this change, we search the container for constructors as needed
for singular parameters (paramSingle) and for value groups
(paramGroupedSlice). Roughly:

    for param in constructor
        switch param {
        case paramSingle:
            for scope in scopes_to_root {
                if scope.provides(param) {
                    found = true
                }
            }
            // ...
        
        case paramGroupedSlice:
            for scope in scopes_to_root {
                providers.append(scope.providers_for(param))
            }
        
        default:
            // ...
        }

This is cleaner because it works by searching the container for what it
needs rather than trying and letting it fail.

This includes a subtle change to constructorNode.Call:
previously, when a constructor ran, its results were stored in the
containerStore that it used to instantiate its dependencies.
Now, results are stored in the containerStore (Scope) to which that
constructor was provided. This works because the leaf param types
(paramSingle and paramGroupedSlice) will search the scope tree to find
the value.