### PR TITLE
Fix issue with wrong invoke for multiple private providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 *.coverprofile
 coverage.txt
 *.pprof
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.coverprofile
 coverage.txt
 *.pprof
+*.swp

--- a/param.go
+++ b/param.go
@@ -213,6 +213,11 @@ func (ps paramSingle) getValue(c containerStore) (reflect.Value, bool) {
 		if v, ok := c.getValue(ps.Name, ps.Type); ok {
 			return v, ok
 		}
+		// If this scope can provide a value, we will build it instead of use upstream, since this
+		// is the closest provider
+		if providers := c.getValueProviders(ps.Name, ps.Type); len(providers) > 0 {
+			return _noValue, false
+		}
 	}
 	return _noValue, false
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -71,6 +71,25 @@ func TestScopedOperations(t *testing.T) {
 		assert.Error(t, c.Invoke(useB))
 	})
 
+	t.Run("private provides doesn't depend on invoke order", func(t *testing.T) {
+		c := digtest.New(t)
+
+		c.RequireProvide(func() string { return "container" })
+
+		child := c.Scope("child")
+		child.RequireProvide(func() string { return "child" })
+
+		verifyContainerStr := func(s string) {
+			assert.Equal(t, "container", s)
+		}
+		verifyChildStr := func(s string) {
+			assert.Equal(t, "child", s)
+		}
+
+		c.RequireInvoke(verifyContainerStr)
+		child.RequireInvoke(verifyChildStr)
+	})
+
 	t.Run("provides to top-level Container propogates to all scopes", func(t *testing.T) {
 		type A struct{}
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -73,10 +73,9 @@ func TestScopedOperations(t *testing.T) {
 
 	t.Run("private provides doesn't depend on invoke order", func(t *testing.T) {
 		c := digtest.New(t)
+		child := c.Scope("child")
 
 		c.RequireProvide(func() string { return "container" })
-
-		child := c.Scope("child")
 		child.RequireProvide(func() string { return "child" })
 
 		verifyContainerStr := func(s string) {


### PR DESCRIPTION
This fixes issue #343 - we check if the value can be provided in each scope from current to root, instead of first searching for pre built ones in all scopes.