### PR TITLE
Bubble location from LocationForPC's ProvideOption up to errors

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -2424,9 +2424,8 @@ func testProvideFailures(t *testing.T, dryRun bool) {
 		type ret struct {
 			dig.Out
 
-			A1 A // same type A provided three times
+			A1 A // same type A provided twice
 			A2 A
-			A3 A
 		}
 
 		locationFn := func() {}
@@ -2435,15 +2434,11 @@ func testProvideFailures(t *testing.T, dryRun bool) {
 			return ret{
 				A1: A{idx: 1},
 				A2: A{idx: 2},
-				A3: A{idx: 3},
 			}
 		}, dig.LocationForPC(reflect.ValueOf(locationFn).Pointer()))
 		require.Error(t, err, "provide must return error")
 		dig.AssertErrorMatches(t, err,
 			`cannot provide function "go.uber.org/dig_test".testProvideFailures.func\d+.1`,
-			`dig_test.go:\d+`, // file:line
-			`cannot provide dig_test.A from \[0\].A2:`,
-			`already provided by \[0\].A1`,
 		)
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -3515,6 +3515,20 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 		)
 	})
 
+	t.Run("duplicate provide with LocationForPC", func(t *testing.T) {
+		c := digtest.New(t)
+		c.RequireProvide(func(x int) float64 {
+			return testStruct{}.TestMethod(x)
+		}, dig.LocationForPC(reflect.TypeOf(testStruct{}).Method(0).Func.Pointer()))
+		err := c.Provide(func(x int) float64 {
+			return testStruct{}.TestMethod(x)
+		}, dig.LocationForPC(reflect.TypeOf(testStruct{}).Method(0).Func.Pointer()))
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `cannot provide function "go.uber.org/dig_test".testStruct.TestMethod`)
+		require.Contains(t, err.Error(), `already provided by "go.uber.org/dig_test".testStruct.TestMethod`)
+	})
+
 	t.Run("named instances", func(t *testing.T) {
 		c := digtest.New(t)
 		type A1 struct{ s string }

--- a/provide.go
+++ b/provide.go
@@ -417,8 +417,15 @@ func (s *Scope) Provide(constructor interface{}, opts ...ProvideOption) error {
 	}
 
 	if err := s.provide(constructor, options); err != nil {
+		var errFunc *digreflect.Func
+		if options.Location == nil {
+			errFunc = digreflect.InspectFunc(constructor)
+		} else {
+			errFunc = options.Location
+		}
+
 		return errProvide{
-			Func:   digreflect.InspectFunc(constructor),
+			Func:   errFunc,
 			Reason: err,
 		}
 	}


### PR DESCRIPTION
Previously, if a location was passed to Provide via the
LocationForPC ProvideOption, the location would not be taken
into account in the case of an error where a constructor could
not be Provided.

This change updates the error returned, making it more readable by
basing the error message on alternate function provided by
LocationForPC rather than the constructor.

For example, the following error:
```
Failed: cannot provide function "reflect".makeFuncStub (/usr/local/Cellar/go/1.17.6/libexec/src/reflect/asm_amd64.s:30):
cannot provide *fx_test.a[name="a"] from [0].Field0: already provided by
"go.uber.org/fx_test".TestAnnotate.func1 (/gocode/src/github.com/uber-go/fx/annotated_test.go:515)
```

Becomes:
```
Failed: cannot provide function "go.uber.org/fx_test".TestAnnotate.func1 (/gocode/src/github.com/uber-go/fx/annotated_test.go:515):
cannot provide *fx_test.a[name="a"] from [0].Field0: already provided by
"go.uber.org/fx_test".TestAnnotate.func1 (/gocode/src/github.com/uber-go/fx/annotated_test.go:515)
```