### PR TITLE
Allow using dig.As with dig.Group

### DIFF
--- a/decorate_test.go
+++ b/decorate_test.go
@@ -38,6 +38,8 @@ type myInt interface {
 }
 type someInt int
 
+var _ myInt = (*someInt)(nil)
+
 func newSomeInt(i int) *someInt {
 	v := someInt(i)
 	return &v

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -32,6 +32,25 @@ import (
 	"go.uber.org/dig/internal/digtest"
 )
 
+type myInt interface {
+	String() string
+	Increment()
+}
+type someInt int
+
+func newSomeInt(i int) *someInt {
+	v := someInt(i)
+	return &v
+}
+
+func (i *someInt) String() string {
+	return fmt.Sprintf("%d", i)
+}
+
+func (i *someInt) Increment() {
+	*i += 1
+}
+
 func TestDecorateSuccess(t *testing.T) {
 	t.Run("simple decorate without names or groups", func(t *testing.T) {
 		t.Parallel()
@@ -121,6 +140,35 @@ func TestDecorateSuccess(t *testing.T) {
 		child.RequireInvoke(func(a *A, b B) {
 			assert.Equal(t, "A'", a.Name, "expected name to equal decorated name in child scope")
 			assert.ElementsMatch(t, []string{"val1'", "val2'", "val3'"}, b.Values)
+		})
+	})
+
+	t.Run("decorate grouped values provided as", func(t *testing.T) {
+		t.Parallel()
+
+		type A struct {
+			dig.In
+			Values []myInt `group:"values"`
+		}
+
+		type B struct {
+			dig.Out
+			Values []myInt `group:"values"`
+		}
+
+		c := digtest.New(t)
+
+		c.RequireProvide(func() *someInt { return newSomeInt(0) }, dig.Group("values"), dig.As(new(myInt)))
+		c.RequireProvide(func() *someInt { return newSomeInt(1) }, dig.Group("values"), dig.As(new(myInt)))
+		c.RequireProvide(func() *someInt { return newSomeInt(2) }, dig.Group("values"), dig.As(new(myInt)))
+		c.Decorate(func(in A) B {
+			for _, v := range in.Values {
+				v.Increment()
+			}
+			return B{Values: in.Values}
+		})
+		c.RequireInvoke(func(a A) {
+			assert.ElementsMatch(t, []myInt{newSomeInt(1), newSomeInt(2), newSomeInt(3)}, a.Values)
 		})
 	})
 

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -160,9 +160,10 @@ func TestDecorateSuccess(t *testing.T) {
 
 		c := digtest.New(t)
 
-		c.RequireProvide(func() *someInt { return newSomeInt(0) }, dig.Group("values"), dig.As(new(myInt)))
-		c.RequireProvide(func() *someInt { return newSomeInt(1) }, dig.Group("values"), dig.As(new(myInt)))
-		c.RequireProvide(func() *someInt { return newSomeInt(2) }, dig.Group("values"), dig.As(new(myInt)))
+		for i := range make([]int, 3) {
+			i := i
+			c.RequireProvide(func() *someInt { return newSomeInt(i) }, dig.Group("values"), dig.As(new(myInt)))
+		}
 		c.Decorate(func(in A) B {
 			for _, v := range in.Values {
 				v.Increment()

--- a/dig_test.go
+++ b/dig_test.go
@@ -752,14 +752,16 @@ func TestEndToEndSuccess(t *testing.T) {
 	t.Run("As same interface", func(t *testing.T) {
 		c := digtest.New(t)
 		c.RequireProvide(func() io.Reader {
-			panic("this function should not be called")
+			t.Fatal("this function should not be called")
+			return nil
 		}, dig.As(new(io.Reader)))
 	})
 
 	t.Run("As same interface with Group", func(t *testing.T) {
 		c := digtest.New(t)
 		c.RequireProvide(func() io.Reader {
-			panic("this function should not be called")
+			t.Fatal("this function should not be called")
+			return nil
 		}, dig.As(new(io.Reader)), dig.Group("readers"))
 	})
 
@@ -989,7 +991,8 @@ func TestEndToEndSuccess(t *testing.T) {
 		})
 
 		c.RequireProvide(func() []*A {
-			panic("[]*A constructor must not be called.")
+			t.Fatal("[]*A constructor must not be called.")
+			return nil
 		})
 
 		c.RequireInvoke(func(a *A, as ...*A) {
@@ -1012,7 +1015,8 @@ func TestEndToEndSuccess(t *testing.T) {
 		})
 
 		c.RequireProvide(func() []*A {
-			panic("[]*A constructor must not be called.")
+			t.Fatal("[]*A constructor must not be called.")
+			return nil
 		})
 
 		var gaveB *B
@@ -1849,7 +1853,8 @@ func TestProvideInvalidName(t *testing.T) {
 
 	c := digtest.New(t)
 	err := c.Provide(func() io.Reader {
-		panic("this function must not be called")
+		t.Fatal("this function must not be called")
+		return nil
 	}, dig.Name("foo`bar"))
 	require.Error(t, err, "Provide must fail")
 	assert.Contains(t, err.Error(), "invalid dig.Name(\"foo`bar\"): names cannot contain backquotes")
@@ -1860,13 +1865,15 @@ func TestProvideInvalidGroup(t *testing.T) {
 
 	c := digtest.New(t)
 	err := c.Provide(func() io.Reader {
-		panic("this function must not be called")
+		t.Fatal("this function must not be called")
+		return nil
 	}, dig.Group("foo`bar"))
 	require.Error(t, err, "Provide must fail")
 	assert.Contains(t, err.Error(), "invalid dig.Group(\"foo`bar\"): group names cannot contain backquotes")
 
 	err = c.Provide(func() io.Reader {
-		panic("this function must not be called")
+		t.Fatal("this function must not be called")
+		return nil
 	}, dig.Group("foo,bar"))
 	require.Error(t, err, "Provide must fail")
 	assert.Contains(t, err.Error(), `cannot parse group "foo,bar": invalid option "bar"`)
@@ -1997,7 +2004,8 @@ func TestProvideIncompatibleOptions(t *testing.T) {
 	t.Run("group and name", func(t *testing.T) {
 		c := digtest.New(t)
 		err := c.Provide(func() io.Reader {
-			panic("this function must not be called")
+			t.Fatal("this function must not be called")
+			return nil
 		}, dig.Group("foo"), dig.Name("bar"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot use named values with value groups: "+
@@ -2770,7 +2778,8 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 		c := digtest.New(t, dig.DryRun(dryRun))
 
 		c.RequireProvide(func(p param) *type3 {
-			panic("function must not be called")
+			t.Fatal("function must not be called")
+			return nil
 		})
 
 		err := c.Invoke(func(*type3) {
@@ -2798,11 +2807,13 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 		c := digtest.New(t, dig.DryRun(dryRun))
 
 		c.RequireProvide(func() type2 {
-			panic("function must not be called")
+			t.Fatal("function must not be called")
+			return type2{}
 		})
 
 		c.RequireProvide(func(type1, *type2) type3 {
-			panic("function must not be called")
+			t.Fatal("function must not be called")
+			return type3{}
 		})
 
 		err := c.Invoke(func(type3) {
@@ -2858,7 +2869,8 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 
 		c := digtest.New(t, dig.DryRun(dryRun))
 		err := c.Provide(func(a args) *type1 {
-			panic("function must not be called")
+			t.Fatal("function must not be called")
+			return nil
 		})
 
 		require.Error(t, err, "expected provide error")
@@ -2887,7 +2899,8 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 		// Container has a constructor for *dep, but that constructor has unmet
 		// dependencies.
 		c.RequireProvide(func(missing) *dep {
-			panic("constructor for *dep should not be called")
+			t.Fatal("constructor for *dep should not be called")
+			return nil
 		})
 
 		// Should still be able to invoke a function that takes params, since *dep
@@ -2918,13 +2931,14 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 		})
 
 		c.RequireProvide(func(*failed) *dep {
-			panic("constructor for *dep should not be called")
+			t.Fatal("constructor for *dep should not be called")
+			return nil
 		})
 
 		// Should still be able to invoke a function that takes params, since *dep
 		// is optional.
 		err := c.Invoke(func(p params) {
-			panic("shouldn't execute invoked function")
+			t.Fatal("shouldn't execute invoked function")
 		})
 		require.Error(t, err, "expected invoke error")
 		dig.AssertErrorMatches(t, err,
@@ -3282,7 +3296,7 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 			return A{}, errors.New("great sadness")
 		})
 
-		err := c.Invoke(func(A) { panic("impossible") })
+		err := c.Invoke(func(A) { t.Fatal("invoke function should not be called") })
 
 		require.Error(t, err, "expected Invoke error")
 		dig.AssertErrorMatches(t, err,
@@ -3307,7 +3321,7 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 			return B{}, nil
 		})
 
-		err := c.Invoke(func(B) { panic("impossible") })
+		err := c.Invoke(func(B) { t.Fatal("invoke function should not be called") })
 
 		require.Error(t, err, "expected Invoke error")
 		dig.AssertErrorMatches(t, err,
@@ -3337,7 +3351,7 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 			A A
 		}
 
-		err := c.Invoke(func(params) { panic("impossible") })
+		err := c.Invoke(func(params) { t.Fatal("invoke function should not be called") })
 
 		require.Error(t, err, "expected Invoke error")
 		dig.AssertErrorMatches(t, err,
@@ -3370,7 +3384,7 @@ func testInvokeFailures(t *testing.T, dryRun bool) {
 			return B{}, nil
 		})
 
-		err := c.Invoke(func(B) { panic("impossible") })
+		err := c.Invoke(func(B) { t.Fatal("invoke function should not be called") })
 
 		require.Error(t, err, "expected Invoke error")
 		dig.AssertErrorMatches(t, err,

--- a/provide.go
+++ b/provide.go
@@ -51,10 +51,6 @@ func (o *provideOptions) Validate() error {
 			return newErrInvalidInput(
 				fmt.Sprintf("cannot use named values with value groups: name:%q provided with group:%q", o.Name, o.Group), nil)
 		}
-		if len(o.As) > 0 {
-			return newErrInvalidInput(
-				fmt.Sprintf("cannot use dig.As with value groups: dig.As provided with group:%q", o.Group), nil)
-		}
 	}
 
 	// Names must be representable inside a backquoted string. The only
@@ -639,6 +635,11 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 		// value there.
 		k := key{group: r.Group, t: r.Type}
 		cv.keyPaths[k] = path
+		for _, asType := range r.As {
+			k := key{group: r.Group, t: asType}
+			cv.keyPaths[k] = path
+		}
+
 	}
 
 	return cv

--- a/provide.go
+++ b/provide.go
@@ -639,7 +639,6 @@ func (cv connectionVisitor) Visit(res result) resultVisitor {
 			k := key{group: r.Group, t: asType}
 			cv.keyPaths[k] = path
 		}
-
 	}
 
 	return cv

--- a/result.go
+++ b/result.go
@@ -88,6 +88,26 @@ func newResult(t reflect.Type, opts resultOptions) (result, error) {
 				fmt.Sprintf("cannot parse group %q", opts.Group), err)
 		}
 		rg := resultGrouped{Type: t, Group: g.Name, Flatten: g.Flatten}
+		if len(opts.As) > 0 {
+			var asTypes []reflect.Type
+			for _, as := range opts.As {
+				ifaceType := reflect.TypeOf(as).Elem()
+				if ifaceType == t {
+					continue
+				}
+				if !t.Implements(ifaceType) {
+					return nil, newErrInvalidInput(
+						fmt.Sprintf("invalid dig.As: %v does not implement %v", t, ifaceType), nil)
+				}
+				asTypes = append(asTypes, ifaceType)
+			}
+			if len(asTypes) > 0 {
+				rg.Type = asTypes[0]
+				rg.As = asTypes[1:]
+			}
+
+		}
+
 		if g.Soft {
 			return nil, newErrInvalidInput(fmt.Sprintf(
 				"cannot use soft with result value groups: soft was used with group:%q", g.Name), nil)
@@ -441,17 +461,27 @@ type resultGrouped struct {
 	// as a group. Requires the value's slice to be a group. If set, Type will be
 	// the type of individual elements rather than the group.
 	Flatten bool
+
+	// If specified, this is a list of types which the value will be made
+	// available as, in addition to its own type.
+	As []reflect.Type
 }
 
 func (rt resultGrouped) DotResult() []*dot.Result {
-	return []*dot.Result{
-		{
-			Node: &dot.Node{
-				Type:  rt.Type,
-				Group: rt.Group,
-			},
+	dotResults := make([]*dot.Result, 0, len(rt.As)+1)
+	dotResults = append(dotResults, &dot.Result{
+		Node: &dot.Node{
+			Type:  rt.Type,
+			Group: rt.Group,
 		},
+	})
+
+	for _, asType := range rt.As {
+		dotResults = append(dotResults, &dot.Result{
+			Node: &dot.Node{Type: asType, Group: rt.Group},
+		})
 	}
+	return dotResults
 }
 
 // newResultGrouped(f) builds a new resultGrouped from the provided field.
@@ -491,6 +521,9 @@ func (rt resultGrouped) Extract(cw containerWriter, decorated bool, v reflect.Va
 	// Decorated values are always flattened.
 	if !decorated && !rt.Flatten {
 		cw.submitGroupedValue(rt.Group, rt.Type, v)
+		for _, asType := range rt.As {
+			cw.submitGroupedValue(rt.Group, asType, v)
+		}
 		return
 	}
 

--- a/result.go
+++ b/result.go
@@ -105,9 +105,7 @@ func newResult(t reflect.Type, opts resultOptions) (result, error) {
 				rg.Type = asTypes[0]
 				rg.As = asTypes[1:]
 			}
-
 		}
-
 		if g.Soft {
 			return nil, newErrInvalidInput(fmt.Sprintf(
 				"cannot use soft with result value groups: soft was used with group:%q", g.Name), nil)


### PR DESCRIPTION
This PR adds the ability to use dig.As with dig.Group.
When dig.As is used with dig.Group, the value produced
by the constructor will be provided to the specified group
as the type specified by dig.As.

```
 c.Provide(newBuffer, dig.As(new(io.Reader)), dig.Group("readers"))
```

For example, the above code is equivalent to the following.

```
 c.Provide(func(...) io.Reader {
   b := newBuffer(...)
   return b
 }, dig.Group("readers"))
```

Fixes #341 