### PR TITLE
Prevent Variable Shadowing and using fixed length slice

### DIFF
--- a/param.go
+++ b/param.go
@@ -123,7 +123,7 @@ func newParamList(ctype reflect.Type, c containerStore) (paramList, error) {
 
 	pl := paramList{
 		ctype:  ctype,
-		Params: make([]param, 0, numArgs),
+		Params: make([]param, numArgs),
 	}
 
 	for i := 0; i < numArgs; i++ {
@@ -131,7 +131,7 @@ func newParamList(ctype reflect.Type, c containerStore) (paramList, error) {
 		if err != nil {
 			return pl, newErrInvalidInput(fmt.Sprintf("bad argument %d", i+1), err)
 		}
-		pl.Params = append(pl.Params, p)
+		pl.Params[i] = p
 	}
 
 	return pl, nil

--- a/provide.go
+++ b/provide.go
@@ -449,14 +449,17 @@ func (s *Scope) provide(ctor interface{}, opts provideOptions) (err error) {
 	// we start making changes to it as we may need to
 	// undo them upon encountering errors.
 	allScopes := s.appendSubscopes(nil)
-	for _, s := range allScopes {
-		s := s
-		s.gh.Snapshot()
-		defer func() {
-			if err != nil {
-				s.gh.Rollback()
+
+	defer func(allSc []*Scope) {
+		if err != nil {
+			for _, sc := range allSc {
+				sc.gh.Rollback()
 			}
-		}()
+		}
+	}(allScopes)
+
+	for _, sc := range allScopes {
+		sc.gh.Snapshot()
 	}
 
 	n, err := newConstructorNode(


### PR DESCRIPTION
This MR I observed some cosmetic issues listed below to avoid common anti-patterns:

- Avoid Variable Shadowing. (better code readability)
- No defer statement in the for loop.
- Avoid using append on a slice, whose length is known, it saves calling some build-in function. (minor performance improvement)

