### PR TITLE
Improve visualize tests

### DIFF
--- a/visualize_test.go
+++ b/visualize_test.go
@@ -449,6 +449,8 @@ func assertCtorEqual(t *testing.T, expected *dot.Ctor, ctor *dot.Ctor) {
 }
 
 func assertCtorsEqual(t *testing.T, expected []*dot.Ctor, ctors []*dot.Ctor) {
+	assert.Len(t, ctors, len(expected))
+
 	for i, c := range ctors {
 		assertCtorEqual(t, expected[i], c)
 	}

--- a/visualize_test.go
+++ b/visualize_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/dig"
 	"go.uber.org/dig/internal/digtest"
 	"go.uber.org/dig/internal/dot"
@@ -449,7 +450,7 @@ func assertCtorEqual(t *testing.T, expected *dot.Ctor, ctor *dot.Ctor) {
 }
 
 func assertCtorsEqual(t *testing.T, expected []*dot.Ctor, ctors []*dot.Ctor) {
-	assert.Len(t, ctors, len(expected))
+	require.Len(t, ctors, len(expected))
 
 	for i, c := range ctors {
 		assertCtorEqual(t, expected[i], c)


### PR DESCRIPTION
Hello!

While working on #403 I've noted that unit tests for `Visualize()` worked not correctly in some cases.
If `CreateGraph()` method returns less `Ctor` elements than expected (and vice versa) - tests will pass.

So I fixed assert function and found new bug shown by `create graph with one constructor and as interface option` scenario.
