### PR TITLE
Stop Decorator Running When Dry Run Set

### DIFF
--- a/decorate.go
+++ b/decorate.go
@@ -128,7 +128,7 @@ func (n *decoratorNode) Call(s containerStore) (err error) {
 		}
 	}
 
-	results := reflect.ValueOf(n.dcor).Call(args)
+	results := s.invoker()(reflect.ValueOf(n.dcor), args)
 	if err := n.results.ExtractList(n.s, true /* decorated */, results); err != nil {
 		return err
 	}

--- a/dig_test.go
+++ b/dig_test.go
@@ -2050,6 +2050,22 @@ func TestDryModeSuccess(t *testing.T) {
 		c.RequireProvide(provides)
 		c.RequireInvoke(invokes)
 	})
+	t.Run("does not call decorators", func(t *testing.T) {
+		type type1 struct{}
+		provides := func() *type1 {
+			t.Fatal("must not be called")
+			return &type1{}
+		}
+		decorates := func(*type1) *type1 {
+			t.Fatal("must not be called")
+			return &type1{}
+		}
+		invokes := func(*type1) {}
+		c := digtest.New(t, dig.DryRun(true))
+		c.RequireProvide(provides)
+		c.RequireDecorate(decorates)
+		c.RequireInvoke(invokes)
+	})
 }
 
 func TestProvideCycleFails(t *testing.T) {


### PR DESCRIPTION
Currently, decorators still run even when dry run is set in the container (see Fx issue: https://github.com/uber-go/fx/issues/1018)

This changes decorators to use the scope's invoker when decorating, causing it to fill-in zero-valued results instead of actually running the function when the dry run option is set.