### PR TITLE
Prepare release 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.18.0] - 2024-08-06
+### Added
+- Child scope constructors are now visualized via `Visualize`
+- `CallbackInfo` now includes constructor/decorator run time.
+
+Thanks to @greeflas for their contribution to this release.
+
+[1.18.0]: https://github.com/uber-go/dig/compare/v1.17.1...v1.18.0
 
 ## [1.17.1] - 2023-10-19
 ### Added

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dig
 
 // Version of the library.
-const Version = "1.18.0-dev"
+const Version = "1.18.0"


### PR DESCRIPTION
Update changelog and `Version` in preparation for a 1.18.0 release.

I have tested the tip of Dig at Uber with no issues.