### PR TITLE
Add DecorateInfo and FillDecorateInfo

### DIFF
--- a/provide.go
+++ b/provide.go
@@ -152,7 +152,7 @@ type ProvideInfo struct {
 	Outputs []*Output
 }
 
-// Input contains information on an input parameter of the constructor.
+// Input contains information on an input parameter of a function.
 type Input struct {
 	t           reflect.Type
 	optional    bool
@@ -178,7 +178,7 @@ func (i *Input) String() string {
 	return fmt.Sprintf("%v[%v]", t, strings.Join(toks, ", "))
 }
 
-// Output contains information on an output produced by the constructor.
+// Output contains information on an output produced by a function.
 type Output struct {
 	t           reflect.Type
 	name, group string


### PR DESCRIPTION
This adds `dig.DecorateInfo` and `dig.FillDecorateInfo`, which behave like `dig.ProvideInfo` and `dig.FillProvideInfo`, except it's for `scope.Decorate`. It records the input and output parameters of the decorator function that Dig was able to get out of. 

Example usage:
```
var info DecorateInfo
c.Decorate(dcor, FillDecorateInfo(&info)) {
  ...
}

// info.Input/info.Output are now lists of stringers (dig.Input) that
// record the type/name/group info for each parameter/result types of dcor.

```

As a side note, I considered naming this `FillDecoratorInfo` but since the other option is named `FillProvideInfo`, not `FillProviderInfo`, I'm naming this to `FillDecorateInfo` to keep some level of consistency.

Ref GO-1220, #318 