### PR TITLE
use Go 1.23 in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        go: ["1.21.x", "1.22.x"]
+        go: ["1.22.x", "1.23.x"]
 
     steps:
     - name: Setup Go


### PR DESCRIPTION
This changes the CI to use Go 1.23 to test, and drops Go 1.21.