### PR TITLE
Add support for getting info from Invoke statements

### DIFF
--- a/dig_test.go
+++ b/dig_test.go
@@ -3757,7 +3757,7 @@ func TestInvokeInfoOption(t *testing.T) {
 			require.NotNil(t, m, "invoke got zero value map")
 		}, dig.FillInvokeInfo(&info))
 
-		assert.Equal(t, 1, len(info.ReqTypes))
+		assert.Len(t, info.ReqTypes, 1)
 		assert.Equal(t, "map[string]string", info.ReqTypes[0].String())
 	})
 
@@ -3776,7 +3776,7 @@ func TestInvokeInfoOption(t *testing.T) {
 			require.NotNil(t, typ1, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info))
 
-		assert.Equal(t, 2, len(info.ReqTypes))
+		assert.Len(t, info.ReqTypes, 2)
 		assert.Equal(t, "map[string]string", info.ReqTypes[0].String())
 		assert.Equal(t, "*dig_test.type1", info.ReqTypes[1].String())
 	})
@@ -3795,14 +3795,14 @@ func TestInvokeInfoOption(t *testing.T) {
 		c.RequireInvoke(func(typ1 *type1) {
 			require.NotNil(t, typ1, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info1))
-		assert.Equal(t, 1, len(info1.ReqTypes))
+		assert.Len(t, info1.ReqTypes, 1)
 		assert.Equal(t, "*dig_test.type1", info1.ReqTypes[0].String())
 
 		var info2 dig.InvokeInfo
 		c.RequireInvoke(func(typ2 *type2) {
 			require.NotNil(t, typ2, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info2))
-		assert.Equal(t, 1, len(info2.ReqTypes))
+		assert.Len(t, info2.ReqTypes, 1)
 		assert.Equal(t, "*dig_test.type2", info2.ReqTypes[0].String())
 	})
 
@@ -3825,7 +3825,7 @@ func TestInvokeInfoOption(t *testing.T) {
 		c.RequireInvoke(func(p params) {
 			require.Equal(t, params{Field1: "hello", Field2: 2023}, p)
 		}, dig.FillInvokeInfo(&info))
-		assert.Equal(t, 2, len(info.ReqTypes))
+		assert.Len(t, info.ReqTypes, 2)
 		assert.Equal(t, "string", info.ReqTypes[0].String())
 		assert.Equal(t, "int", info.ReqTypes[1].String())
 	})
@@ -3849,7 +3849,7 @@ func TestInvokeInfoOption(t *testing.T) {
 		c.RequireInvoke(func(typ1 *type1) {
 			require.NotNil(t, typ1, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info))
-		assert.Equal(t, 1, len(info.ReqTypes))
+		assert.Len(t, info.ReqTypes, 1)
 		assert.Equal(t, "*dig_test.type1", info.ReqTypes[0].String())
 	})
 }

--- a/dig_test.go
+++ b/dig_test.go
@@ -3757,8 +3757,8 @@ func TestInvokeInfoOption(t *testing.T) {
 			require.NotNil(t, m, "invoke got zero value map")
 		}, dig.FillInvokeInfo(&info))
 
-		assert.Len(t, info.ReqTypes, 1)
-		assert.Equal(t, "map[string]string", info.ReqTypes[0].String())
+		assert.Len(t, info.Inputs, 1)
+		assert.Equal(t, "map[string]string", info.Inputs[0].String())
 	})
 
 	t.Run("one map, one struct ptr type requested", func(t *testing.T) {
@@ -3776,9 +3776,9 @@ func TestInvokeInfoOption(t *testing.T) {
 			require.NotNil(t, typ1, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info))
 
-		assert.Len(t, info.ReqTypes, 2)
-		assert.Equal(t, "map[string]string", info.ReqTypes[0].String())
-		assert.Equal(t, "*dig_test.type1", info.ReqTypes[1].String())
+		assert.Len(t, info.Inputs, 2)
+		assert.Equal(t, "map[string]string", info.Inputs[0].String())
+		assert.Equal(t, "*dig_test.type1", info.Inputs[1].String())
 	})
 
 	t.Run("two invokes requesting types", func(t *testing.T) {
@@ -3795,15 +3795,15 @@ func TestInvokeInfoOption(t *testing.T) {
 		c.RequireInvoke(func(typ1 *type1) {
 			require.NotNil(t, typ1, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info1))
-		assert.Len(t, info1.ReqTypes, 1)
-		assert.Equal(t, "*dig_test.type1", info1.ReqTypes[0].String())
+		assert.Len(t, info1.Inputs, 1)
+		assert.Equal(t, "*dig_test.type1", info1.Inputs[0].String())
 
 		var info2 dig.InvokeInfo
 		c.RequireInvoke(func(typ2 *type2) {
 			require.NotNil(t, typ2, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info2))
-		assert.Len(t, info2.ReqTypes, 1)
-		assert.Equal(t, "*dig_test.type2", info2.ReqTypes[0].String())
+		assert.Len(t, info2.Inputs, 1)
+		assert.Equal(t, "*dig_test.type2", info2.Inputs[0].String())
 	})
 
 	t.Run("invoke with param", func(t *testing.T) {
@@ -3825,9 +3825,9 @@ func TestInvokeInfoOption(t *testing.T) {
 		c.RequireInvoke(func(p params) {
 			require.Equal(t, params{Field1: "hello", Field2: 2023}, p)
 		}, dig.FillInvokeInfo(&info))
-		assert.Len(t, info.ReqTypes, 2)
-		assert.Equal(t, "string", info.ReqTypes[0].String())
-		assert.Equal(t, "int", info.ReqTypes[1].String())
+		assert.Len(t, info.Inputs, 2)
+		assert.Equal(t, "string", info.Inputs[0].String())
+		assert.Equal(t, "int", info.Inputs[1].String())
 	})
 
 	t.Run("invoke type with dependencies", func(t *testing.T) {
@@ -3849,8 +3849,8 @@ func TestInvokeInfoOption(t *testing.T) {
 		c.RequireInvoke(func(typ1 *type1) {
 			require.NotNil(t, typ1, "invoke got nil struct")
 		}, dig.FillInvokeInfo(&info))
-		assert.Len(t, info.ReqTypes, 1)
-		assert.Equal(t, "*dig_test.type1", info.ReqTypes[0].String())
+		assert.Len(t, info.Inputs, 1)
+		assert.Equal(t, "*dig_test.type1", info.Inputs[0].String())
 	})
 }
 

--- a/dig_test.go
+++ b/dig_test.go
@@ -3806,6 +3806,12 @@ func TestInvokeInfoOption(t *testing.T) {
 			assert.Equal(t, tt.wantStrs[i], info.Inputs[i].String())
 		}
 	}
+
+	t.Run("no error on nil InvokeInfo", func(t *testing.T) {
+		c := digtest.New(t)
+		c.RequireProvide(func() string { return "" })
+		c.RequireInvoke(func(s string) {}, dig.FillInvokeInfo(nil))
+	})
 }
 
 func TestFillInvokeInfoString(t *testing.T) {

--- a/invoke.go
+++ b/invoke.go
@@ -41,12 +41,15 @@ type InvokeInfo struct {
 	Inputs []*Input
 }
 
-// FillInvokeInfo is an InvokeOption that writes info on the types requested
-// by the Invoke function into the specified InvokeInfo.
+// FillInvokeInfo is an InvokeOption that writes information on the types
+// accepted by the Invoke function into the specified InvokeInfo.
 // For example:
 //
-//	var info dig.InvokeInfo
-//	err := c.Invoke(..., dig.FillInvokeInfo(&info))
+//			var info dig.InvokeInfo
+//			err := c.Invoke(func(string, int){}, dig.FillInvokeInfo(&info))
+//
+//	  info.Inputs[0].String() will be string.
+//	  info.Inputs[1].String() will be int.
 func FillInvokeInfo(info *InvokeInfo) InvokeOption {
 	return fillInvokeInfoOption{info: info}
 }

--- a/invoke.go
+++ b/invoke.go
@@ -43,6 +43,10 @@ type InvokeInfo struct {
 
 // FillInvokeInfo is an InvokeOption that writes info on the types requested
 // by the Invoke function into the specified InvokeInfo.
+// For example:
+//
+//	var info dig.InvokeInfo
+//	err := c.Invoke(..., dig.FillInvokeInfo(&info))
 func FillInvokeInfo(info *InvokeInfo) InvokeOption {
 	return fillInvokeInfoOption{info: info}
 }

--- a/invoke.go
+++ b/invoke.go
@@ -38,7 +38,7 @@ type invokeOptions struct {
 
 // InvokeInfo provides information about an Invoke.
 type InvokeInfo struct {
-	ReqTypes []*Output
+	Inputs []*Input
 }
 
 // FillInvokeInfo is an InvokeOption that writes info on the types requested
@@ -142,15 +142,16 @@ func (s *Scope) Invoke(function interface{}, opts ...InvokeOption) (err error) {
 	// Record info for the invoke if requested
 	if info := options.Info; info != nil {
 		params := pl.DotParam()
-
-		info.ReqTypes = make([]*Output, len(params))
+		info.Inputs = make([]*Input, len(params))
 		for i, p := range params {
-			info.ReqTypes[i] = &Output{
-				t:     p.Type,
-				name:  p.Name,
-				group: p.Group,
+			info.Inputs[i] = &Input{
+				t:        p.Type,
+				optional: p.Optional,
+				name:     p.Name,
+				group:    p.Group,
 			}
 		}
+
 	}
 
 	returned := s.invokerFn(reflect.ValueOf(function), args)


### PR DESCRIPTION
This commit exposes `InvokeInfo` and `FillInvokeInfo` to help users extract the types requested by an Invoke statement.

Example usage -

```
var info InvokeInfo
c.Invoke(func(typ1 type1, typ2 type2){}, FillInvokeInfo(&info))

// Will print the types requested by the Invoke statement
for _, typ := range info.ReqTypes {
    fmt.Println(typ) 
}

``` 

Refs: GO-669