### PR TITLE
go.mod: Set 'go' to 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.x", "1.18.x", "1.19.x"]
+        go: ["1.18.x", "1.19.x"]
         include:
         - go: 1.19.x
           latest: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/dig
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.7.1
 


### PR DESCRIPTION
Set the go directive in go.mod to 1.18.
This will allow use of features introduced in Go 1.18.
Go 1.19 was released some time ago, and 1.20 is around the corner,
so there's no reason to support 1.17.
