### PR TITLE
Prepare release v1.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.18.2] - 2025-05-08
+### Fixed
+
+- The exported Version string incorrectly containing "-dev".
 
 ## [1.18.1] - 2025-03-03
 ### Changed

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dig
 
 // Version of the library.
-const Version = "1.18.1-dev"
+const Version = "1.18.2"


### PR DESCRIPTION
Prepare a release to fix the exported version string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The exported version string now correctly displays the release version without the "-dev" suffix.

- **Documentation**
  - Updated the changelog to reflect the new 1.18.2 release and its changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->