### PR TITLE
Refactor paramSingle build

### DIFF
--- a/param.go
+++ b/param.go
@@ -264,6 +264,7 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 	// Dependencies of this type will begin searching at that container,
 	// rather than starting at base.
 	var providers []provider
+	var providingContainer containerStore
 	for _, container := range c.storesToRoot() {
 		// first check if the scope already has cached a value for the type.
 		if v, ok := container.getValue(ps.Name, ps.Type); ok {
@@ -271,6 +272,7 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 		}
 		providers = container.getValueProviders(ps.Name, ps.Type)
 		if len(providers) > 0 {
+			providingContainer = container
 			break
 		}
 	}
@@ -303,11 +305,7 @@ func (ps paramSingle) Build(c containerStore) (reflect.Value, error) {
 
 	// If we get here, it's impossible for the value to be absent from the
 	// container.
-	for _, container := range c.storesToRoot() {
-		if v, ok := container.getValue(ps.Name, ps.Type); ok {
-			return v, nil
-		}
-	}
+	v, _ = providingContainer.getValue(ps.Name, ps.Type)
 	return v, nil
 }
 


### PR DESCRIPTION
This cleans up some duplicate logic added in #344 added a fix for lookup logic
of cached values in dig Scopes.

Since paramSingle.getValues no longer only "gets" values cached in the container,
it's easier if we just inline this logic inside the build method and avoid having
to duplicate the logic across two places.