### PR TITLE
Feature: add outputs infos into InvokeInfo struct

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -38,7 +38,8 @@ type invokeOptions struct {
 
 // InvokeInfo provides information about an Invoke.
 type InvokeInfo struct {
-	Inputs []*Input
+	Inputs  []*Input
+	Outputs []reflect.Value
 }
 
 // FillInvokeInfo is an InvokeOption that writes information on the types
@@ -161,6 +162,12 @@ func (s *Scope) Invoke(function interface{}, opts ...InvokeOption) (err error) {
 	if len(returned) == 0 {
 		return nil
 	}
+
+	if options.Info != nil {
+		options.Info.Outputs = make([]reflect.Value, len(returned))
+		copy(options.Info.Outputs, returned)
+	}
+
 	if last := returned[len(returned)-1]; isError(last.Type()) {
 		if err, _ := last.Interface().(error); err != nil {
 			return err


### PR DESCRIPTION
As we are building a home made framework we need to get informations of the output of a invoke function. 

This can be used for instance with http handler, where we use invoke to provide dependency injection and need information for output, for instance getting Raw[T] or Json[T] or Render[T] and do some stuff based on that. 

Hope it will be useful for others. 


