### PR TITLE
[chore] Fix go vet error in error.go

### DIFF
--- a/error.go
+++ b/error.go
@@ -186,7 +186,7 @@ func (e errInvalidInput) Error() string { return fmt.Sprint(e) }
 func (e errInvalidInput) Unwrap() error { return e.Cause }
 
 func (e errInvalidInput) writeMessage(w io.Writer, _ string) {
-	fmt.Fprintf(w, e.Message)
+	fmt.Fprint(w, e.Message)
 }
 
 func (e errInvalidInput) Format(w fmt.State, c rune) {


### PR DESCRIPTION
This fixes an error found by go vet in error.go where we were putting in unnecessary format call (fmt.Fprintf) w/o any formatting argument in it - replaced it with fmt.Fprint.