### PR TITLE
Fix Invoke order changing execution result in multiple decorations of same type

### DIFF
--- a/decorate.go
+++ b/decorate.go
@@ -98,7 +98,7 @@ func (n *decoratorNode) Call(s containerStore) error {
 		}
 	}
 
-	args, err := n.params.BuildList(n.s, true /* decorating */)
+	args, err := n.params.BuildList(n.s, s == n.s /* decorating */)
 	if err != nil {
 		return errArgumentsFailed{
 			Func:   n.location,

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -589,20 +589,20 @@ func TestMultipleDecorates(t *testing.T) {
 	t.Run("decorate same type from parent and child, invoke child first", func(t *testing.T) {
 		t.Parallel()
 		type A struct{ value int }
-		c := digtest.New(t)
-		child := c.Scope("child")
+		root := digtest.New(t)
+		child := root.Scope("child")
 
 		decorator := func(a A) A {
 			return A{value: a.value + 1}
 		}
-		c.RequireProvide(func() A { return A{value: 0} })
-		c.RequireDecorate(decorator)
+		root.RequireProvide(func() A { return A{value: 0} })
+		root.RequireDecorate(decorator)
 		child.RequireDecorate(decorator)
 
 		child.Invoke(func(a A) {
 			assert.Equal(t, 2, a.value)
 		})
-		c.Invoke(func(a A) {
+		root.Invoke(func(a A) {
 			assert.Equal(t, 1, a.value)
 		})
 	})
@@ -610,16 +610,16 @@ func TestMultipleDecorates(t *testing.T) {
 	t.Run("decorate same type from parent and child, invoke parent first", func(t *testing.T) {
 		t.Parallel()
 		type A struct{ value int }
-		c := digtest.New(t)
-		child := c.Scope("child")
+		root := digtest.New(t)
+		child := root.Scope("child")
 		decorator := func(a A) A {
 			return A{value: a.value + 1}
 		}
-		c.RequireProvide(func() A { return A{value: 0} })
-		c.RequireDecorate(decorator)
+		root.RequireProvide(func() A { return A{value: 0} })
+		root.RequireDecorate(decorator)
 		child.RequireDecorate(decorator)
 
-		c.Invoke(func(a A) {
+		root.Invoke(func(a A) {
 			assert.Equal(t, 1, a.value)
 		})
 		child.Invoke(func(a A) {
@@ -640,8 +640,8 @@ func TestMultipleDecorates(t *testing.T) {
 			Values []int `group:"val"`
 		}
 
-		c := digtest.New(t)
-		child := c.Scope("child")
+		root := digtest.New(t)
+		child := root.Scope("child")
 		decorator := func(a A) B {
 			var newV []int
 			for _, v := range a.Values {
@@ -651,12 +651,12 @@ func TestMultipleDecorates(t *testing.T) {
 		}
 
 		// provide {0, 1, 2}
-		c.Provide(func() int { return 0 }, dig.Group("val"))
-		c.Provide(func() int { return 1 }, dig.Group("val"))
-		c.Provide(func() int { return 2 }, dig.Group("val"))
+		root.Provide(func() int { return 0 }, dig.Group("val"))
+		root.Provide(func() int { return 1 }, dig.Group("val"))
+		root.Provide(func() int { return 2 }, dig.Group("val"))
 
 		// decorate +1 to each element in parent
-		c.RequireDecorate(decorator)
+		root.RequireDecorate(decorator)
 
 		// decorate +1 to each element in child
 		child.RequireDecorate(decorator)
@@ -667,7 +667,7 @@ func TestMultipleDecorates(t *testing.T) {
 		})
 
 		// assert parent sees 1, 2, 3
-		c.Invoke(func(a A) {
+		root.Invoke(func(a A) {
 			assert.ElementsMatch(t, []int{1, 2, 3}, a.Values)
 		})
 	})
@@ -685,8 +685,8 @@ func TestMultipleDecorates(t *testing.T) {
 			Values []int `group:"val"`
 		}
 
-		c := digtest.New(t)
-		child := c.Scope("child")
+		root := digtest.New(t)
+		child := root.Scope("child")
 		decorator := func(a A) B {
 			var newV []int
 			for _, v := range a.Values {
@@ -696,18 +696,18 @@ func TestMultipleDecorates(t *testing.T) {
 		}
 
 		// provide {0, 1, 2}
-		c.Provide(func() int { return 0 }, dig.Group("val"))
-		c.Provide(func() int { return 1 }, dig.Group("val"))
-		c.Provide(func() int { return 2 }, dig.Group("val"))
+		root.Provide(func() int { return 0 }, dig.Group("val"))
+		root.Provide(func() int { return 1 }, dig.Group("val"))
+		root.Provide(func() int { return 2 }, dig.Group("val"))
 
 		// decorate +1 to each element in parent
-		c.RequireDecorate(decorator)
+		root.RequireDecorate(decorator)
 
 		// decorate +1 to each element in child
 		child.RequireDecorate(decorator)
 
 		// assert parent sees 1, 2, 3
-		c.Invoke(func(a A) {
+		root.Invoke(func(a A) {
 			assert.ElementsMatch(t, []int{1, 2, 3}, a.Values)
 		})
 

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -661,12 +661,10 @@ func TestMultipleDecorates(t *testing.T) {
 		// decorate +1 to each element in child
 		child.RequireDecorate(decorator)
 
-		// assert child sees 2, 3, 4
 		child.RequireInvoke(func(a A) {
 			assert.ElementsMatch(t, []int{2, 3, 4}, a.Values)
 		})
 
-		// assert parent sees 1, 2, 3
 		root.RequireInvoke(func(a A) {
 			assert.ElementsMatch(t, []int{1, 2, 3}, a.Values)
 		})
@@ -706,12 +704,10 @@ func TestMultipleDecorates(t *testing.T) {
 		// decorate +1 to each element in child
 		child.RequireDecorate(decorator)
 
-		// assert parent sees 1, 2, 3
 		root.Invoke(func(a A) {
 			assert.ElementsMatch(t, []int{1, 2, 3}, a.Values)
 		})
 
-		// assert child sees 2, 3, 4
 		child.Invoke(func(a A) {
 			assert.ElementsMatch(t, []int{2, 3, 4}, a.Values)
 		})

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -599,10 +599,10 @@ func TestMultipleDecorates(t *testing.T) {
 		root.RequireDecorate(decorator)
 		child.RequireDecorate(decorator)
 
-		child.Invoke(func(a A) {
+		child.RequireInvoke(func(a A) {
 			assert.Equal(t, 2, a.value)
 		})
-		root.Invoke(func(a A) {
+		root.RequireInvoke(func(a A) {
 			assert.Equal(t, 1, a.value)
 		})
 	})
@@ -619,10 +619,10 @@ func TestMultipleDecorates(t *testing.T) {
 		root.RequireDecorate(decorator)
 		child.RequireDecorate(decorator)
 
-		root.Invoke(func(a A) {
+		root.RequireInvoke(func(a A) {
 			assert.Equal(t, 1, a.value)
 		})
-		child.Invoke(func(a A) {
+		child.RequireInvoke(func(a A) {
 			assert.Equal(t, 2, a.value)
 		})
 	})
@@ -662,12 +662,12 @@ func TestMultipleDecorates(t *testing.T) {
 		child.RequireDecorate(decorator)
 
 		// assert child sees 2, 3, 4
-		child.Invoke(func(a A) {
+		child.RequireInvoke(func(a A) {
 			assert.ElementsMatch(t, []int{2, 3, 4}, a.Values)
 		})
 
 		// assert parent sees 1, 2, 3
-		root.Invoke(func(a A) {
+		root.RequireInvoke(func(a A) {
 			assert.ElementsMatch(t, []int{1, 2, 3}, a.Values)
 		})
 	})


### PR DESCRIPTION
This fixes the multiple decoration logic for paramSingle where there
are more than one scopes that contain decorators for a type. The lookup
logic only looked up one-level for the decorator. For example, if Scope S
has a decorator and its parent Sp also has a decorator for the same type, it never
executed Sp's decorator.

This caused the order of the Scopes in which a function that used such type
was Invoked from to change the execution result.

This PR addresses the issue by more diligently looking up the types by
traversing for more decorators until there is no more decorators found
in the path to the root Scope.

Also added several tests that cover this case.

Fixes #321 and https://github.com/uber-go/fx/issues/841
Internal Ref: GO-1228