### PR TITLE
Fix a typo in the docstring for FillProvideInfo

### DIFF
--- a/provide.go
+++ b/provide.go
@@ -200,7 +200,7 @@ func (o *Output) String() string {
 	return fmt.Sprintf("%v[%v]", t, strings.Join(toks, ", "))
 }
 
-// FillProvideInfo is a ProvideOption that writes info on what Dig was able to get out
+// FillProvideInfo is a ProvideOption that writes info on what Dig was able to get
 // out of the provided constructor into the provided ProvideInfo.
 func FillProvideInfo(info *ProvideInfo) ProvideOption {
 	return fillProvideInfoOption{info: info}


### PR DESCRIPTION
The docstring for FillProvideInfo had a typo and duplicated "out".
This removes the duplicated typo.