### PR TITLE
feat: add function runtime to dig.CallbackInfo

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -35,7 +35,7 @@ type CallbackInfo struct {
 	// this will be set to a [PanicError] when the function panics.
 	Error error
 
-	// Runtime contains the duration of time it took for the associated
+	// Runtime contains the duration it took for the associated
 	// function to run.
 	Runtime time.Duration
 }

--- a/callback.go
+++ b/callback.go
@@ -20,6 +20,8 @@
 
 package dig
 
+import "time"
+
 // CallbackInfo contains information about a provided function or decorator
 // called by Dig, and is passed to a [Callback] registered with
 // [WithProviderCallback] or [WithDecoratorCallback].
@@ -32,6 +34,10 @@ type CallbackInfo struct {
 	// function, if any. When used in conjunction with [RecoverFromPanics],
 	// this will be set to a [PanicError] when the function panics.
 	Error error
+
+	// Runtime contains the duration of time it took for the associated
+	// function to run.
+	Runtime time.Duration
 }
 
 // Callback is a function that can be registered with a provided function

--- a/constructor.go
+++ b/constructor.go
@@ -161,11 +161,13 @@ func (n *constructorNode) Call(c containerStore) (err error) {
 	}
 
 	if n.callback != nil {
+		start := c.clock().Now()
 		// Wrap in separate func to include PanicErrors
 		defer func() {
 			n.callback(CallbackInfo{
-				Name:  fmt.Sprintf("%v.%v", n.location.Package, n.location.Name),
-				Error: err,
+				Name:    fmt.Sprintf("%v.%v", n.location.Package, n.location.Name),
+				Error:   err,
+				Runtime: c.clock().Since(start),
 			})
 		}()
 	}

--- a/container.go
+++ b/container.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"reflect"
 
+	"go.uber.org/dig/internal/digclock"
 	"go.uber.org/dig/internal/dot"
 )
 
@@ -141,6 +142,9 @@ type containerStore interface {
 
 	// Returns invokerFn function to use when calling arguments.
 	invoker() invokerFn
+
+	// Returns a clock to use
+	clock() digclock.Clock
 }
 
 // New constructs a Container.
@@ -209,6 +213,21 @@ func (o setRandOption) String() string {
 
 func (o setRandOption) applyOption(c *Container) {
 	c.scope.rand = o.r
+}
+
+// Changes the source of time for the container.
+func setClock(c digclock.Clock) Option {
+	return setClockOption{c: c}
+}
+
+type setClockOption struct{ c digclock.Clock }
+
+func (o setClockOption) String() string {
+	return fmt.Sprintf("setClock(%v)", o.c)
+}
+
+func (o setClockOption) applyOption(c *Container) {
+	c.scope.clockSrc = o.c
 }
 
 // DryRun is an Option which, when set to true, disables invocation of functions supplied to

--- a/decorate.go
+++ b/decorate.go
@@ -122,11 +122,13 @@ func (n *decoratorNode) Call(s containerStore) (err error) {
 	}
 
 	if n.callback != nil {
+		start := s.clock().Now()
 		// Wrap in separate func to include PanicErrors
 		defer func() {
 			n.callback(CallbackInfo{
-				Name:  fmt.Sprintf("%v.%v", n.location.Package, n.location.Name),
-				Error: err,
+				Name:    fmt.Sprintf("%v.%v", n.location.Package, n.location.Name),
+				Error:   err,
+				Runtime: s.clock().Since(start),
 			})
 		}()
 	}

--- a/dig_test.go
+++ b/dig_test.go
@@ -1798,7 +1798,7 @@ func TestCallback(t *testing.T) {
 }
 
 func TestCallbackRuntime(t *testing.T) {
-	t.Run("provided ctor runtime", func(t *testing.T) {
+	t.Run("constructor runtime", func(t *testing.T) {
 		var called bool
 
 		mockClock := digclock.NewMock()

--- a/internal/digclock/clock.go
+++ b/internal/digclock/clock.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package digclock
+
+import (
+	"time"
+)
+
+// Clock defines how dig accesses time.
+// We keep the interface pretty minimal.
+type Clock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
+// System is the default implementation of Clock based on real time.
+var System Clock = systemClock{}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+func (systemClock) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+// Mock is a fake source of time.
+// It implements standard time operations, but allows
+// the user to control the passage of time.
+//
+// Use the [Add] method to progress time.
+//
+// Note that this implementation is not safe for concurrent use.
+type Mock struct {
+	now time.Time
+}
+
+var _ Clock = (*Mock)(nil)
+
+// NewMock creates a new mock clock with the current time set to the current time.
+func NewMock() *Mock {
+	return &Mock{now: time.Now()}
+}
+
+// Now returns the current time.
+func (m *Mock) Now() time.Time {
+	return m.now
+}
+
+// Since returns the time elapsed since the given time.
+func (m *Mock) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
+}
+
+// Add progresses time by the given duration.
+//
+// It panics if the duration is negative.
+func (m *Mock) Add(d time.Duration) {
+	if d < 0 {
+		panic("cannot add negative duration")
+	}
+	m.now = m.now.Add(d)
+}

--- a/internal/digclock/clock.go
+++ b/internal/digclock/clock.go
@@ -25,7 +25,6 @@ import (
 )
 
 // Clock defines how dig accesses time.
-// We keep the interface pretty minimal.
 type Clock interface {
 	Now() time.Time
 	Since(time.Time) time.Duration
@@ -48,7 +47,7 @@ func (systemClock) Since(t time.Time) time.Duration {
 // It implements standard time operations, but allows
 // the user to control the passage of time.
 //
-// Use the [Add] method to progress time.
+// Use the [Mock.Add] method to progress time.
 //
 // Note that this implementation is not safe for concurrent use.
 type Mock struct {


### PR DESCRIPTION
This change adds runtime of the associated constructor 
or decorator to `dig.CallbackInfo`.

For example, users can access the runtime of a particular
constructor by:
```go
c := dig.New()
c.Provide(NewFoo, dig.WithProviderCallback(func(ci dig.CallbackInfo) {
    if ci.Error == nil {
        fmt.Printf("constructor %q finished running in %v", ci.Name, ci.Runtime)
    }
}))
```

This change is a prerequisite for adding https://github.com/uber-go/fx/issues/1213 
to report runtime of constructors in Run events.

