### PR TITLE
CHANGELOG: Add missing references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A stack overflow bug that happens when cycles are introduced via self-pointing
   dependencies with DeferAcyclicVerification.
 
+[1.14.0]: https://github.com/uber-go/dig/compare/v1.13.0...v1.14.0
+
 ## [1.13.0] - 2021-09-21
 ### Added
 - Introduce `As` option which supports providing a type as interface(s)
@@ -29,21 +31,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `LocationForPC` option which overrides the function inspection
   for a program counter address to a provided function info.
 
+[1.13.0]: https://github.com/uber-go/dig/compare/v1.12.0...v1.13.0
+
 ## [1.12.0] - 2021-07-29
 ### Added
 - Support for ProvideInfo and FillProvideInfo that allow the caller of
   `Provide` to get info about what dig understood from the constructor.
+
+[1.12.0]: https://github.com/uber-go/dig/compare/v1.11.0...v1.12.0
 
 ## [1.11.0] - 2021-06-09
 ### Added
 - Support unexported fields on `dig.In` structs with the
   `ignore-unexported:"true` struct tag.
 
+[1.11.0]: https://github.com/uber-go/dig/compare/v1.10.0...v1.11.0
+
 ## [1.10.0] - 2020-06-16
 ### Added
 - Introduce `DryRun` Option which, when set to true, disables invocation
   of functions supplied to `Provide` and `Invoke`. This option will be
   used to build no-op containers, for example for `fx.ValidateApp` method.
+
+[1.10.0]: https://github.com/uber-go/dig/compare/v1.9.0...v1.10.0
 
 ## [1.9.0] - 2020-03-31
 ### Added
@@ -57,14 +67,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Drop library dependency on `golang.org/x/lint`.
 - Support printing multi-line error messages with `%+v`.
 
+[1.9.0]: https://github.com/uber-go/dig/compare/v1.8.0...v1.9.0
+
 ## [1.8.0] - 2019-11-14
 ### Changed
 - Migrated to Go modules.
+
+[1.8.0]: https://github.com/uber-go/dig/compare/v1.7.0...v1.8.0
 
 ## [1.7.0] - 2019-01-04
 ### Added
 - Added `Group` option for `Provide` to add value groups to the container without
 rewriting constructors. See package doucmentation for more information.
+
+[1.7.0]: https://github.com/uber-go/dig/compare/v1.6.0...v1.7.0
 
 ## [1.6.0] - 2018-11-06
 ### Changed
@@ -72,9 +88,13 @@ rewriting constructors. See package doucmentation for more information.
   contains failure nodes.
 - Container visualization is now oriented from right to left.
 
+[1.6.0]: https://github.com/uber-go/dig/compare/v1.5.1...v1.6.0
+
 ## [1.5.1] - 2018-11-01
 ### Fixed
 - Fixed a test that was causing Dig to be unusable with Go Modules.
+
+[1.5.1]: https://github.com/uber-go/dig/compare/v1.5.0...v1.5.1
 
 ## [1.5.0] - 2018-09-19
 ### Added
@@ -83,6 +103,8 @@ rewriting constructors. See package doucmentation for more information.
 
 ### Changed
 - Improved cycle-detection performance by 50x in certain degenerative cases.
+
+[1.5.0]: https://github.com/uber-go/dig/compare/v1.4.0...v1.5.0
 
 ## [1.4.0] - 2018-08-16
 ### Added
@@ -99,16 +121,22 @@ rewriting constructors. See package doucmentation for more information.
 - `name:"..."` tags on nested Result Objects will now cause errors instead of
   being ignored.
 
+[1.4.0]: https://github.com/uber-go/dig/compare/v1.3.0...v1.4.0
+
 ## [1.3.0] - 2017-12-04
 ### Changed
 - Improved messages for errors thrown by Dig under a many scenarios to be more
   informative.
+
+[1.3.0]: https://github.com/uber-go/dig/compare/v1.2.0...v1.3.0
 
 ## [1.2.0] - 2017-11-07
 ### Added
 - `dig.In` and `dig.Out` now support value groups, making it possible to
   produce many values of the same type from different constructors. See package
   documentation for more information.
+
+[1.2.0]: https://github.com/uber-go/dig/compare/v1.1.0...v1.2.0
 
 ## [1.1.0] - 2017-09-15
 ### Added
@@ -119,6 +147,8 @@ rewriting constructors. See package doucmentation for more information.
 - Errors from `Invoke` now attempt to hint to the user a presence of a similar
   type, for example a pointer to the requested type and vice versa.
 
+[1.1.0]: https://github.com/uber-go/dig/compare/v1.0.0...v1.1.0
+
 ## [1.0.0] - 2017-07-31
 
 First stable release: no breaking changes will be made in the 1.x series.
@@ -127,6 +157,8 @@ First stable release: no breaking changes will be made in the 1.x series.
 - `Provide` and `Invoke` will now fail if `dig.In` or `dig.Out` structs
   contain unexported fields. Previously these fields were ignored which often
   led to confusion.
+
+[1.0.0]: https://github.com/uber-go/dig/compare/v1.0.0-rc2...v1.0.0
 
 ## [1.0.0-rc2] - 2017-07-21
 ### Added
@@ -139,9 +171,14 @@ First stable release: no breaking changes will be made in the 1.x series.
 - Functions with variadic arguments can now be passed to `dig.Provide` and
   `dig.Invoke`. Previously this caused an error, whereas now the args will be ignored.
 
+[1.0.0-rc2]: https://github.com/uber-go/dig/compare/v1.0.0-rc1...v1.0.0-rc2
+
 ## [1.0.0-rc1] - 2017-06-21
 
 First release candidate.
+
+[1.0.0-rc1]: https://github.com/uber-go/dig/compare/v0.5.0...v1.0.0-rc1
+
 
 ## [0.5.0] - 2017-06-19
 ### Added
@@ -160,6 +197,8 @@ First release candidate.
 - Structs compatible with `dig.In` and `dig.Out` may now be generated using
   `reflect.StructOf`.
 
+[0.5.0]: https://github.com/uber-go/dig/compare/v0.4.0...v0.5.0
+
 ## [0.4.0] - 2017-06-12
 ### Added
 - Add `dig.In` embeddable type for advanced use-cases of specifying dependencies.
@@ -176,6 +215,8 @@ First release candidate.
 - **[Breaking]** Remove `Must*` funcs to greatly reduce API surface area.
 - Providing constructors with common returned types results in an error.
 
+[0.4.0]: https://github.com/uber-go/dig/compare/v0.3...v0.4.0
+
 ## [0.3] - 2017-05-02
 ### Added
 - Add functionality to `Provide` to support constructor with `n` return
@@ -187,6 +228,8 @@ First release candidate.
 - Rename `RegisterAll` and `MustRegisterAll` to `ProvideAll` and
   `MustProvideAll`.
 
+[0.3]: https://github.com/uber-go/dig/compare/v0.2...v0.3
+
 ## [0.2] - 2017-03-27
 ### Changed
 - Rename `Register` to `Provide` for clarity and to recude clash with other
@@ -196,26 +239,8 @@ First release candidate.
 ### Removed
 - Remove the package-level functions and the `DefaultGraph`.
 
+[0.2]: https://github.com/uber-go/dig/compare/v0.1...v0.2
+
 ## 0.1 - 2017-03-23
 
 Initial release.
-
-[1.11.0]: https://github.com/uber-go/dig/compare/v1.10.0...v1.11.0
-[1.10.0]: https://github.com/uber-go/dig/compare/v1.9.0...v1.10.0
-[1.9.0]: https://github.com/uber-go/dig/compare/v1.8.0...v1.9.0
-[1.8.0]: https://github.com/uber-go/dig/compare/v1.7.0...v1.8.0
-[1.7.0]: https://github.com/uber-go/dig/compare/v1.6.0...v1.7.0
-[1.6.0]: https://github.com/uber-go/dig/compare/v1.5.1...v1.6.0
-[1.5.1]: https://github.com/uber-go/dig/compare/v1.5.0...v1.5.1
-[1.5.0]: https://github.com/uber-go/dig/compare/v1.4.0...v1.5.0
-[1.4.0]: https://github.com/uber-go/dig/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/uber-go/dig/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/uber-go/dig/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/uber-go/dig/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/uber-go/dig/compare/v1.0.0-rc2...v1.0.0
-[1.0.0-rc2]: https://github.com/uber-go/dig/compare/v1.0.0-rc1...v1.0.0-rc2
-[1.0.0-rc1]: https://github.com/uber-go/dig/compare/v0.5.0...v1.0.0-rc1
-[0.5.0]: https://github.com/uber-go/dig/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/uber-go/dig/compare/v0.3...v0.4.0
-[0.3]: https://github.com/uber-go/dig/compare/v0.2...v0.3
-[0.2]: https://github.com/uber-go/dig/compare/v0.1...v0.2


### PR DESCRIPTION
Markdown reference links take the form,

    [foo] bar

    [foo]: https://example.com

We were placing these at the bottom of the file which made them easy to
forget -- we've missed them for 1.12, 1.13, and 1.14.

Move the reference links to each release's section, and add missing
links.
