### PR TITLE
Keep track of single decorator per Scope

### DIFF
--- a/container.go
+++ b/container.go
@@ -126,13 +126,13 @@ type containerStore interface {
 	// type across all the Scopes that are in effect of this containerStore.
 	getAllValueProviders(name string, t reflect.Type) []provider
 
-	// Returns the decorators that can produce values for the given name and
+	// Returns the decorator that can decorate values for the given name and
 	// type.
-	getValueDecorators(name string, t reflect.Type) []decorator
+	getValueDecorator(name string, t reflect.Type) (decorator, bool)
 
-	// Reutrns the decorators that can produce values for the given group and
+	// Reutrns the decorator that can decorate values for the given group and
 	// type.
-	getGroupDecorators(name string, t reflect.Type) []decorator
+	getGroupDecorator(name string, t reflect.Type) (decorator, bool)
 
 	// Reports a list of stores (starting at this store) up to the root
 	// store.

--- a/decorate.go
+++ b/decorate.go
@@ -216,13 +216,13 @@ func (s *Scope) Decorate(decorator interface{}, opts ...DecorateOption) error {
 
 	keys := findResultKeys(dn.results)
 	for _, k := range keys {
-		if len(s.decorators[k]) > 0 {
+		if _, ok := s.decorators[k]; ok {
 			return fmt.Errorf("cannot decorate using function %v: %s already decorated",
 				dn.dtype,
 				k,
 			)
 		}
-		s.decorators[k] = append(s.decorators[k], dn)
+		s.decorators[k] = dn
 	}
 
 	if info := options.Info; info != nil {

--- a/scope.go
+++ b/scope.go
@@ -47,8 +47,8 @@ type Scope struct {
 	// key.
 	providers map[key][]*constructorNode
 
-	// Mapping from key to all decorator nodes that decorates a value for that key.
-	decorators map[key][]*decoratorNode
+	// Mapping from key to the decorator that decorates a value for that key.
+	decorators map[key]*decoratorNode
 
 	// constructorNodes provided directly to this Scope. i.e. it does not include
 	// any nodes that were provided to the parent Scope this inherited from.
@@ -92,7 +92,7 @@ type Scope struct {
 func newScope() *Scope {
 	s := &Scope{
 		providers:       make(map[key][]*constructorNode),
-		decorators:      make(map[key][]*decoratorNode),
+		decorators:      make(map[key]*decoratorNode),
 		values:          make(map[key]reflect.Value),
 		decoratedValues: make(map[key]reflect.Value),
 		groups:          make(map[key][]reflect.Value),
@@ -215,24 +215,17 @@ func (s *Scope) getGroupProviders(name string, t reflect.Type) []provider {
 	return s.getProviders(key{group: name, t: t})
 }
 
-func (s *Scope) getValueDecorators(name string, t reflect.Type) []decorator {
+func (s *Scope) getValueDecorator(name string, t reflect.Type) (decorator, bool) {
 	return s.getDecorators(key{name: name, t: t})
 }
 
-func (s *Scope) getGroupDecorators(name string, t reflect.Type) []decorator {
+func (s *Scope) getGroupDecorator(name string, t reflect.Type) (decorator, bool) {
 	return s.getDecorators(key{group: name, t: t})
 }
 
-func (s *Scope) getDecorators(k key) []decorator {
-	nodes, ok := s.decorators[k]
-	if !ok {
-		return nil
-	}
-	decorators := make([]decorator, len(nodes))
-	for i, n := range nodes {
-		decorators[i] = n
-	}
-	return decorators
+func (s *Scope) getDecorators(k key) (decorator, bool) {
+	d, found := s.decorators[k]
+	return d, found
 }
 
 func (s *Scope) getProviders(k key) []provider {


### PR DESCRIPTION
Currently, a type can only be decorated at most once per Scope. However,
Scope was keeping track of multiple decorators per type which resulted in
some amount of additional bookkeeping throughout the codebase.

This is mainly a refactor to make Scope keep track of a single decorator
per type.