### PR TITLE
fix: golangci-lint installation step in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,7 +56,7 @@ jobs:
       name: Install golangci-lint
       with:
         version: latest
-        args: --version  # make lint will run the linter
+        args: --help  # make lint will run the linter
 
     - run: make lint
       name: Lint


### PR DESCRIPTION
Following https://github.com/uber-go/fx/pull/1185 as an example, fix CI to use --help flag since --version is no longer accepted.

Example failure: https://github.com/uber-go/dig/actions/runs/9702790298/job/26779466435?pr=412