### PR TITLE
Build value group values using their original scope

### DIFF
--- a/param.go
+++ b/param.go
@@ -606,7 +606,7 @@ func (pt paramGroupedSlice) callGroupProviders(c containerStore) (int, error) {
 		providers := c.getGroupProviders(pt.Group, pt.Type.Elem())
 		itemCount += len(providers)
 		for _, n := range providers {
-			if err := n.Call(c); err != nil {
+			if err := n.Call(n.OrigScope()); err != nil {
 				return 0, errParamGroupFailed{
 					CtorID: n.ID(),
 					Key:    key{group: pt.Group, t: pt.Type.Elem()},


### PR DESCRIPTION
We call simple providers with their original scope. ([ref](https://github.com/uber-go/dig/blob/master/param.go#L287)) This allows decorators to be applied even if the constructor is exported via `dig.Export(true)`.

However, we call value group value providers with whatever scope we found them in: ([ref](https://github.com/uber-go/dig/blob/master/param.go#L609))

This has the consequence of causing exported value group value providers within a module to not be able to be decorated by decorators within the same module, when using `dig.Export(true)`, unlike their simple provider counterpart.

For example ([playground](https://go.dev/play/p/R2uqaTvT57P)):
```go
type Foo struct{}
type FooResults struct {
	dig.Out

	Foo Foo `group:"foos"`
}

func NewFoo(s string) FooResults {
	fmt.Printf("String in NewFoo: %q\n", s)
	return FooResults{
		Foo: Foo{},
	}
}

type Bar struct{}

func NewBar(s string) Bar {
	fmt.Printf("String in NewBar: %q\n", s)
	return Bar{}
}

type UseFooAndBarParams struct {
	dig.In

	Foos []Foo `group:"foos"`
	Bar  Bar
}

func UseFooAndBar(UseFooAndBarParams) {}

func main() {
	c := dig.New()
	c.Provide(func() string { return "base" })
	child := c.Scope("child")
	child.Decorate(func(s string) string {
		return s + "-decorated"
	})
	child.Provide(NewFoo, dig.Export(true))
	child.Provide(NewBar, dig.Export(true))
}

// Output:
// String in NewFoo: "base"
// String in NewBar: "base-decorated"
```

Since we use `dig.Export(true)` by default in Fx, this is the default behavior for value group providers, see https://github.com/uber-go/fx/issues/1104

This commit changes `callGroupProviders` to use the value group provider's original scope as well, and adds a test to verify the behavior is fixed.