### PR TITLE
Prepare release v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.17.1] - 2023-10-19
+### Added
+- Suggestions for value vs. pointer elements for slice and array types.
+
+### Fixed
+- An issue where value group values were not getting decorated
+  by decorators within the same module when using dig.Export(true).
+- A typo in docs.
+- An issue where false positives in cycle detection were occurring
+  when providing to a child scope.
+
+Thanks to @paullen and @lcarilla for their contributions to this release.
+
+[1.17.1]: https://github.com/uber-go/dig/compare/v1.17.0...v1.17.1
 
 ## [1.17.0] - 2023-05-02
 ### Added

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dig
 
 // Version of the library.
-const Version = "1.18.0-dev"
+const Version = "1.17.1"


### PR DESCRIPTION
This updates the changelog and version to 1.17.1
to prepare for tagging a new release.