### PR TITLE
Add support for soft value groups

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -1380,7 +1380,7 @@ func TestGroups(t *testing.T) {
 		assert.Contains(t, err.Error(), "flatten can be applied to slices only")
 	})
 
-	t.Run("check providers for value groups aren't called if only they're provided", func(t *testing.T) {
+	t.Run("a soft value group provider is not called when only that value group is consumed", func(t *testing.T) {
 		type Param struct {
 			dig.In
 
@@ -1394,7 +1394,7 @@ func TestGroups(t *testing.T) {
 		c := digtest.New(t)
 
 		c.RequireProvide(func() (Result, int) {
-			require.FailNow(t, "This shouldn't be called")
+			require.FailNow(t, "this function should not be called")
 			return Result{Value: "sad times"}, 20
 		})
 
@@ -1403,7 +1403,7 @@ func TestGroups(t *testing.T) {
 		})
 	})
 
-	t.Run("soft value group", func(t *testing.T) {
+	t.Run("soft value group is provided", func(t *testing.T) {
 		type Param1 struct {
 			dig.In
 
@@ -1460,7 +1460,12 @@ func TestGroups(t *testing.T) {
 			assert.Equal(t, float32(3.1416), p.Value3)
 		})
 	})
-
+	t.Run("soft in a result value group", func(t *testing.T) {
+		c := digtest.New(t)
+		err := c.Provide(func() int { return 10 }, dig.Group("foo,soft"))
+		require.Error(t, err, "failed to privide")
+		assert.Contains(t, err.Error(), "cannot use soft with result value groups")
+	})
 	t.Run("value group provided after a hard dependency is provided", func(t *testing.T) {
 		type Param struct {
 			dig.In

--- a/dig_test.go
+++ b/dig_test.go
@@ -1380,6 +1380,29 @@ func TestGroups(t *testing.T) {
 		assert.Contains(t, err.Error(), "flatten can be applied to slices only")
 	})
 
+	t.Run("check providers for value groups aren't called if only they're provided", func(t *testing.T) {
+		type Param struct {
+			dig.In
+
+			Values []string `group:"foo,soft"`
+		}
+		type Result struct {
+			dig.Out
+
+			Value string `group:"foo"`
+		}
+		c := digtest.New(t)
+
+		c.RequireProvide(func() (Result, int) {
+			require.FailNow(t, "This shouldn't be called")
+			return Result{Value: "sad times"}, 20
+		})
+
+		c.RequireInvoke(func(p Param) {
+			assert.ElementsMatch(t, []string{}, p.Values)
+		})
+	})
+
 	t.Run("soft value group", func(t *testing.T) {
 		type Param1 struct {
 			dig.In

--- a/dig_test.go
+++ b/dig_test.go
@@ -53,7 +53,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.NotNil(t, got, "invoke got nil buffer")
 			require.True(t, got == b, "invoke got wrong buffer")
 		})
-
 	})
 
 	t.Run("nil pointer constructor", func(t *testing.T) {
@@ -65,7 +64,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(b *bytes.Buffer) {
 			require.Nil(t, b, "expected to get nil buffer")
 		})
-
 	})
 
 	t.Run("struct constructor", func(t *testing.T) {
@@ -80,7 +78,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			// ensure we're getting back the buffer we put in
 			require.Equal(t, "foo", b.String(), "invoke got new buffer")
 		})
-
 	})
 
 	t.Run("slice constructor", func(t *testing.T) {
@@ -96,7 +93,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.True(t, b1 == bs[0], "first item did not match")
 			require.True(t, b2 == bs[1], "second item did not match")
 		})
-
 	})
 
 	t.Run("array constructor", func(t *testing.T) {
@@ -106,7 +102,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(bs [1]*bytes.Buffer) {
 			require.NotNil(t, bs[0], "invoke got new array")
 		})
-
 	})
 
 	t.Run("map constructor", func(t *testing.T) {
@@ -118,7 +113,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(m map[string]string) {
 			require.NotNil(t, m, "invoke got zero value map")
 		})
-
 	})
 
 	t.Run("channel constructor", func(t *testing.T) {
@@ -130,7 +124,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(ch chan int) {
 			require.NotNil(t, ch, "invoke got nil chan")
 		})
-
 	})
 
 	t.Run("func constructor", func(t *testing.T) {
@@ -142,7 +135,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(f func(int)) {
 			require.NotNil(t, f, "invoke got nil function pointer")
 		})
-
 	})
 
 	t.Run("interface constructor", func(t *testing.T) {
@@ -154,7 +146,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(w io.Writer) {
 			require.NotNil(t, w, "invoke got nil interface")
 		})
-
 	})
 
 	t.Run("param", func(t *testing.T) {
@@ -178,7 +169,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.NoError(t, err, "read from buffer failed")
 			require.Equal(t, "hello world", string(out), "contents don't match")
 		})
-
 	})
 
 	t.Run("invoke param", func(t *testing.T) {
@@ -196,7 +186,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(args Args) {
 			require.NotNil(t, args.Buffer, "invoke got nil buffer")
 		})
-
 	})
 
 	t.Run("param wrapper", func(t *testing.T) {
@@ -226,7 +215,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.NotNil(t, args.Buffer, "invoke got nil buffer")
 			require.True(t, args.Buffer == buff, "buffer must match constructor's return value")
 		})
-
 	})
 
 	t.Run("param recurse", func(t *testing.T) {
@@ -265,7 +253,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.True(t, p.Buffer == p.Another.Buffer, "buffers fields must match")
 			require.True(t, p.Buffer == buff, "buffer must match constructor's return value")
 		})
-
 	})
 
 	t.Run("multiple-type constructor", func(t *testing.T) {
@@ -334,7 +321,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireProvide(func() *bytes.Buffer {
 			return &bytes.Buffer{}
 		})
-
 	})
 
 	t.Run("optional param field", func(t *testing.T) {
@@ -365,7 +351,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.NotNil(t, p.T4, "optional type in the graph should not return nil")
 			assert.Nil(t, p.T5, "optional type not in the graph should return nil")
 		})
-
 	})
 
 	t.Run("ignore unexported fields", func(t *testing.T) {
@@ -390,7 +375,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.NotNil(t, p.T2, "optional type in the graph should not return nil")
 			assert.Nil(t, p.t3, "unexported field should not be set")
 		})
-
 	})
 
 	t.Run("out type inserts multiple objects into the graph", func(t *testing.T) {
@@ -415,7 +399,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.True(t, myA == a, "should get the same pointer for &A")
 			assert.Equal(t, b, myB, "b and myB should be equal")
 		})
-
 	})
 
 	t.Run("constructor with optional", func(t *testing.T) {
@@ -440,7 +423,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(got *type2) {
 			require.True(t, got == gave, "type2 reference must be the same")
 		})
-
 	})
 
 	t.Run("nested dependencies", func(t *testing.T) {
@@ -458,7 +440,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, b, B{"A->B"})
 			assert.Equal(t, c, C{"AB->C"})
 		})
-
 	})
 
 	t.Run("primitives", func(t *testing.T) {
@@ -476,7 +457,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, "piper", s)
 			assert.Equal(t, 10*time.Second, d)
 		})
-
 	})
 
 	t.Run("out types recurse", func(t *testing.T) {
@@ -509,7 +489,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(a *A, b *B, c C) {
 			require.NotNil(t, a, "*A should be part of the container through Ret2->Ret1")
 		})
-
 	})
 
 	t.Run("named instances can be created with tags", func(t *testing.T) {
@@ -540,7 +519,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, 1, p.A1.idx)
 			assert.Equal(t, 3, p.A3.idx)
 		})
-
 	})
 
 	t.Run("named instances can be created with Name option", func(t *testing.T) {
@@ -567,7 +545,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, 1, p.A1.idx)
 			assert.Equal(t, 3, p.A3.idx)
 		})
-
 	})
 
 	t.Run("named and unnamed instances coexist", func(t *testing.T) {
@@ -593,7 +570,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, 1, i.A1.idx)
 			assert.Equal(t, 2, i.A2.idx)
 		})
-
 	})
 
 	t.Run("named instances recurse", func(t *testing.T) {
@@ -629,7 +605,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, 1, p.A1.idx)
 			assert.Equal(t, 2, p.A2.idx)
 		})
-
 	})
 
 	t.Run("named instances do not cause cycles", func(t *testing.T) {
@@ -666,7 +641,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, 1, p.A1.idx)
 			assert.Equal(t, 2, p.A2.idx)
 		})
-
 	})
 
 	t.Run("struct constructor with as interface option", func(t *testing.T) {
@@ -690,7 +664,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		require.Error(t, c.Invoke(func(*bytes.Buffer) {
 			t.Fatalf("must not be called")
 		}), "must not have a *bytes.Buffer in the container")
-
 	})
 
 	t.Run("As with Name", func(t *testing.T) {
@@ -720,7 +693,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireProvide(func() io.Reader {
 			panic("this function should not be called")
 		}, dig.As(new(io.Reader)))
-
 	})
 
 	t.Run("As different interface", func(t *testing.T) {
@@ -728,7 +700,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireProvide(func() io.ReadCloser {
 			panic("this function should not be called")
 		}, dig.As(new(io.Reader), new(io.Closer)))
-
 	})
 
 	t.Run("invoke on a type that depends on named parameters", func(t *testing.T) {
@@ -762,7 +733,6 @@ func TestEndToEndSuccess(t *testing.T) {
 		c.RequireInvoke(func(b *B) {
 			require.Equal(t, 3, b.sum)
 		})
-
 	})
 
 	t.Run("optional and named ordering doesn't matter", func(t *testing.T) {
@@ -819,7 +789,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.True(t, called1)
 			assert.True(t, called2)
 		})
-
 	})
 
 	t.Run("dynamically generated dig.In", func(t *testing.T) {
@@ -937,7 +906,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			assert.Equal(t, &A{Value: 2}, p.Bar, "Bar must match")
 			assert.Nil(t, p.Baz, "Baz must be unset")
 		})
-
 	})
 
 	t.Run("variadic arguments invoke", func(t *testing.T) {
@@ -960,7 +928,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.True(t, a == gaveA, "A must match")
 			require.Empty(t, as, "varargs must be empty")
 		})
-
 	})
 
 	t.Run("variadic arguments dependency", func(t *testing.T) {
@@ -992,7 +959,6 @@ func TestEndToEndSuccess(t *testing.T) {
 			require.NotNil(t, b, "B must not be nil")
 			require.True(t, b == gaveB, "B must match")
 		})
-
 	})
 
 	t.Run("non-error return arguments from invoke are ignored", func(t *testing.T) {
@@ -1027,7 +993,6 @@ func TestGroups(t *testing.T) {
 		c.RequireInvoke(func(i in) {
 			require.Empty(t, i.Values)
 		})
-
 	})
 
 	t.Run("values are provided", func(t *testing.T) {
@@ -1043,7 +1008,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() out {
 				return out{Value: i}
 			})
-
 		}
 
 		provide(1)
@@ -1059,7 +1023,6 @@ func TestGroups(t *testing.T) {
 		c.RequireInvoke(func(i in) {
 			assert.Equal(t, []int{2, 3, 1}, i.Values)
 		})
-
 	})
 
 	t.Run("groups are provided via option", func(t *testing.T) {
@@ -1069,7 +1032,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() int {
 				return i
 			}, dig.Group("val"))
-
 		}
 
 		provide(1)
@@ -1085,7 +1047,6 @@ func TestGroups(t *testing.T) {
 		c.RequireInvoke(func(i in) {
 			assert.Equal(t, []int{2, 3, 1}, i.Values)
 		})
-
 	})
 
 	t.Run("different types may be grouped", func(t *testing.T) {
@@ -1095,7 +1056,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() (int, string) {
 				return i, s
 			}, dig.Group("val"))
-
 		}
 
 		provide(1, "a")
@@ -1113,7 +1073,6 @@ func TestGroups(t *testing.T) {
 			assert.Equal(t, []int{2, 3, 1}, i.Ivalues)
 			assert.Equal(t, []string{"a", "c", "b"}, i.Svalues)
 		})
-
 	})
 
 	t.Run("group options may not be provided for result structs", func(t *testing.T) {
@@ -1149,7 +1108,6 @@ func TestGroups(t *testing.T) {
 				calls[i]++
 				return out{Result: i}
 			})
-
 		}
 
 		provide("foo")
@@ -1174,7 +1132,6 @@ func TestGroups(t *testing.T) {
 			c.RequireInvoke(func(i in) {
 				require.Equal(t, want, i.Results)
 			})
-
 		}
 
 		for s, v := range calls {
@@ -1195,7 +1152,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() out {
 				return out{Result: strings}
 			})
-
 		}
 
 		provideStrings("1", "2")
@@ -1224,7 +1180,6 @@ func TestGroups(t *testing.T) {
 				"6": {}, "7": {}, "8": {}, "9": {}, "10": {},
 			}, got)
 		})
-
 	})
 
 	t.Run("provide multiple values", func(t *testing.T) {
@@ -1239,7 +1194,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() (outInt, error) {
 				return outInt{Int: i}, nil
 			})
-
 		}
 
 		type outString struct {
@@ -1251,7 +1205,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() outString {
 				return outString{String: s}
 			})
-
 		}
 
 		type outBoth struct {
@@ -1265,7 +1218,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() (outBoth, error) {
 				return outBoth{Int: i, String: s}, nil
 			})
-
 		}
 
 		provideInt(1)
@@ -1291,7 +1243,6 @@ func TestGroups(t *testing.T) {
 				Strings: []string{"foo", "bar", "baz", "quux", "qux"},
 			}, got)
 		})
-
 	})
 
 	t.Run("duplicate values are supported", func(t *testing.T) {
@@ -1307,7 +1258,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() out {
 				return out{Result: i}
 			})
-
 		}
 
 		provide("a")
@@ -1332,7 +1282,6 @@ func TestGroups(t *testing.T) {
 				stringSlice{"d", "c", "a", "a", "d", "e", "b", "a"},
 				i.Strings)
 		})
-
 	})
 
 	t.Run("failure to build a grouped value fails everything", func(t *testing.T) {
@@ -1391,7 +1340,6 @@ func TestGroups(t *testing.T) {
 			c.RequireProvide(func() out {
 				return out{Value: i}
 			})
-
 		}
 
 		provide([]int{1, 2})
@@ -1406,7 +1354,6 @@ func TestGroups(t *testing.T) {
 		c.RequireInvoke(func(i in) {
 			assert.Equal(t, []int{2, 3, 4, 1}, i.Values)
 		})
-
 	})
 
 	t.Run("flatten via option", func(t *testing.T) {
@@ -1424,7 +1371,6 @@ func TestGroups(t *testing.T) {
 		c.RequireInvoke(func(i in) {
 			assert.Equal(t, []int{2, 3, 1}, i.Values)
 		})
-
 	})
 
 	t.Run("flatten via option error if not a slice", func(t *testing.T) {
@@ -1432,6 +1378,89 @@ func TestGroups(t *testing.T) {
 		err := c.Provide(func() int { return 1 }, dig.Group("val,flatten"))
 		require.Error(t, err, "failed to provide")
 		assert.Contains(t, err.Error(), "flatten can be applied to slices only")
+	})
+
+	t.Run("soft value group", func(t *testing.T) {
+		type Param1 struct {
+			dig.In
+
+			Values []string `group:"foo,soft"`
+		}
+		type Result struct {
+			dig.Out
+
+			Value1 string `group:"foo"`
+			Value2 int
+		}
+
+		c := digtest.New(t)
+		c.RequireProvide(func() Result { return Result{Value1: "a", Value2: 2} })
+		c.RequireProvide(func() string { return "b" }, dig.Group("foo"))
+
+		// The only value that must be in the group is the one that's provided
+		// because it would be provided anyways by another dependency, in
+		// this case we need an int, so the first constructor is called, and
+		// this provides a string, which is the one in the group
+		c.RequireInvoke(func(p2 int, p1 Param1) {
+			assert.ElementsMatch(t, []string{"a"}, p1.Values)
+		})
+	})
+
+	t.Run("two soft group values provided by one constructor", func(t *testing.T) {
+		type param struct {
+			dig.In
+
+			Value1 []string `group:"foo,soft"`
+			Value2 []int    `group:"bar,soft"`
+			Value3 float32
+		}
+
+		type result struct {
+			dig.Out
+
+			Result1 []string `group:"foo,flatten"`
+			Result2 int      `group:"bar"`
+		}
+		c := digtest.New(t)
+
+		c.RequireProvide(func() result {
+			return result{
+				Result1: []string{"a", "b", "c"},
+				Result2: 4,
+			}
+		})
+		c.RequireProvide(func() float32 { return 3.1416 })
+
+		c.RequireInvoke(func(p param) {
+			assert.ElementsMatch(t, []string{}, p.Value1)
+			assert.ElementsMatch(t, []int{}, p.Value2)
+			assert.Equal(t, float32(3.1416), p.Value3)
+		})
+	})
+
+	t.Run("value group provided after a hard dependency is provided", func(t *testing.T) {
+		type Param struct {
+			dig.In
+
+			Value []string `group:"foo,soft"`
+		}
+
+		type Result struct {
+			dig.Out
+
+			Value1 string `group:"foo"`
+		}
+
+		c := digtest.New(t)
+		c.Provide(func() (Result, int) { return Result{Value1: "a"}, 2 })
+
+		c.RequireInvoke(func(param Param) {
+			assert.ElementsMatch(t, []string{}, param.Value)
+		})
+		c.RequireInvoke(func(int) {})
+		c.RequireInvoke(func(param Param) {
+			assert.ElementsMatch(t, []string{"a"}, param.Value)
+		})
 	})
 }
 
@@ -1561,7 +1590,6 @@ func TestProvideRespectsConstructorErrors(t *testing.T) {
 		c.RequireInvoke(func(b *bytes.Buffer) {
 			require.NotNil(t, b, "invoke got nil buffer")
 		})
-
 	})
 	t.Run("constructor fails", func(t *testing.T) {
 		c := digtest.New(t)
@@ -1628,7 +1656,6 @@ func TestProvideWithWeirdNames(t *testing.T) {
 		c.RequireInvoke(func(p params) {
 			assert.Equal(t, &type1{value: 42}, p.T)
 		})
-
 	})
 
 	t.Run("name with newline", func(t *testing.T) {
@@ -1649,7 +1676,6 @@ func TestProvideWithWeirdNames(t *testing.T) {
 		c.RequireInvoke(func(p params) {
 			assert.Equal(t, &type1{value: 42}, p.T)
 		})
-
 	})
 }
 
@@ -3517,7 +3543,6 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 			require.NotNil(t, got, "invoke got nil buffer")
 			require.True(t, got == b, "invoke got wrong buffer")
 		})
-
 	})
 
 	t.Run("duplicate provide", func(t *testing.T) {
@@ -3598,9 +3623,6 @@ func TestEndToEndSuccessWithAliases(t *testing.T) {
 			assert.Equal(t, "a", p.A3.s, "A3 should match")
 			assert.Equal(t, "b", p.B3.s, "B3 should match")
 			assert.Equal(t, "c", p.C3.s, "C3 should match")
-
 		})
-
 	})
-
 }

--- a/group.go
+++ b/group.go
@@ -32,6 +32,7 @@ const (
 type group struct {
 	Name    string
 	Flatten bool
+	Soft    bool
 }
 
 type errInvalidGroupOption struct{ Option string }
@@ -47,6 +48,8 @@ func parseGroupString(s string) (group, error) {
 		switch c {
 		case "flatten":
 			g.Flatten = true
+		case "soft":
+			g.Soft = true
 		default:
 			return g, errInvalidGroupOption{Option: c}
 		}

--- a/group_test.go
+++ b/group_test.go
@@ -44,6 +44,11 @@ func TestParseGroup(t *testing.T) {
 			wantG: group{Name: "somegroup", Flatten: true},
 		},
 		{
+			name:  "soft group",
+			group: "somegroup,soft",
+			wantG: group{Name: "somegroup", Soft: true},
+		},
+		{
 			name:    "error",
 			group:   `somegroup,abc`,
 			wantErr: `invalid option "abc"`,

--- a/param.go
+++ b/param.go
@@ -401,8 +401,7 @@ func (po paramObject) Build(c containerStore) (reflect.Value, error) {
 	var softGroupsQueue []paramObjectField
 	var fields []paramObjectField
 	for _, f := range po.Fields {
-		p, ok := f.Param.(paramGroupedSlice)
-		if ok && p.Soft {
+		if p, ok := f.Param.(paramGroupedSlice); ok && p.Soft {
 			softGroupsQueue = append(softGroupsQueue, f)
 			continue
 		}
@@ -499,7 +498,9 @@ type paramGroupedSlice struct {
 	// Type of the slice.
 	Type reflect.Type
 
-	// Soft
+	// Soft is used to denote a soft dependency between this param and its
+	// constructors, if it's true its constructors are only called if they
+	// provide another value requested in the graph
 	Soft bool
 
 	orders map[*Scope]int

--- a/result.go
+++ b/result.go
@@ -90,6 +90,10 @@ func newResult(t reflect.Type, opts resultOptions) (result, error) {
 				"cannot parse group %q", opts.Group, err)
 		}
 		rg := resultGrouped{Type: t, Group: g.Name, Flatten: g.Flatten}
+		if g.Soft {
+			return nil, errf("cannot use soft with result value groups",
+				"soft was used with group:%q", g.Name)
+		}
 		if g.Flatten {
 			if t.Kind() != reflect.Slice {
 				return nil, errf(
@@ -469,6 +473,9 @@ func newResultGrouped(f reflect.StructField) (resultGrouped, error) {
 	case g.Flatten && f.Type.Kind() != reflect.Slice:
 		return rg, errf("flatten can be applied to slices only",
 			"field %q (%v) is not a slice", f.Name, f.Type)
+	case g.Soft:
+		return rg, errf("cannot use soft with result value groups",
+			"soft was used with group:%q", rg.Group)
 	case name != "":
 		return rg, errf(
 			"cannot use named values with value groups",

--- a/result.go
+++ b/result.go
@@ -475,7 +475,7 @@ func newResultGrouped(f reflect.StructField) (resultGrouped, error) {
 			"field %q (%v) is not a slice", f.Name, f.Type)
 	case g.Soft:
 		return rg, errf("cannot use soft with result value groups",
-			"soft was used with group:%q", rg.Group)
+			"soft was used with group %q", rg.Group)
 	case name != "":
 		return rg, errf(
 			"cannot use named values with value groups",

--- a/result_test.go
+++ b/result_test.go
@@ -191,7 +191,6 @@ func TestNewResultObject(t *testing.T) {
 			assert.Equal(t, tt.wantFields, got.Fields)
 		})
 	}
-
 }
 
 func TestNewResultObjectErrors(t *testing.T) {
@@ -287,6 +286,15 @@ func TestNewResultObjectErrors(t *testing.T) {
 				Writer io.Writer `group:"writers,flatten"`
 			}{},
 			err: "flatten can be applied to slices only",
+		},
+		{
+			desc: "soft on value group",
+			give: struct {
+				Out
+
+				Fries []struct{} `group:"potato,flatten,soft"`
+			}{},
+			err: "cannot use soft with result value groups",
 		},
 	}
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -89,7 +89,7 @@ func TestScopedOperations(t *testing.T) {
 		child.RequireInvoke(verifyChildStr)
 	})
 
-	t.Run("provides to top-level Container propogates to all scopes", func(t *testing.T) {
+	t.Run("provides to top-level Container propagates to all scopes", func(t *testing.T) {
 		type A struct{}
 
 		// Scope tree:
@@ -355,14 +355,12 @@ func TestScopeValueGroups(t *testing.T) {
 			root.RequireInvoke(func(i param) {
 				assert.ElementsMatch(t, []string{"a", "b", "c"}, i.Values)
 			})
-
 		})
 
 		t.Run("invoke child", func(t *testing.T) {
 			child.RequireInvoke(func(i param) {
 				assert.ElementsMatch(t, []string{"a", "b", "c", "d"}, i.Values)
 			})
-
 		})
 	})
 


### PR DESCRIPTION
This adds the soft attribute to value parameter value groups. Types in
a soft value group won't call their providers if they are the only value
that it's provided by these constructors. This helps to avoid providing
unnecessary values to the dependency graph and also prevent calling
unnecessary constructors.

Example:
```
type Param struct {
    dig.In

    Values []string `group:"foo,soft"`
}
type Result1 struct {
    dig.Out

    Value1 string `group:"foo"`
}

// This constructor won't be called as it only provides a value to the
// soft group
func Result1Ctr() Result1 {
    return Result1{ Value1: "hello" }
}
type Result2 struct {
    dig.Out

    Value1 string `group:"foo"`
    Value2 int
}

// This constructor will be called as we need the provided integer
func Result2Ctr() Result2 {
    return Result2{ Value1: "bye", Value2: 10 }
}

c := dig.New()
c.Provide(Result1Ctr)
c.Provide(Result2Ctr)
// The string "bye" is provided because its constructor is called anways
c.Invoke(func(num int, p Param) {
    // p.Values = {"bye"}
    // num = 10
})
```