### PR TITLE
Add retract directive for v1.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v1.16.0 // bad release
+)


### PR DESCRIPTION
This adds retract directive to go.mod for v1.16.0 which was a bad release causing issues like #370.

See also: https://go.dev/ref/mod#go-mod-file-retract.