### PR TITLE
Adding a before-call-begins callback, to help with troubleshooting

### DIFF
--- a/before_callback.go
+++ b/before_callback.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Uber Technologies, Inc.
+// Copyright (c) 2025 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,8 +30,8 @@ type BeforeCallbackInfo struct {
 }
 
 // BeforeCallback is a function that can be registered with a provided function
-// or decorator with [WithCallback] to cause it to be called before the
-// provided function or decorator is run.
+// using [WithProviderBeforeCallback] or decorator using [WithDecoratorBeforeCallback]
+// to cause it to be called before the provided function or decorator is run.
 type BeforeCallback func(bci BeforeCallbackInfo)
 
 // WithProviderBeforeCallback returns a [ProvideOption] which has Dig call

--- a/before_callback.go
+++ b/before_callback.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dig
+
+// BeforeCallbackInfo contains information about a provided function or decorator
+// called by Dig, and is passed to a [BeforeCallback] registered with
+// [WithProviderBeforeCallback] or [WithDecoratorBeforeCallback].
+type BeforeCallbackInfo struct {
+	// Name is the name of the function in the format:
+	// <package_name>.<function_name>
+	Name string
+}
+
+// BeforeCallback is a function that can be registered with a provided function
+// or decorator with [WithCallback] to cause it to be called before the
+// provided function or decorator is run.
+type BeforeCallback func(bci BeforeCallbackInfo)
+
+// WithProviderBeforeCallback returns a [ProvideOption] which has Dig call
+// the passed in [BeforeCallback] before the corresponding constructor begins running.
+//
+// For example, the following prints a message
+// before "myConstructor" is called:
+//
+//	c := dig.New()
+//	myCallback := func(bci BeforeCallbackInfo) {
+//		fmt.Printf("%q started", bci.Name)
+//	}
+//	c.Provide(myConstructor, WithProviderBeforeCallback(myCallback)),
+//
+// BeforeCallbacks can also be specified for Decorators with [WithDecoratorBeforeCallback].
+//
+// See [BeforeCallbackInfo] for more info on the information passed to the [BeforeCallback].
+func WithProviderBeforeCallback(callback BeforeCallback) ProvideOption {
+	return withBeforeCallbackOption{
+		callback: callback,
+	}
+}
+
+// WithDecoratorBeforeCallback returns a [DecorateOption] which has Dig call
+// the passed in [BeforeCallback] before the corresponding decorator begins running.
+//
+// For example, the following prints a message
+// before "myDecorator" is called:
+//
+//	c := dig.New()
+//	myCallback := func(bci BeforeCallbackInfo) {
+//		fmt.Printf("%q started", bci.Name)
+//	}
+//	c.Decorate(myDecorator, WithDecoratorBeforeCallback(myCallback)),
+//
+// BeforeCallbacks can also be specified for Constructors with [WithProviderBeforeCallback].
+//
+// See [BeforeCallbackInfo] for more info on the information passed to the [BeforeCallback].
+func WithDecoratorBeforeCallback(callback BeforeCallback) DecorateOption {
+	return withBeforeCallbackOption{
+		callback: callback,
+	}
+}
+
+type withBeforeCallbackOption struct {
+	callback BeforeCallback
+}
+
+var (
+	_ ProvideOption  = withBeforeCallbackOption{}
+	_ DecorateOption = withBeforeCallbackOption{}
+)
+
+func (o withBeforeCallbackOption) applyProvideOption(po *provideOptions) {
+	po.BeforeCallback = o.callback
+}
+
+func (o withBeforeCallbackOption) apply(do *decorateOptions) {
+	do.BeforeCallback = o.callback
+}

--- a/callback.go
+++ b/callback.go
@@ -41,8 +41,8 @@ type CallbackInfo struct {
 }
 
 // Callback is a function that can be registered with a provided function
-// or decorator with [WithCallback] to cause it to be called after the
-// provided function or decorator is run.
+// or decorator with [WithProviderCallback] or decorator with [WithDecoratorCallback]
+// to cause it to be called after the provided function or decorator is run.
 type Callback func(CallbackInfo)
 
 // WithProviderCallback returns a [ProvideOption] which has Dig call

--- a/decorate.go
+++ b/decorate.go
@@ -68,6 +68,9 @@ type decoratorNode struct {
 
 	// Callback for this decorator, if there is one.
 	callback Callback
+
+	// BeforeCallback for this decorator, if there is one
+	beforeCallback BeforeCallback
 }
 
 func newDecoratorNode(dcor interface{}, s *Scope, opts decorateOptions) (*decoratorNode, error) {
@@ -86,15 +89,16 @@ func newDecoratorNode(dcor interface{}, s *Scope, opts decorateOptions) (*decora
 	}
 
 	n := &decoratorNode{
-		dcor:     dcor,
-		dtype:    dtype,
-		id:       dot.CtorID(dptr),
-		location: digreflect.InspectFunc(dcor),
-		orders:   make(map[*Scope]int),
-		params:   pl,
-		results:  rl,
-		s:        s,
-		callback: opts.Callback,
+		dcor:           dcor,
+		dtype:          dtype,
+		id:             dot.CtorID(dptr),
+		location:       digreflect.InspectFunc(dcor),
+		orders:         make(map[*Scope]int),
+		params:         pl,
+		results:        rl,
+		s:              s,
+		callback:       opts.Callback,
+		beforeCallback: opts.BeforeCallback,
 	}
 	return n, nil
 }
@@ -119,6 +123,11 @@ func (n *decoratorNode) Call(s containerStore) (err error) {
 			Func:   n.location,
 			Reason: err,
 		}
+	}
+	if n.beforeCallback != nil {
+		n.beforeCallback(BeforeCallbackInfo{
+			Name: fmt.Sprintf("%v.%v", n.location.Package, n.location.Name),
+		})
 	}
 
 	if n.callback != nil {
@@ -162,8 +171,9 @@ type DecorateOption interface {
 }
 
 type decorateOptions struct {
-	Info     *DecorateInfo
-	Callback Callback
+	Info           *DecorateInfo
+	Callback       Callback
+	BeforeCallback BeforeCallback
 }
 
 // FillDecorateInfo is a DecorateOption that writes info on what Dig was

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.uber.org/dig"
 	"go.uber.org/dig/internal/digtest"
 )
@@ -164,7 +165,7 @@ func TestDecorateSuccess(t *testing.T) {
 			i := i
 			c.RequireProvide(func() *someInt { return newSomeInt(i) }, dig.Group("values"), dig.As(new(myInt)))
 		}
-		c.Decorate(func(in A) B {
+		c.RequireDecorate(func(in A) B {
 			for _, v := range in.Values {
 				v.Increment()
 			}

--- a/provide.go
+++ b/provide.go
@@ -37,13 +37,14 @@ type ProvideOption interface {
 }
 
 type provideOptions struct {
-	Name     string
-	Group    string
-	Info     *ProvideInfo
-	As       []interface{}
-	Location *digreflect.Func
-	Exported bool
-	Callback Callback
+	Name           string
+	Group          string
+	Info           *ProvideInfo
+	As             []interface{}
+	Location       *digreflect.Func
+	Exported       bool
+	Callback       Callback
+	BeforeCallback BeforeCallback
 }
 
 func (o *provideOptions) Validate() error {
@@ -464,11 +465,12 @@ func (s *Scope) provide(ctor interface{}, opts provideOptions) (err error) {
 		s,
 		origScope,
 		constructorOptions{
-			ResultName:  opts.Name,
-			ResultGroup: opts.Group,
-			ResultAs:    opts.As,
-			Location:    opts.Location,
-			Callback:    opts.Callback,
+			ResultName:     opts.Name,
+			ResultGroup:    opts.Group,
+			ResultAs:       opts.As,
+			Location:       opts.Location,
+			Callback:       opts.Callback,
+			BeforeCallback: opts.BeforeCallback,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
# What

Adds a "With...BeforeCallback" option, mirroring "With...Callback" but it is called _before_ the provided func is called by Dig, rather than after.

This exists primarily to support https://github.com/uber-go/fx/pull/1267

# Motivation

A recent startup-issue debugging session included logs like this:
```
{"level":"info","ts":1742516783.6106565,"caller":"fxevent/zap.go:51","message":"provided","constructor":"a", ...
...
{"level":"info","ts":1742516783.6106653,"caller":"fxevent/zap.go:51","message":"provided","constructor":"q", ...
...
{"level":"info","ts":1742516783.6106734,"caller":"fxevent/zap.go:51","message":"provided","constructor":"z", ...
...
{"level":"info","ts":1742516784.7998207,"caller":"fxevent/zap.go:51","message":"run","name":"a", ...
{"level":"info","ts":1742516784.7999196,"caller":"fxevent/zap.go:51","message":"run","name":"b", ...
{"level":"info","ts":1742516784.9025834,"caller":"application.go:123", ...
{"level":"info","ts":1742516789.5810778,"caller":"application.go:234", ... 
{"level":"info","ts":1742516790.740516,"caller":"application.go:345", ...
# EOF
```
which accurately reflected the logs the app produced: during startup, it was getting OOM-killed after the final log, several seconds after the last Fx-"run" event.

Unfortunately, Fx's `Run` event is logged _after_ a call completes, so the fxevent log immediately before the application-produced logs tells us _almost nothing_ about what is currently running.  That seems... kinda not ideal.  I've run into this quite a few times over the years, but I finally decided to do something about it.

So I added a "before run" event, so this log will be much easier to diagnose:
```
{"level":"info","ts":1742516784.7899196,"caller":"fxevent/zap.go:51","message":"before run","name":"b", ...
{"level":"info","ts":1742516784.7999196,"caller":"fxevent/zap.go:51","message":"run","name":"b", ...
{"level":"info","ts":1742516784.8000196,"caller":"fxevent/zap.go:51","message":"before run","name":"c", ...
{"level":"info","ts":1742516784.9025834,"caller":"application.go:123", ...
# ^ clearly logged during "c"
```

After a quick attempt in Fx it became pretty clear that it would be difficult or almost impossible to do without changing Dig, so this PR changes Dig to support https://github.com/uber-go/fx/pull/1267

# How

There's not much type-safety for a change like this, as nothing tells you "you forgot to add X / inspect field Y", so pretty much all of this was:
- copy/paste Callback's core file
- find Callback uses, add BeforeCallback equivalents
- hope I didn't miss anything

I'm not entirely sure what else I should be checking, in case there are gaps I didn't see, but the Fx PR does a decent job showing that the core bits of it work IMO so I haven't tried reading, like, _everything_ to verify it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added pre-execution hooks for dependency injection, allowing additional logic (e.g., logging or validation) to run before providers or decorators execute.
- **Tests**
	- Updated testing routines to verify that the new pre-execution hooks trigger correctly and enforce stricter error handling during the dependency injection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->