### PR TITLE
Error out when trying to decorate a value group with single value

### DIFF
--- a/decorate_test.go
+++ b/decorate_test.go
@@ -673,6 +673,22 @@ func TestDecorateFailure(t *testing.T) {
 		assert.Contains(t, err.Error(), "function func(dig_test.Param) dig_test.Result")
 		assert.Contains(t, err.Error(), "*dig_test.A already decorated")
 	})
+
+	t.Run("decorate value group with a single value", func(t *testing.T) {
+		type A struct {
+			dig.Out
+
+			Value int `group:"val"`
+		}
+
+		root := digtest.New(t)
+
+		root.RequireProvide(func() A { return A{Value: 1} })
+		err := root.Decorate(func() A { return A{Value: 11} })
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decorating a value group requires decorating the entire value group")
+	})
 }
 
 func TestMultipleDecorates(t *testing.T) {


### PR DESCRIPTION
When a value group is being decorated with a single value, it currently
panics because decorate tries to take element of a non-slice value.

While it's possible to allow this technically, after some consideration,
this should just not be allowed because it can be confusing to distinguish
between the two cases. For example, when providing a slice of slices as a
value group, it's unclear whether or not the target type is the slice of types,
or the slice of slices of types.

In addition, if there is a good way to support it in the future, it is
possible to add that later.

Fix https://github.com/uber-go/fx/issues/859
Ref GO-1261