### PR TITLE
Fix issue with multiple decoration passes in same Scope

### DIFF
--- a/decorate_test.go
+++ b/decorate_test.go
@@ -124,7 +124,6 @@ func TestDecorateSuccess(t *testing.T) {
 	})
 
 	t.Run("simple decorate a provider to a scope and its descendants", func(t *testing.T) {
-		t.Parallel()
 		type A struct {
 			name string
 		}
@@ -356,6 +355,24 @@ func TestDecorateSuccess(t *testing.T) {
 
 		require.NoError(t, child.Invoke(func(i InvokeIn) {
 			assert.ElementsMatch(t, []string{"good happy dog", "good happy cat"}, i.Values)
+		}))
+	})
+
+	t.Run("decorate two times within same scope", func(t *testing.T) {
+		type A struct {
+			name string
+		}
+		parent := digtest.New(t)
+		parent.RequireProvide(func() string { return "parent" })
+		parent.RequireProvide(func(n string) A { return A{name: n} })
+
+		child := parent.Scope("child")
+
+		child.RequireDecorate(func() string { return "child" })
+		child.RequireDecorate(func(n string) A { return A{name: n + " decorated"} })
+
+		require.NoError(t, child.Invoke(func(a A) {
+			assert.Equal(t, "child decorated", a.name)
 		}))
 	})
 

--- a/param.go
+++ b/param.go
@@ -227,14 +227,20 @@ func (ps paramSingle) buildWithDecorators(c containerStore, decorating bool) (v 
 		decoratingScope containerStore
 	)
 	stores := c.storesToRoot()
-	// If we are already in a decorating stack,
-	// skip the current Scope to avoid infinite
-	// recursion.
-	if decorating {
-		stores = stores[1:]
-	}
 	for _, s := range stores {
-		if decorators = s.getValueDecorators(ps.Name, ps.Type); len(decorators) > 0 {
+		if decorators = s.getValueDecorators(ps.Name, ps.Type); len(decorators) == 0 {
+			continue
+		}
+		searchParentScope := false
+		for _, d := range decorators {
+			if d.State() == decoratorOnStack {
+				decorators = nil // reset this stuff.
+				searchParentScope = true
+			}
+		}
+		if searchParentScope {
+			continue
+		} else {
 			decoratingScope = s
 			break
 		}

--- a/param.go
+++ b/param.go
@@ -234,7 +234,9 @@ storeLoop:
 		}
 		for _, d := range decorators {
 			if d.State() == decoratorOnStack {
-				decorators = nil // reset this stuff.
+				// This decorator is already being run.
+				// Avoid a cycle and look further.
+				decorators = nil
 				continue storeLoop
 			}
 		}

--- a/param.go
+++ b/param.go
@@ -227,23 +227,19 @@ func (ps paramSingle) buildWithDecorators(c containerStore, decorating bool) (v 
 		decoratingScope containerStore
 	)
 	stores := c.storesToRoot()
+storeLoop:
 	for _, s := range stores {
 		if decorators = s.getValueDecorators(ps.Name, ps.Type); len(decorators) == 0 {
 			continue
 		}
-		searchParentScope := false
 		for _, d := range decorators {
 			if d.State() == decoratorOnStack {
 				decorators = nil // reset this stuff.
-				searchParentScope = true
+				continue storeLoop
 			}
 		}
-		if searchParentScope {
-			continue
-		} else {
-			decoratingScope = s
-			break
-		}
+		decoratingScope = s
+		break
 	}
 	if len(decorators) == 0 {
 		return _noValue, false, nil


### PR DESCRIPTION
This fixes issue when there is a decorator that depends on a type
that is decorated by another decorator that lives in the same
Scope.

Previously, there is a "circuit-breaker" for the parameter building
logic specifically for the case when the decorator depends on the same
type as its output type; this basically causes the decorator.Call and
paramSingle.Build to call each other, ending up in an infinite recursion.

To avoid that, it was skipping over the current Scope when looking for
decorators for its parameters if it was already in the context of a decorator.

However, that logic is incorrect as it is possible for the decorator can still
depend on *other* types that is decorated within the same Scope.

This fixes the issue by keeping track of the decorator's state in 3 modes -
ready, on stack, and called. If a decorator is on stack, that means that it is
still in the middle of being executed, so when parameter builder finds that
decorator, it knows to skip over the current Scope to look for any decorators
from parent Scopes. Otherwise, it can safely look for decorators from the same
Scope since we won't end up in an infinite recursion.

This fixes #328.